### PR TITLE
SUG-002: Expand core_en_v1.yaml to 6+ rules with advice and templates

### DIFF
--- a/contract_review_app/legal_rules/policy_packs/core_en_v1.yaml
+++ b/contract_review_app/legal_rules/policy_packs/core_en_v1.yaml
@@ -11,3 +11,64 @@ rules:
       firm: "This Agreement shall be governed by the laws of England and Wales."
       hard: "Governing law: England and Wales."
 
+  - id: confidentiality_basic
+    clause_type: confidentiality
+    severity: medium
+    patterns:
+      - "(?i)confidential information"
+      - "(?i)keep.*confidential"
+      - "(?i)non[- ]disclosure"
+    advice: "Include confidentiality obligations to protect sensitive information."
+    suggest_text:
+      friendly: "Each party shall keep the other party's confidential information confidential."
+
+  - id: termination_notice_basic
+    clause_type: termination
+    severity: medium
+    patterns:
+      - '(?i)terminate.*?\d{1,3}\s+days''?\s+notice'
+      - '(?i)upon\s+\d{1,3}\s+days''?\s+written\s+notice'
+    advice: "Specify reasonable notice periods for termination."
+    suggest_text:
+      friendly: "Either party may terminate this Agreement upon 30 days' written notice."
+
+  - id: liability_cap_basic
+    clause_type: liability
+    severity: high
+    patterns:
+      - '(?i)liability\s+shall\s+not\s+exceed'
+      - '(?i)limitation\s+of\s+liability'
+    advice: "Clarify liability caps to manage exposure."
+    suggest_text:
+      friendly: "Each party's liability is limited to the amounts paid under this Agreement."
+
+  - id: jurisdiction_basic
+    clause_type: jurisdiction
+    severity: medium
+    patterns:
+      - "(?i)exclusive jurisdiction of the courts of [a-z ,]+"
+      - "(?i)submit to the jurisdiction of.*courts"
+    advice: "State the forum for resolving disputes."
+    suggest_text:
+      friendly: "The parties submit to the exclusive jurisdiction of the courts of England and Wales."
+
+  - id: ip_rights_basic
+    clause_type: intellectual_property
+    severity: medium
+    patterns:
+      - "(?i)intellectual property rights remain (?:the )?property of"
+      - "(?i)retain all (?:right|title)s? and interest in (?:its )?ip"
+    advice: "Clarify ownership of intellectual property."
+    suggest_text:
+      friendly: "Each party retains all rights, title, and interest in its pre-existing intellectual property."
+
+  - id: payment_terms_basic
+    clause_type: payment
+    severity: medium
+    patterns:
+      - '(?i)payment\s+shall\s+be\s+made\s+within\s+\d+\s+days'
+      - '(?i)within\s+\d+\s+days\s+of\s+(?:receipt|invoice)'
+    advice: "Define clear payment timelines to avoid disputes."
+    suggest_text:
+      friendly: "Customer shall pay all invoices within 30 days of receipt."
+

--- a/contract_review_app/tests/rules/test_loader_min.py
+++ b/contract_review_app/tests/rules/test_loader_min.py
@@ -10,3 +10,21 @@ def test_match_text_governing_law():
     findings = match_text(text)
     assert any(f.get("clause_type") == "governing_law" for f in findings)
 
+
+def test_match_text_confidentiality():
+    text = "Each party shall keep all confidential information confidential."
+    findings = match_text(text)
+    assert any(f.get("rule_id") == "confidentiality_basic" for f in findings)
+
+
+def test_match_text_termination_notice():
+    text = "Either party may terminate this agreement upon 30 days' written notice."
+    findings = match_text(text)
+    assert any(f.get("rule_id") == "termination_notice_basic" for f in findings)
+
+
+def test_match_text_payment_terms():
+    text = "Customer shall pay all invoices within 30 days of receipt."
+    findings = match_text(text)
+    assert any(f.get("rule_id") == "payment_terms_basic" for f in findings)
+

--- a/contract_review_app/tests/rules/test_rules_count.py
+++ b/contract_review_app/tests/rules/test_rules_count.py
@@ -1,0 +1,5 @@
+from contract_review_app.legal_rules.loader import rules_count
+
+
+def test_rules_count_minimum():
+    assert rules_count() >= 6


### PR DESCRIPTION
## Summary
- extend `core_en_v1` policy pack with confidentiality, termination, liability cap, jurisdiction, IP rights, and payment terms rules
- add tests for minimum rule count and regex matches on new rules

## Testing
- `pytest contract_review_app/tests/rules -q`
- `python - <<'PY'
import sys
sys.path.append('.')
from fastapi.testclient import TestClient
from contract_review_app.api.app import app
client = TestClient(app)
print('health', client.get('/health').json())
text = "Either party may terminate this agreement upon 30 days' written notice."
res = client.post('/api/analyze', json={'text': text})
print('analyze', res.json())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ab7db38b88832596c22ef179f148a5