### PR TITLE
COD-004: QA recheck tolerant + safe insert

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -429,8 +429,19 @@ def _top3_residuals(after: Dict[str, Any]) -> List[Dict[str, Any]]:
     if not isinstance(findings, list):
         return []
     sev_rank = {"critical": 3, "high": 2, "medium": 1, "low": 0}
+    norm: List[Dict[str, Any]] = []
+    for f in findings:
+        if isinstance(f, dict):
+            code = f.get("code")
+            msg = f.get("message")
+            sev = f.get("severity") or f.get("risk") or f.get("severity_level")
+        else:
+            code = getattr(f, "code", None)
+            msg = getattr(f, "message", None)
+            sev = getattr(f, "severity", None) or getattr(f, "risk", None) or getattr(f, "severity_level", None)
+        norm.append({"code": code, "message": msg, "severity": sev})
     findings_sorted = sorted(
-        findings, key=lambda f: sev_rank.get((f.get("severity") or "").lower(), -1), reverse=True
+        norm, key=lambda f: sev_rank.get(str(f.get("severity") or "").lower(), -1), reverse=True
     )
     return findings_sorted[:3]
 
@@ -791,6 +802,8 @@ async def api_qa_recheck(request: Request, response: Response, x_cid: Optional[s
             result = await asyncio.wait_for(_maybe_await(run_qa_recheck, model), timeout=QA_TIMEOUT_SEC)
             if not isinstance(result, dict):
                 result = _as_dict(result)
+            if "issues" not in result and "residual_risks" in result:
+                result["issues"] = result.get("residual_risks", [])
         except asyncio.TimeoutError:
             return _problem_response(504, "Timeout", "QA Recheck timed out")
         except Exception:
@@ -799,12 +812,14 @@ async def api_qa_recheck(request: Request, response: Response, x_cid: Optional[s
                     before = await asyncio.wait_for(_maybe_await(run_analyze, AnalyzeIn(text=model.text)), timeout=ANALYZE_TIMEOUT_SEC)
                     patched_text = _safe_apply_patches(model.text, model.applied_changes or [])
                     after = await asyncio.wait_for(_maybe_await(run_analyze, AnalyzeIn(text=patched_text)), timeout=ANALYZE_TIMEOUT_SEC)
+                    issues = _top3_residuals(after)
                     result = {
                         "risk_delta": _safe_delta_risk(before, after),
                         "score_delta": _safe_delta_score(before, after),
                         "status_from": _safe_doc_status(before),
                         "status_to": _safe_doc_status(after),
-                        "residual_risks": _top3_residuals(after),
+                        "residual_risks": issues,
+                        "issues": issues,
                     }
                 except Exception as ex2:
                     return _problem_response(500, "QA Recheck failed", f"{ex2}")
@@ -816,6 +831,7 @@ async def api_qa_recheck(request: Request, response: Response, x_cid: Optional[s
                     "status_from": "OK",
                     "status_to": "OK",
                     "residual_risks": [],
+                    "issues": [],
                 }
     else:
         if run_analyze is not None:
@@ -823,12 +839,14 @@ async def api_qa_recheck(request: Request, response: Response, x_cid: Optional[s
                 before = await asyncio.wait_for(_maybe_await(run_analyze, AnalyzeIn(text=model.text)), timeout=ANALYZE_TIMEOUT_SEC)
                 patched_text = _safe_apply_patches(model.text, model.applied_changes or [])
                 after = await asyncio.wait_for(_maybe_await(run_analyze, AnalyzeIn(text=patched_text)), timeout=ANALYZE_TIMEOUT_SEC)
+                issues = _top3_residuals(after)
                 result = {
                     "risk_delta": _safe_delta_risk(before, after),
                     "score_delta": _safe_delta_score(before, after),
                     "status_from": _safe_doc_status(before),
                     "status_to": _safe_doc_status(after),
-                    "residual_risks": _top3_residuals(after),
+                    "residual_risks": issues,
+                    "issues": issues,
                 }
             except Exception as ex2:
                 return _problem_response(500, "QA Recheck failed", f"{ex2}")
@@ -840,10 +858,14 @@ async def api_qa_recheck(request: Request, response: Response, x_cid: Optional[s
                 "status_from": "OK",
                 "status_to": "OK",
                 "residual_risks": [],
+                "issues": [],
             }
 
     _set_std_headers(response, cid=cid, xcache="miss", schema=SCHEMA_VERSION, latency_ms=_now_ms() - t0)
-    payload = {"status": "ok", **result, "deltas": {
+    issues = result.get("issues")
+    if issues is None:
+        issues = result.get("residual_risks", [])
+    payload = {"status": "ok", "issues": issues, **result, "deltas": {
         "score_delta": result.get("score_delta", 0),
         "risk_delta": result.get("risk_delta", 0),
         "status_from": result.get("status_from", "OK"),

--- a/contract_review_app/tests/qa/test_recheck_tolerant.py
+++ b/contract_review_app/tests/qa/test_recheck_tolerant.py
@@ -1,0 +1,19 @@
+from contract_review_app.api.app import _top3_residuals
+
+
+class DummyFinding:
+    def __init__(self, code, message, severity):
+        self.code = code
+        self.message = message
+        self.severity = severity
+
+
+def test_recheck_tolerant_mixed_list():
+    mixed = [
+        {"code": "A", "message": "dict", "severity": "high"},
+        DummyFinding("B", "obj", "low"),
+    ]
+    out = _top3_residuals({"analysis": {"findings": mixed}})
+    assert len(out) == 2
+    assert out[0]["code"] == "A"
+    assert out[1]["code"] == "B"

--- a/contract_review_app/tests/test_api_headers_and_qarecheck.py
+++ b/contract_review_app/tests/test_api_headers_and_qarecheck.py
@@ -40,5 +40,5 @@ def test_qarecheck_always_enveloped_status_ok_and_flattened():
     assert r.status_code == 200
     j = r.json()
     assert j.get("status") == "ok"
-    for k in ("score_delta", "risk_delta", "status_from", "status_to", "residual_risks"):
+    for k in ("score_delta", "risk_delta", "status_from", "status_to", "residual_risks", "issues"):
         assert k in j

--- a/word_addin_dev/taskpane.bundle.js
+++ b/word_addin_dev/taskpane.bundle.js
@@ -48,7 +48,13 @@
 
   function $(id) { return document.getElementById(id); }
   function val(e) { return e ? (e.value || "") : ""; }
-  function setVal(e, v) { if (e) e.value = (v == null ? "" : String(v)); }
+  function setVal(e, v) {
+    if (!e) return;
+    if (v && typeof v === "object") {
+      v = v.draft_text || JSON.stringify(v, null, 2);
+    }
+    e.value = (v == null ? "" : String(v));
+  }
   function txt(e, v) { if (e) e.textContent = (v == null ? "" : String(v)); }
   function en(e, on) { if (e) e.disabled = !on; }
   function log(s) {


### PR DESCRIPTION
## Summary
- make QA recheck tolerant of dicts or objects and always expose issues in payload
- stringify objects or draft_text before inserting into Word
- test mixed finding lists for QA recheck tolerance

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/qa/test_recheck_tolerant.py contract_review_app/tests/test_api_headers_and_qarecheck.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab4eb771b083258ec5247944258811