### PR TITLE
feat: make QA recheck tolerant to mixed clause inputs

### DIFF
--- a/contract_review_app/tests/test_qa_recheck_mixed_types.py
+++ b/contract_review_app/tests/test_qa_recheck_mixed_types.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+from contract_review_app.api import orchestrator
+
+client = TestClient(app)
+
+
+class Obj:
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _fake_doc():
+    finding_obj = Obj(code="OBJ", message="o-msg", severity="low")
+    analysis_obj = Obj(
+        clause_type="obj", risk_level="medium", score=1, findings=[finding_obj]
+    )
+    analysis_dict = {
+        "clause_type": "dict",
+        "risk_level": "high",
+        "score": 2,
+        "findings": [{"code": "D", "message": "d-msg", "severity": "high"}],
+    }
+    return Obj(
+        summary_risk="medium",
+        summary_score=0,
+        summary_status="OK",
+        analyses=[analysis_dict, analysis_obj],
+    )
+
+
+def test_qa_recheck_mixed_dict_and_object(monkeypatch):
+    def fake_analyze_document(text):
+        return _fake_doc()
+
+    monkeypatch.setattr(orchestrator, "_engine", SimpleNamespace(analyze_document=fake_analyze_document))
+    body = {"text": "Hello", "applied_changes": []}
+    r = client.post("/api/qa-recheck", data=json.dumps(body))
+    assert r.status_code == 200
+    j = r.json()
+    assert j["status"] == "ok"
+    assert isinstance(j.get("residual_risks"), list)
+    assert len(j["residual_risks"]) == 1


### PR DESCRIPTION
## Summary
- handle analyses and findings passed as objects in QA recheck to avoid `Clause.get` errors
- add regression test using mixed dict/object inputs

## Testing
- `pytest contract_review_app/tests/test_qa_recheck_mixed_types.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'contract_review_app')*


------
https://chatgpt.com/codex/tasks/task_e_68ab50cbbf38832591f73c2b06e042ae