### PR TITLE
COD-202: add policy profile support

### DIFF
--- a/contract_review_app/core/schemas.py
+++ b/contract_review_app/core/schemas.py
@@ -141,6 +141,7 @@ class AnalyzeIn(AppBaseModel):
 
     # policy & switches
     policy: Dict[str, Any] = Field(default_factory=dict)
+    policy_profile: str = "friendly"
     return_legacy: bool = True     # keep analysis/results/clauses
     return_ssot: bool = True       # include document-level SSOT
 
@@ -257,6 +258,7 @@ class Finding(AppBaseModel):
     tags: List[str] = Field(default_factory=list)
     # Legacy support:
     legal_basis: List[str] = Field(default_factory=list)
+    suggest_text: Dict[str, Any] = Field(default_factory=dict)
 
     # Back-compat accessor: some rules may read .severity
     @property
@@ -863,6 +865,7 @@ class SuggestIn(AppBaseModel):
     clause_type: Optional[str] = None
     text: str
     mode: DraftMode = "friendly"
+    policy_profile: str = "friendly"
     top_k: int = Field(default=3, ge=1, le=10)
 
     @model_validator(mode="after")

--- a/contract_review_app/policy/__init__.py
+++ b/contract_review_app/policy/__init__.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+from typing import Any, Dict
+
+_POLICIES: Dict[str, Dict[str, Any]] | None = None
+
+
+def _load() -> Dict[str, Dict[str, Any]]:
+    global _POLICIES
+    if _POLICIES is None:
+        path = Path(__file__).resolve().parent / "policies.yaml"
+        try:
+            _POLICIES = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except Exception:
+            _POLICIES = {}
+    return _POLICIES
+
+
+def get_policy(profile: str) -> Dict[str, Any]:
+    data = _load()
+    profile = (profile or "friendly").lower().strip()
+    return data.get(profile, data.get("friendly", {}))

--- a/contract_review_app/policy/policies.yaml
+++ b/contract_review_app/policy/policies.yaml
@@ -1,0 +1,12 @@
+friendly:
+  survival_years_min: 3
+  liability_cap: "2x fees"
+  insurance_limit: 1000000
+firm:
+  survival_years_min: 5
+  liability_cap: "1x fees"
+  insurance_limit: 2000000
+hard:
+  survival_years_min: 0  # 0 means indefinite for trade secrets
+  liability_cap: "uncapped"
+  insurance_limit: 5000000

--- a/contract_review_app/policy/suggest.py
+++ b/contract_review_app/policy/suggest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from typing import Dict, Any
+
+
+def pick_suggest_text(data: Dict[str, Any], profile: str) -> str:
+    """Return suggestion text for profile with friendly fallback."""
+    if not isinstance(data, dict):
+        return ""
+    profile = (profile or "friendly").lower().strip()
+    return str(data.get(profile) or data.get("friendly") or "")

--- a/contract_review_app/tests/api/test_policy_profiles.py
+++ b/contract_review_app/tests/api/test_policy_profiles.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+
+import importlib
+from contract_review_app.api import app as api_app
+
+importlib.reload(api_app)  # ensure latest pipeline
+api_app.run_suggest_edits = None  # ensure pipeline path
+client = TestClient(api_app.app)
+
+
+def _payload():
+    return {"text": "Each party shall keep information confidential.", "clause_type": "confidentiality"}
+
+
+def test_suggest_edits_profile_variants():
+    base = _payload()
+    r_friendly = client.post("/api/suggest_edits", json={**base, "policy_profile": "friendly"})
+    r_firm = client.post("/api/suggest_edits", json={**base, "policy_profile": "firm"})
+    r_hard = client.post("/api/suggest_edits", json={**base, "policy_profile": "hard"})
+
+    friendly_text = r_friendly.json()["suggestions"][0]["proposed_text"]
+    firm_text = r_firm.json()["suggestions"][0]["proposed_text"]
+    hard_text = r_hard.json()["suggestions"][0]["proposed_text"]
+
+    assert "3" in friendly_text
+    assert "5" in firm_text
+    assert "indefinitely" in hard_text.lower()
+
+    r_default = client.post("/api/suggest_edits", json=base)
+    assert r_default.json()["suggestions"][0]["proposed_text"] == friendly_text


### PR DESCRIPTION
## Summary
- add policy profiles config and loader
- propagate optional `policy_profile` field through schemas and API
- customize suggestion fallback based on profile and add tests

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_policy_profiles.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab804fcf2c8325968f959066661dfa