### PR TITLE
COD-203: expand suggest templates to cover v2 rules

### DIFF
--- a/contract_review_app/engine/suggest.py
+++ b/contract_review_app/engine/suggest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import yaml
+
+# Load templates from YAML
+_TEMPLATES_PATH = Path(__file__).with_name("suggest_templates.yaml")
+try:
+    _TEMPLATES: Dict[str, Dict[str, Any]] = yaml.safe_load(_TEMPLATES_PATH.read_text()) or {}
+except FileNotFoundError:  # pragma: no cover
+    _TEMPLATES = {}
+
+
+def _range_from_findings(text: str, findings: Optional[List[Dict[str, Any]]] = None) -> Dict[str, int]:
+    """Compute replacement range using first finding span if available."""
+    if findings:
+        for f in findings:
+            span = f.get("span") if isinstance(f, dict) else getattr(f, "span", None)
+            if isinstance(span, dict):
+                start = int(span.get("start", 0))
+                end = int(span.get("end", start))
+                if end > start:
+                    return {"start": start, "length": end - start}
+    return {"start": 0, "length": len(text or "")}
+
+
+# Map clause types to range functions; default uses finding spans
+_RANGE_FUNCS: Dict[str, Callable[[str, Optional[List[Dict[str, Any]]]], Dict[str, int]]] = {
+    ct: _range_from_findings for ct in _TEMPLATES.keys()
+}
+
+
+def has_template(clause_type: str) -> bool:
+    """Return True if templates exist for the clause type."""
+    return clause_type in _TEMPLATES
+
+
+def suggest_for_clause(
+    text: str,
+    clause_type: str,
+    profile: str = "friendly",
+    findings: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Build suggestion cards for a given clause type."""
+    info = _TEMPLATES.get(clause_type)
+    if not info:
+        return []
+
+    template = ""
+    st = info.get("suggest_text") if isinstance(info, dict) else None
+    if isinstance(st, dict):
+        template = st.get(profile) or st.get("friendly") or st.get("default") or ""
+    if not template:
+        edits = info.get("edits") if isinstance(info, dict) else None
+        if isinstance(edits, list) and edits:
+            template = edits[0].get("template", "")
+    template = str(template)
+    note = str(info.get("note", ""))
+
+    rng = _RANGE_FUNCS.get(clause_type, _range_from_findings)(text or "", findings)
+    action = "replace" if rng.get("length", 0) > 0 else "append"
+
+    return [
+        {
+            "clause_type": clause_type,
+            "action": action,
+            "range": rng,
+            "proposed_text": template,
+            "message": template,
+            "note": note,
+        }
+    ]

--- a/contract_review_app/engine/suggest_templates.yaml
+++ b/contract_review_app/engine/suggest_templates.yaml
@@ -1,0 +1,48 @@
+confidentiality_survival_term_min_3y:
+  suggest_text:
+    friendly: "Confidentiality obligations shall survive for at least three (3) years after termination or expiry."
+  note: "Survival term should be no less than three years to protect post-termination disclosures."
+notices_formal_service:
+  suggest_text:
+    friendly: "All notices must be in writing and delivered by registered mail or courier to the addresses stated herein."
+  note: "Formal service methods reduce disputes over whether notice was properly given."
+assignment_consent_exceptions:
+  suggest_text:
+    friendly: "Neither party may assign this Agreement without consent except to affiliates or successors."
+  note: "Allows routine corporate reorganisations without requiring consent."
+subcontracting_control_flowdown:
+  suggest_text:
+    friendly: "Supplier remains responsible for subcontractors and shall flow down all obligations of this Agreement."
+  note: "Ensures subcontractors are controlled and bound by equivalent terms."
+ip_ownership_licenseback:
+  suggest_text:
+    friendly: "All intellectual property created under this Agreement belongs to Customer; Supplier receives a limited licence back to use it."
+  note: "Clarifies ownership while permitting necessary internal use."
+force_majeure_exclusions:
+  suggest_text:
+    friendly: "Force Majeure shall not excuse payment obligations or failures caused by labour disputes."
+  note: "Standard exclusions prevent abuse of the Force Majeure clause."
+warranties_goods_services:
+  suggest_text:
+    friendly: "Supplier warrants that goods and services will conform to specifications and be performed with reasonable skill and care."
+  note: "Provides baseline assurance on quality and performance."
+ip_infringement_indemnity:
+  suggest_text:
+    friendly: "Supplier shall indemnify and defend Customer against third-party claims that the Deliverables infringe intellectual property rights."
+  note: "Shifts IP infringement risk to the provider of the Deliverables."
+limitation_of_liability_cap_and_carveouts:
+  suggest_text:
+    friendly: "Total liability is capped at the fees paid, except for fraud, death or personal injury."
+  note: "Sets a monetary cap while preserving key carve-outs."
+data_protection_link_exhibit_M:
+  suggest_text:
+    friendly: "The parties' data protection obligations are set out in Exhibit M, incorporated by reference."
+  note: "Links to detailed data protection terms without repeating them."
+info_security_link_exhibit_L:
+  suggest_text:
+    friendly: "Information security requirements are detailed in Exhibit L, which forms part of this Agreement."
+  note: "References a separate schedule for technical security standards."
+termination_for_convenience_no_anticipatory_profit:
+  suggest_text:
+    friendly: "Either party may terminate for convenience on 30 days' notice without liability for anticipated profits."
+  note: "Avoids claims for profits that would have been earned after termination."

--- a/contract_review_app/tests/test_suggest_templates.py
+++ b/contract_review_app/tests/test_suggest_templates.py
@@ -1,0 +1,32 @@
+import pytest
+
+from contract_review_app.engine import pipeline
+
+SAMPLES = {
+    "confidentiality_survival_term_min_3y": "Confidentiality survives termination.",
+    "notices_formal_service": "Notices shall be sent to the addresses.",
+    "assignment_consent_exceptions": "Assignment requires consent.",
+    "subcontracting_control_flowdown": "Supplier may use subcontractors.",
+    "ip_ownership_licenseback": "IP belongs to the customer.",
+    "force_majeure_exclusions": "Force majeure applies.",
+    "warranties_goods_services": "Supplier warrants goods.",
+    "ip_infringement_indemnity": "Supplier defends IP claims.",
+    "limitation_of_liability_cap_and_carveouts": "Liability is limited.",
+    "data_protection_link_exhibit_M": "See Exhibit M.",
+    "info_security_link_exhibit_L": "See Exhibit L.",
+    "termination_for_convenience_no_anticipatory_profit": "Either party may terminate for convenience.",
+}
+
+
+@pytest.mark.parametrize("clause_type,text", SAMPLES.items())
+def test_suggest_templates_provide_edits(clause_type, text):
+    edits = pipeline.suggest_edits(text, clause_id=None, mode="friendly", clause_type=clause_type)
+    assert edits, f"No edits returned for {clause_type}"
+    edit = edits[0]
+    assert isinstance(edit.get("proposed_text"), str)
+    rng = edit.get("range", {})
+    if edit.get("action") == "replace":
+        assert rng.get("length", 0) > 0
+    else:
+        assert rng.get("start", -1) == len(text)
+        assert rng.get("length", 1) == 0


### PR DESCRIPTION
## Summary
- add clause-specific suggestion templates and notes
- route clause-specific templates through pipeline
- cover new clause types with unit tests

## Testing
- `pytest contract_review_app/tests/test_suggest_templates.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'registry' from 'contract_review_app.legal_rules.rules')*


------
https://chatgpt.com/codex/tasks/task_e_68ab8056de008325952ce521a910be4d