### PR TITLE
COD-104: numeric and carve-out validators

### DIFF
--- a/contract_review_app/legal_rules/policy_packs/core_en_v1.yaml
+++ b/contract_review_app/legal_rules/policy_packs/core_en_v1.yaml
@@ -1,3 +1,8 @@
+carve_out_whitelist:
+  - fraud
+  - gross negligence
+  - wilful misconduct
+
 rules:
   - id: governing_law_basic
     clause_type: governing_law
@@ -11,3 +16,46 @@ rules:
       firm: "This Agreement shall be governed by the laws of England and Wales."
       hard: "Governing law: England and Wales."
 
+  - id: liability_cap_placeholders
+    clause_type: liability
+    severity: high
+    patterns:
+      - '(?i)liability[^\n]*\[●\]'
+      - '(?i)liability[^\n]*\b0\b'
+    advice: "Fill in liability cap values; placeholders or zeros not allowed."
+
+  - id: pollution_cap_value_present
+    clause_type: pollution_cap
+    severity: medium
+    patterns:
+      - '(?i)pollution[^\n]*(?:£|\$|€)\s?\d{1,3}(?:,\d{3})*(?:\.\d+)?'
+    advice: "Specify pollution cap monetary values."
+
+  - id: property_damage_cap_value_present
+    clause_type: property_damage_cap
+    severity: medium
+    patterns:
+      - '(?i)property damage[^\n]*(?:£|\$|€)\s?\d{1,3}(?:,\d{3})*(?:\.\d+)?'
+    advice: "Specify property damage cap monetary values."
+
+  - id: insurance_additional_insureds_required
+    clause_type: insurance
+    severity: medium
+    patterns:
+      - '(?i)additional insureds?'
+    advice: "Insurance schedule must require additional insureds."
+
+  - id: failure_to_comply_termination
+    clause_type: insurance
+    severity: medium
+    patterns:
+      - '(?i)failure to comply[^\n]*termination'
+    advice: "Include termination clause for failure to comply with insurance requirements."
+
+  - id: payment_terms_vat_present
+    clause_type: payment_terms
+    severity: low
+    patterns:
+      - '(?i)vat'
+      - '(?i)value added tax'
+    advice: "Mention VAT in payment terms."

--- a/contract_review_app/tests/rules/test_numeric_validators.py
+++ b/contract_review_app/tests/rules/test_numeric_validators.py
@@ -1,0 +1,55 @@
+from contract_review_app.legal_rules.loader import (
+    MONEY_RE,
+    PERCENT_RE,
+    carveouts_valid,
+    match_text,
+)
+
+
+def _has(rule_id, findings):
+    return any(f.get("rule_id") == rule_id for f in findings)
+
+
+def test_liability_cap_placeholder():
+    text = "The liability cap shall be [●]."
+    findings = match_text(text)
+    assert _has("liability_cap_placeholders", findings)
+
+
+def test_pollution_cap_value_present():
+    text = "The pollution cap is £5,000,000 per occurrence."
+    findings = match_text(text)
+    assert _has("pollution_cap_value_present", findings)
+
+
+def test_property_damage_cap_value_present():
+    text = "Property damage cap is €2,500,000 per occurrence."
+    findings = match_text(text)
+    assert _has("property_damage_cap_value_present", findings)
+
+
+def test_insurance_requirements():
+    text = (
+        "Vendor shall name Company as an additional insured. "
+        "Failure to comply shall result in termination."
+    )
+    findings = match_text(text)
+    assert _has("insurance_additional_insureds_required", findings)
+    assert _has("failure_to_comply_termination", findings)
+
+
+def test_payment_terms_vat_present():
+    text = "Invoices are payable within 30 days plus VAT of 20%."
+    findings = match_text(text)
+    assert _has("payment_terms_vat_present", findings)
+
+
+def test_money_and_percent_regex():
+    text = "Amounts: £5,000 and $3,200. Discount 10.5%."
+    assert MONEY_RE.findall(text) == ["£5,000", "$3,200"]
+    assert PERCENT_RE.findall(text) == ["10.5%"]
+
+
+def test_carveouts_valid():
+    assert carveouts_valid("fraud, gross negligence")
+    assert not carveouts_valid("fraud, bad faith")


### PR DESCRIPTION
## Summary
- parse monetary values and percentages with compiled regex helpers
- validate carve-outs against whitelist and add liability/insurance/payment rules
- cover numeric extraction and carve-out checks with unit tests

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/rules/test_loader_min.py contract_review_app/tests/rules/test_numeric_validators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7f36c2f48325a64bad8f845aa69d