### PR TITLE
COD-205: Call-Off validation endpoint

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -16,6 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+from contract_review_app.api.calloff_validator import validate_calloff
 
 # SSOT DTO imports
 from contract_review_app.core.schemas import (
@@ -881,6 +882,31 @@ async def api_qa_recheck(request: Request, response: Response, x_cid: Optional[s
         "status_to": result.get("status_to", "OK"),
     }}
     return payload
+
+
+@router.post("/api/calloff/validate")
+async def api_calloff_validate(
+    request: Request, response: Response, x_cid: Optional[str] = Header(None)
+):
+    t0 = _now_ms()
+    try:
+        body = await _read_body_guarded(request)
+        payload = json.loads(body.decode("utf-8")) if body else {}
+    except HTTPException:
+        return _problem_response(413, "Payload too large", "Request body exceeds limits")
+    except Exception:
+        return _problem_response(400, "Bad JSON", "Request body is not valid JSON")
+
+    cid = x_cid or _sha256_hex(str(t0) + json.dumps(payload, sort_keys=True)[:128])
+    issues = validate_calloff(payload if isinstance(payload, dict) else {})
+    _set_std_headers(
+        response,
+        cid=cid,
+        xcache="miss",
+        schema=SCHEMA_VERSION,
+        latency_ms=_now_ms() - t0,
+    )
+    return {"status": "ok", "issues": issues}
 
 
 @router.post("/api/learning/log", status_code=204)

--- a/contract_review_app/api/calloff_validator.py
+++ b/contract_review_app/api/calloff_validator.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+"""Simple rule-based validator for Call-Off details."""
+
+from typing import Any, Dict, List
+import re
+
+REQUIRED_FIELDS = {
+    "term": "Term",
+    "description": "Services/Goods description",
+    "price": "Price",
+    "currency": "Currency",
+    "vat": "VAT",
+    "delivery_point": "Delivery Point",
+    "representatives": "Representatives address",
+    "notices": "Notices address",
+    "po_number": "PO/Call-Off number",
+}
+
+_PLACEHOLDER_PATTERNS = [re.compile(p, re.IGNORECASE) for p in (r"\[●\]", r"TBC")]
+
+def _has_placeholder(val: str) -> bool:
+    for pat in _PLACEHOLDER_PATTERNS:
+        if pat.search(val):
+            return True
+    return False
+
+def validate_calloff(data: Dict[str, Any]) -> List[Dict[str, str]]:
+    issues: List[Dict[str, str]] = []
+
+    # required fields
+    for key, label in REQUIRED_FIELDS.items():
+        val = data.get(key)
+        if not isinstance(val, str) or not val.strip():
+            issues.append({
+                "id": "calloff_required_fields",
+                "severity": "major",
+                "advice": f"{label} is required",
+                "location": key,
+            })
+
+    # placeholders in any string or list of strings
+    def check_placeholder(field: str, value: Any) -> None:
+        if isinstance(value, str):
+            if _has_placeholder(value):
+                issues.append({
+                    "id": "calloff_placeholders_forbidden",
+                    "severity": "major",
+                    "advice": f"Placeholder detected in {field}",
+                    "location": field,
+                })
+        elif isinstance(value, list):
+            for idx, item in enumerate(value):
+                check_placeholder(f"{field}[{idx}]", item)
+
+    for k, v in data.items():
+        check_placeholder(k, v)
+
+    # subcontractor listing
+    uses_sub = bool(data.get("subcontracts") or data.get("uses_subcontracts"))
+    subs = data.get("subcontractors") or data.get("critical_subcontractors")
+    if uses_sub and (not isinstance(subs, list) or len(subs) == 0):
+        issues.append({
+            "id": "calloff_subcontractor_listing",
+            "severity": "major",
+            "advice": "List critical subcontractors when subcontracts are used",
+            "location": "subcontractors",
+        })
+
+    # variation link
+    if data.get("scope_altered") and not data.get("variation_reference"):
+        issues.append({
+            "id": "calloff_variation_link",
+            "severity": "major",
+            "advice": "Provide VO/VR reference when scope is altered",
+            "location": "variation_reference",
+        })
+
+    return issues

--- a/contract_review_app/tests/api/test_calloff_validate.py
+++ b/contract_review_app/tests/api/test_calloff_validate.py
@@ -1,0 +1,47 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_calloff_validate_ok():
+    payload = {
+        "term": "12 months",
+        "description": "Supply of goods",
+        "price": "1000",
+        "currency": "USD",
+        "vat": "20%",
+        "delivery_point": "Warehouse A",
+        "representatives": "John Doe",
+        "notices": "Main Street",
+        "po_number": "PO123",
+        "subcontracts": False,
+        "scope_altered": False,
+    }
+    r = client.post("/api/calloff/validate", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "ok"
+    assert isinstance(data.get("issues"), list)
+    assert len(data["issues"]) == 0
+
+
+def test_calloff_validate_with_issues():
+    payload = {
+        "description": "[●]",
+        "currency": "USD",
+        "delivery_point": "Port",
+        "representatives": "",
+        "notices": "",
+        "po_number": "",
+        "subcontracts": True,
+        "subcontractors": [],
+        "scope_altered": True,
+    }
+    r = client.post("/api/calloff/validate", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "ok"
+    issues = data.get("issues") or []
+    assert len(issues) > 0
+    assert any(i.get("id") == "calloff_placeholders_forbidden" for i in issues)

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -59,6 +59,7 @@
         <button id="btnDraft">POST /api/gpt/draft</button>
         <button id="btnSuggest">POST /api/suggest_edits</button>
         <button id="btnQA">POST /api/qa-recheck</button>
+        <button id="btnCalloff">POST /api/calloff/validate</button>
         <button id="btnTrace">GET /api/trace/{cid}</button>
       </div>
       <div class="small">CID used for requests: <span id="cidLbl" class="mono pill"></span></div>
@@ -82,6 +83,7 @@
             <tr id="row-draft"><td>POST /api/gpt/draft</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
             <tr id="row-suggest"><td>POST /api/suggest_edits</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
             <tr id="row-qa"><td>POST /api/qa-recheck</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+            <tr id="row-calloff"><td>POST /api/calloff/validate</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
             <tr id="row-trace"><td>GET /api/trace/{cid}</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
           </tbody>
         </table>
@@ -215,6 +217,19 @@
       setJSON("resp", r.body);
       return r;
     }
+    async function testCalloff(){
+      const r = await callEndpoint({
+        name:"calloff", method:"POST", path:"/api/calloff/validate",
+        body:{ description:"[●]" }
+      });
+      setStatusRow("row-calloff", r);
+      const issues = (r.body && r.body.issues) ? r.body.issues.length : 0;
+      const tr = document.getElementById("row-calloff");
+      const cells = tr.getElementsByTagName('td');
+      cells[6].innerHTML = r.ok ? `<span class="ok">ok / issues ${issues}</span>` : '<span class="err">error</span>';
+      setJSON("resp", r.body);
+      return r;
+    }
     async function testTrace(){
       const cid = lastCid || clientCid || "cid-dummy";
       const r = await callEndpoint({
@@ -228,7 +243,7 @@
 
     async function runAll(){
       // reset table rows
-      for (const id of ["row-health","row-analyze","row-draft","row-suggest","row-qa","row-trace"]) {
+      for (const id of ["row-health","row-analyze","row-draft","row-suggest","row-qa","row-calloff","row-trace"]) {
         setStatusRow(id, {code:"",xcid:"",xcache:"",xschema:"",latencyMs:null,ok:false});
       }
       document.getElementById("resp").textContent = "";
@@ -241,6 +256,7 @@
       await testDraft();
       await testSuggest();
       await testQA();
+      await testCalloff();
       await testTrace();
     }
 
@@ -252,6 +268,7 @@
     document.getElementById("btnDraft").addEventListener("click", testDraft);
     document.getElementById("btnSuggest").addEventListener("click", testSuggest);
     document.getElementById("btnQA").addEventListener("click", testQA);
+    document.getElementById("btnCalloff").addEventListener("click", testCalloff);
     document.getElementById("btnTrace").addEventListener("click", testTrace);
 
     // Load defaults on first paint


### PR DESCRIPTION
## Summary
- add rule-based validator for Call-Off data
- expose `/api/calloff/validate` endpoint and self-test hook
- cover required fields and placeholder issues with API tests

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_calloff_validate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab80640aa0832580e728cf4d3b5b8e