### PR TITLE
Add governing law rule for England and Wales

### DIFF
--- a/contract_review_app/legal_rules/policy_packs/governing_law_england_wales.yaml
+++ b/contract_review_app/legal_rules/policy_packs/governing_law_england_wales.yaml
@@ -1,0 +1,28 @@
+- id: "gl_england_wales"
+  clause_type: "governing_law"
+  severity: high
+  intent: "Ensure governing law is England and Wales and exclude CISG."
+  triggers:
+    any:
+      - "(?i)governing law"
+      - "(?i)laws of england and wales"
+  checks:
+    must_include:
+      - "(?i)laws of england and wales"
+    must_exclude:
+      - "(?i)united nations convention .* international sale of goods"
+  placeholders_forbidden: true
+  suggest_text:
+    friendly: "This Agreement is governed by the laws of England and Wales."
+    firm: "This Agreement shall be governed by the laws of England and Wales."
+    hard: "Governing law: England and Wales."
+  edits:
+    - when: "first_match('governing law')"
+      op: "replace"
+      template: "This Agreement and each Call-Off shall be governed by the laws of England and Wales."
+      note: "Normalize jurisdiction to England & Wales."
+  examples:
+    positive:
+      - "This Agreement shall be governed by the laws of England and Wales."
+    negative:
+      - "Governing law of New York."

--- a/contract_review_app/tests/policy_packs/test_governing_law_england_wales_yaml.py
+++ b/contract_review_app/tests/policy_packs/test_governing_law_england_wales_yaml.py
@@ -1,0 +1,27 @@
+import re
+import yaml
+from pathlib import Path
+
+RULE_PATH = Path("contract_review_app/legal_rules/policy_packs/governing_law_england_wales.yaml")
+
+def load_rule():
+    data = yaml.safe_load(RULE_PATH.read_text())
+    assert isinstance(data, list) and data, "Rule file should contain a list with one rule"
+    return data[0]
+
+def test_positive_examples_pass_checks():
+    rule = load_rule()
+    must_include = [re.compile(pat, re.I) for pat in rule["checks"]["must_include"]]
+    must_exclude = [re.compile(pat, re.I) for pat in rule["checks"]["must_exclude"]]
+    for text in rule["examples"]["positive"]:
+        assert any(re.search(trig, text) for trig in rule["triggers"]["any"])
+        for rx in must_include:
+            assert rx.search(text)
+        for rx in must_exclude:
+            assert not rx.search(text)
+
+def test_negative_examples_fail_includes():
+    rule = load_rule()
+    must_include = [re.compile(pat, re.I) for pat in rule["checks"]["must_include"]]
+    for text in rule["examples"]["negative"]:
+        assert not all(rx.search(text) for rx in must_include)


### PR DESCRIPTION
## Summary
- add YAML rule requiring governing law to be England & Wales and excluding CISG
- test the rule's regex checks on positive and negative examples

## Testing
- `pytest contract_review_app/tests/policy_packs/test_governing_law_england_wales_yaml.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab7f021f288325a4dcb7495f9e7a6b