### PR TITLE
Add stub learning log endpoint

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -852,11 +852,18 @@ async def api_qa_recheck(request: Request, response: Response, x_cid: Optional[s
     return payload
 
 
-@router.post("/api/learning/log")
-async def api_learning_log(response: Response, body: LearningLogIn):
+@router.post("/api/learning/log", response_class=Response)
+async def api_learning_log(response: Response, body: Any | None = None) -> Response:
     t0 = _now_ms()
-    _set_std_headers(response, cid="learning/log", xcache="miss", schema=SCHEMA_VERSION, latency_ms=_now_ms() - t0)
-    return {"status": "ok", "accepted": min(len(body.events), 100)}
+    _set_std_headers(
+        response,
+        cid="learning/log",
+        xcache="miss",
+        schema=SCHEMA_VERSION,
+        latency_ms=_now_ms() - t0,
+    )
+    response.status_code = 204
+    return response
 
 
 @router.post("/api/learning/update")

--- a/contract_review_app/tests/api/test_app_contract.py
+++ b/contract_review_app/tests/api/test_app_contract.py
@@ -135,9 +135,8 @@ def test_panel_static_and_cache_headers():
 
 
 def test_learning_endpoints_minimal_ok():
-    log = client.post("/api/learning/log", json={"events": [{"event": "applied", "cid": "X"}]})
-    assert log.status_code == 200
-    assert log.json()["status"] == "ok"
+    log = client.post("/api/learning/log", json={"any": "json"})
+    assert log.status_code == 204
 
     upd = client.post("/api/learning/update", json={"force": True})
     assert upd.status_code == 200


### PR DESCRIPTION
## Summary
- Add `/api/learning/log` stub returning 204 so the panel no longer 404s
- Update minimal test for learning log

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_app_contract.py::test_learning_endpoints_minimal_ok -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab50bfad5483259af4b6d10440e93d