### PR TITLE
feat: add suggest edits mapping

### DIFF
--- a/contract_review_app/core/schemas.py
+++ b/contract_review_app/core/schemas.py
@@ -885,6 +885,33 @@ class SuggestOut(AppBaseModel):
     """
     suggestions: List[Suggestion]
 
+
+class ActionableEdit(TextPatch):
+    """Edit item returned by /api/suggest_edits."""
+    note: Optional[str] = ""
+
+
+class SuggestEditsIn(AppBaseModel):
+    """Request DTO for /api/suggest_edits."""
+    clause_type: Optional[str] = None
+    span: Optional[Span] = None
+    text: str
+
+    @model_validator(mode="after")
+    def _validate_requirements(self):
+        if not isinstance(self.text, str) or self.text.strip() == "":
+            raise ValueError("SuggestEditsIn: 'text' is required and must be non-empty")
+        self.text = self.text.strip()
+        if not (self.clause_type or self.span is not None):
+            raise ValueError("SuggestEditsIn: provide 'clause_type' or 'span'")
+        return self
+
+
+class SuggestEditsOut(AppBaseModel):
+    """Response DTO for /api/suggest_edits."""
+    edits: List[ActionableEdit]
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
 class AppliedChange(AppBaseModel):
     """
     Item describing a change applied to a clause between analyses.

--- a/contract_review_app/engine/suggest.py
+++ b/contract_review_app/engine/suggest.py
@@ -1,0 +1,66 @@
+import json
+import re
+from pathlib import Path
+from typing import Dict, Any, Optional, List
+
+import yaml
+
+# Load templates from YAML
+_TEMPLATES_PATH = Path(__file__).with_name("suggest_templates.yaml")
+try:
+    with open(_TEMPLATES_PATH, "r", encoding="utf-8") as f:
+        _TEMPLATES = yaml.safe_load(f) or {}
+except Exception:
+    _TEMPLATES = {}
+
+
+def _ensure_str(v: Any) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, str):
+        return v
+    return str(v)
+
+
+def suggest_edits(text: str, clause_type: Optional[str] = None, span: Optional[Dict[str, int]] = None) -> Dict[str, Any]:
+    """Return actionable edits for a clause.
+
+    Args:
+        text: Clause text.
+        clause_type: Optional clause type key.
+        span: Optional dict with start/length if text is part of a bigger document.
+
+    Returns:
+        Dict with keys ``edits`` and ``meta``.
+    """
+    text = text or ""
+    template = _TEMPLATES.get(clause_type or "") if clause_type else None
+    if not template:
+        return {"edits": [], "meta": {"reason": "unknown_clause_type"}}
+
+    edits: List[Dict[str, Any]] = []
+    tmpl_edits = template.get("edits", [])
+    for e in tmpl_edits:
+        action = e.get("action", "insert_if_missing")
+        note = _ensure_str(e.get("note"))
+        replacement = _ensure_str(e.get("replacement"))
+        if action == "replace":
+            start = span.get("start", 0) if span else 0
+            length = span.get("length", len(text)) if span else len(text)
+            edits.append({"range": {"start": int(start), "length": int(length)}, "replacement": replacement, "note": note})
+        elif action == "insert_if_missing":
+            if replacement not in text:
+                start = (span.get("start", 0) + span.get("length", 0)) if span else len(text)
+                edits.append({"range": {"start": int(start), "length": 0}, "replacement": replacement, "note": note})
+        elif action == "replace_pattern":
+            pattern = e.get("pattern")
+            if not isinstance(pattern, str):
+                continue
+            for m in re.finditer(pattern, text):
+                start = m.start()
+                length = m.end() - m.start()
+                edits.append({"range": {"start": int(start), "length": int(length)}, "replacement": replacement, "note": note})
+    meta = {"clause_type": clause_type or ""}
+    if not edits:
+        meta["reason"] = "no_match"
+    return {"edits": edits, "meta": meta}

--- a/contract_review_app/engine/suggest_templates.yaml
+++ b/contract_review_app/engine/suggest_templates.yaml
@@ -1,0 +1,55 @@
+governing_law:
+  suggest_text: "This Agreement shall be governed by and construed in accordance with the laws of England and Wales."
+  edits:
+    - action: replace
+      note: "Standard E&W governing law."
+      replacement: "This Agreement shall be governed by and construed in accordance with the laws of England and Wales."
+dispute_resolution:
+  suggest_text: "All disputes shall be resolved amicably. The parties submit to the exclusive jurisdiction of the courts of England and Wales."
+  edits:
+    - action: insert_if_missing
+      note: "Insert exclusive jurisdiction sentence."
+      replacement: "The parties submit to the exclusive jurisdiction of the courts of England and Wales."
+termination_convenience:
+  suggest_text: "Either party may terminate for convenience with 30 days notice. The terminating party shall have no right to anticipatory profits."
+  edits:
+    - action: insert_if_missing
+      note: "Insert 'no anticipatory profit' line."
+      replacement: "The terminating party shall have no right to anticipatory profits."
+liability_cap:
+  suggest_text: "Liability capped at 100. The liability cap shall not apply to claims arising from Health, Safety and Environment, Taxes, Intellectual Property, Insurance, Confidentiality, or Data/Information Security Exhibits."
+  edits:
+    - action: insert_if_missing
+      note: "Insert carve-out list."
+      replacement: "The liability cap shall not apply to claims arising from Health, Safety and Environment, Taxes, Intellectual Property, Insurance, Confidentiality, or Data/Information Security Exhibits."
+insurance_noncompliance:
+  suggest_text: "If the Supplier fails to maintain insurance, the Customer may claim damages. Failure to maintain required insurance gives the other party the right to terminate this Agreement."
+  edits:
+    - action: insert_if_missing
+      note: "Insert termination right sentence."
+      replacement: "Failure to maintain required insurance gives the other party the right to terminate this Agreement."
+export_hmrc:
+  suggest_text: "The Supplier shall comply with export controls. Each party shall ensure an Exporter of Record or Importer of Record is appointed and comply with HMRC procedures."
+  edits:
+    - action: insert_if_missing
+      note: "Insert EoR/IoR and HMRC procedure compliance sentence."
+      replacement: "Each party shall ensure an Exporter of Record or Importer of Record is appointed and comply with HMRC procedures."
+placeholder_police:
+  suggest_text: null
+  edits:
+    - action: replace_pattern
+      note: "Replace placeholder and add comment."
+      pattern: "\\[●\\]"
+      replacement: "<TO BE COMPLETED>"
+notices:
+  suggest_text: "Notices shall be served to the addresses set out in Schedule 1."
+  edits:
+    - action: replace
+      note: "Normalize service addresses block."
+      replacement: "Notices shall be served to the addresses set out in Schedule 1."
+confidentiality:
+  suggest_text: "The parties shall keep information confidential. The confidentiality obligations shall survive for X years."
+  edits:
+    - action: insert_if_missing
+      note: "Add survival period placeholder 'X years'."
+      replacement: "The confidentiality obligations shall survive for X years."

--- a/contract_review_app/tests/api/test_api_suggest_edits.py
+++ b/contract_review_app/tests/api/test_api_suggest_edits.py
@@ -1,0 +1,22 @@
+import json
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_api_returns_string_replacement():
+    payload = {
+        "text": "This contract is governed by the laws of Mars.",
+        "clause_type": "governing_law",
+    }
+    r = client.post("/api/suggest_edits", data=json.dumps(payload))
+    assert r.status_code == 200
+    j = r.json()
+    assert j["status"] == "ok"
+    assert isinstance(j.get("edits"), list)
+    assert j["edits"], "expected edits"
+    replacement = j["edits"][0]["replacement"]
+    assert isinstance(replacement, str)
+    assert "[object Object]" not in replacement

--- a/contract_review_app/tests/engine/test_suggest_edits.py
+++ b/contract_review_app/tests/engine/test_suggest_edits.py
@@ -1,0 +1,43 @@
+import pytest
+import pytest
+
+from contract_review_app.engine.suggest import suggest_edits
+
+
+def _get_first_edit(text: str, clause_type: str):
+    res = suggest_edits(text, clause_type=clause_type)
+    assert isinstance(res.get("edits"), list)
+    assert res["edits"], f"no edits for {clause_type}"
+    return res["edits"][0]
+
+
+@pytest.mark.parametrize(
+    "clause_type,text,mode",
+    [
+        ("governing_law", "This contract is governed by the laws of Mars.", "replace"),
+        ("dispute_resolution", "Disputes will be handled informally.", "insert"),
+        ("termination_convenience", "Either party may terminate for convenience with 30 days notice.", "insert"),
+        ("liability_cap", "Liability capped at 100.", "insert"),
+        ("insurance_noncompliance", "If the Supplier fails to maintain insurance, the Customer may claim damages.", "insert"),
+        ("export_hmrc", "The Supplier shall comply with export controls.", "insert"),
+        ("placeholder_police", "The amount is [●] GBP.", "replace_pattern"),
+        ("notices", "All notices shall be served in writing.", "replace"),
+        ("confidentiality", "The parties shall keep information confidential.", "insert"),
+    ],
+)
+def test_templates_produce_edit(clause_type, text, mode):
+    edit = _get_first_edit(text, clause_type)
+    rng = edit["range"]
+    assert {"start", "length"}.issubset(rng.keys())
+    if mode == "replace":
+        assert rng["start"] == 0
+        assert rng["length"] == len(text)
+    elif mode == "insert":
+        assert rng["start"] == len(text)
+        assert rng["length"] == 0
+    elif mode == "replace_pattern":
+        pos = text.index("[●]")
+        assert rng["start"] == pos
+        assert rng["length"] == len("[●]")
+    assert isinstance(edit.get("replacement"), str)
+    assert edit["replacement"] != "[object Object]"


### PR DESCRIPTION
## Summary
- add YAML-backed templates and engine for clause edit suggestions
- expose `/api/suggest_edits` returning `edits[]` with ranges, replacements and notes
- cover templates and API with tests to ensure valid ranges and string replacements

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/engine/test_suggest_edits.py contract_review_app/tests/api/test_api_suggest_edits.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab7f296b108325b534bf521859809a