### PR TITLE
Add rule-based draft fallback and safe draft insertion

### DIFF
--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -132,7 +132,7 @@ const DraftAssistantPanel: React.FC = () => {
         analysis,
         mode: "friendly",
       });
-      setDraft(env);
+      setDraft({ ...env, draft_text: String(env?.draft_text || "") });
     } catch (e: any) {
       setError(e?.message || "Draft failed");
     } finally {

--- a/contract_review_app/tests/api/test_api_smoke.py
+++ b/contract_review_app/tests/api/test_api_smoke.py
@@ -22,63 +22,29 @@ def test_api_analyze_smoke(monkeypatch):
 
 
 def test_api_gpt_draft_new_request(monkeypatch):
-    # Навіть якщо новий формат не потребує аналізу, підкинемо стаб
-    def _fake_analyze(text: str):
-        return {"status": "OK", "findings": []}
-
-    # Стаб GPT-пайплайна: приймає GPTDraftRequest
-    def _fake_gpt_pipeline(gpt_req):
-        assert "status" in gpt_req.analysis  # перевірка що analysis передано
-        return {
-            "clause_type": "confidentiality",
-            "original_text": "ORIG",
-            "draft_text": "DRAFT",
-            "explanation": "ok",
-            "score": 90,
-            "status": "ok",
-            "title": "Confidentiality - Draft",
-        }
+    def _fake_draft(inp):
+        return {"text": "DRAFT", "model": "mock"}
 
     import contract_review_app.api.app as app_mod
-    monkeypatch.setattr(app_mod, "_analyze_document", _fake_analyze, raising=True)
-    monkeypatch.setattr(app_mod, "run_gpt_drafting_pipeline", _fake_gpt_pipeline, raising=True)
+    monkeypatch.setattr(app_mod, "run_gpt_draft", _fake_draft, raising=True)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
 
-    # Новий формат: передаємо одразу analysis
-    new_req = {
-        "analysis": {"status": "OK", "findings": [], "summary": {"x": 1}},
-        "model": "gpt-4",
-    }
+    new_req = {"analysis": {"status": "OK"}, "model": "gpt-4"}
     resp = client.post("/api/gpt/draft", json=new_req)
     assert resp.status_code == 200
     data = resp.json()
     assert data["draft_text"] == "DRAFT"
     assert data["status"] == "ok"
-    assert data["score"] == 90
+    assert data["meta"]["model"] == "mock"
 
 
 def test_api_gpt_draft_legacy_request(monkeypatch):
-    # Стаб аналізатора для легасі-шляху
-    def _fake_analyze(text: str):
-        assert text == "Text"
-        return {"status": "OK", "findings": [{"code": "X"}]}
-
-    # Стаб GPT-пайплайна
-    def _fake_gpt_pipeline(gpt_req):
-        # очікуємо, що analysis вже підставлений з _fake_analyze
-        assert gpt_req.analysis["status"] == "OK"
-        return {
-            "clause_type": "termination",
-            "original_text": "Text",
-            "draft_text": "[AI-DRAFT] Text",
-            "explanation": "ok",
-            "score": 85,
-            "status": "ok",
-            "title": "Termination - Draft",
-        }
+    def _fake_draft(inp):
+        return {"text": "[AI-DRAFT] Text", "model": "mock"}
 
     import contract_review_app.api.app as app_mod
-    monkeypatch.setattr(app_mod, "_analyze_document", _fake_analyze, raising=True)
-    monkeypatch.setattr(app_mod, "run_gpt_drafting_pipeline", _fake_gpt_pipeline, raising=True)
+    monkeypatch.setattr(app_mod, "run_gpt_draft", _fake_draft, raising=True)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
 
     legacy_req = {"clause_type": "termination", "text": "Text", "language": "en"}
     resp = client.post("/api/gpt/draft", json=legacy_req)
@@ -86,4 +52,4 @@ def test_api_gpt_draft_legacy_request(monkeypatch):
     data = resp.json()
     assert data["draft_text"].startswith("[AI-DRAFT]")
     assert data["status"] == "ok"
-    assert data["score"] == 85
+    assert data["meta"]["model"] == "mock"

--- a/contract_review_app/tests/api/test_app_contract.py
+++ b/contract_review_app/tests/api/test_app_contract.py
@@ -88,6 +88,16 @@ def test_gpt_draft_shape_and_headers():
     assert _is_int(r.headers.get("x-latency-ms", "0"))
 
 
+def test_gpt_draft_stub_without_llm_keys(monkeypatch):
+    for k in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "LLM_API_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    r = client.post("/api/gpt/draft", json={"text": "Law"})
+    assert r.status_code == 200
+    data = r.json()
+    assert isinstance(data.get("draft_text"), str) and data["draft_text"].strip()
+    assert data.get("meta", {}).get("model") == "rulebased"
+
+
 def test_qa_recheck_fallback_payload_and_deltas():
     text = "Payment shall be made within 30 days."
     # apply a trivial patch (replace '30' -> '60')

--- a/word_addin_dev/taskpane.bundle.js
+++ b/word_addin_dev/taskpane.bundle.js
@@ -650,7 +650,7 @@
       var r = await apiGptDraft(input);
       if (!r.ok) { status("Draft HTTP " + r.status); return; }
       var env = (r.json && (r.json.data || r.json)) || {};
-      var draft = env.draft_text || env.draft || "";
+      var draft = String(env.draft_text || env.draft || "");
       setVal(els.draft, draft);
       window.LAST_DRAFT = draft;
       enableDraftApply(!!draft);


### PR DESCRIPTION
## Summary
- return rule-based stub from `/api/gpt/draft` when no LLM keys and ensure draft_text is always a string
- insert only the draft text in Word add-in and React panel
- add regression test for draft fallback when keys are absent

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_api_smoke.py::test_api_gpt_draft_new_request contract_review_app/tests/api/test_api_smoke.py::test_api_gpt_draft_legacy_request contract_review_app/tests/api/test_app_contract.py::test_gpt_draft_stub_without_llm_keys -q -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ab50abadbc832582a47f6e4153e989