### PR TITLE
COD-208: Numeric validators and insurance thresholds

### DIFF
--- a/contract_review_app/legal_rules/loader.py
+++ b/contract_review_app/legal_rules/loader.py
@@ -11,6 +11,8 @@ import yaml
 # Load and compile rules on import
 # ---------------------------------------------------------------------------
 _RULES: List[Dict[str, Any]] = []
+# additional python-level rules with custom validators
+_PY_RULES: List[Dict[str, Any]] = []
 
 
 def _load_rules() -> None:
@@ -37,6 +39,168 @@ def _load_rules() -> None:
 
 _load_rules()
 
+# ---------------------------------------------------------------------------
+# Common regex helpers
+# ---------------------------------------------------------------------------
+MONEY_RX = re.compile(
+    r"(?:(£|€|\$)\s*|\b(GBP|EUR|USD)\s*)?(\d{1,3}(?:,\d{3})*(?:\.\d{2})?)",
+    re.IGNORECASE,
+)
+PERCENT_RX = re.compile(r"\b\d+(?:\.\d+)?%")
+
+
+def _to_number(val: str) -> float:
+    """Convert currency/percentage string to numeric value."""
+    try:
+        return float(val.replace(",", ""))
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Numeric rule implementations
+# ---------------------------------------------------------------------------
+def _rule_insurance_limits(text: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    checks = [
+        (r"employers'? liability", 10_000_000),
+        (r"public liability", 5_000_000),
+    ]
+    # professional indemnity only if professional services mentioned
+    if re.search(r"professional services", text, re.IGNORECASE):
+        checks.append((r"professional indemnity", 2_000_000))
+    for label, minimum in checks:
+        rx = re.compile(label + r"[^£€$\d]{0,50}" + MONEY_RX.pattern, re.IGNORECASE)
+        m = rx.search(text)
+        if not m:
+            findings.append(
+                {
+                    "rule_id": "insurance_limits_min",
+                    "clause_type": "insurance",
+                    "severity": "high",
+                    "start": 0,
+                    "end": 0,
+                    "snippet": f"Missing {label} amount",
+                    "advice": f"Specify at least £{minimum:,} for {label}.",
+                }
+            )
+            continue
+        amount_str = m.group(3)
+        amount = _to_number(amount_str)
+        if amount < minimum:
+            findings.append(
+                {
+                    "rule_id": "insurance_limits_min",
+                    "clause_type": "insurance",
+                    "severity": "high",
+                    "start": m.start(3),
+                    "end": m.end(3),
+                    "snippet": m.group(0),
+                    "advice": f"Increase {label} to at least £{minimum:,}.",
+                }
+            )
+    return findings
+
+
+def _rule_cap_present(keyword: str, rule_id: str, text: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    if re.search(keyword, text, re.IGNORECASE):
+        rx = re.compile(keyword + r"[^£€$\d]{0,50}" + MONEY_RX.pattern, re.IGNORECASE)
+        m = rx.search(text)
+        if not m or re.search(r"xx|tbd|to be", m.group(0), re.IGNORECASE):
+            findings.append(
+                {
+                    "rule_id": rule_id,
+                    "clause_type": "liability_cap",
+                    "severity": "medium",
+                    "start": m.start() if m else 0,
+                    "end": m.end() if m else 0,
+                    "snippet": m.group(0) if m else keyword,
+                    "advice": "Provide a concrete monetary cap",
+                }
+            )
+    return findings
+
+
+def _rule_pollution_cap(text: str) -> List[Dict[str, Any]]:
+    return _rule_cap_present(r"pollution", "pollution_cap_present", text)
+
+
+def _rule_property_damage_cap(text: str) -> List[Dict[str, Any]]:
+    return _rule_cap_present(r"property damage", "property_damage_cap_present", text)
+
+
+def _rule_service_credits(text: str) -> List[Dict[str, Any]]:
+    if re.search(r"\bSLA\b|service level agreement", text, re.IGNORECASE):
+        if not re.search(r"service credits|liquidated damages", text, re.IGNORECASE):
+            return [
+                {
+                    "rule_id": "service_credits_lds_present_if_sla",
+                    "clause_type": "service_levels",
+                    "severity": "medium",
+                    "start": 0,
+                    "end": 0,
+                    "snippet": "SLA referenced without service credits/LDs",
+                    "advice": "Include service credits or liquidated damages when referencing an SLA",
+                }
+            ]
+    return []
+
+
+def _rule_payment_terms(text: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    m = re.search(r"net\s*(\d{1,3})\s*days", text, re.IGNORECASE)
+    if m:
+        days = int(m.group(1))
+        if not (30 <= days <= 45):
+            findings.append(
+                {
+                    "rule_id": "payment_terms_days",
+                    "clause_type": "payment_terms",
+                    "severity": "medium",
+                    "start": m.start(1),
+                    "end": m.end(1),
+                    "snippet": m.group(0),
+                    "advice": "Payment terms should be within 30-45 days",
+                }
+            )
+    else:
+        findings.append(
+            {
+                "rule_id": "payment_terms_days",
+                "clause_type": "payment_terms",
+                "severity": "medium",
+                "start": 0,
+                "end": 0,
+                "snippet": "Payment term not found",
+                "advice": "Specify net payment days",
+            }
+        )
+    if not re.search(r"valid\s+VAT\s+invoice", text, re.IGNORECASE):
+        findings.append(
+            {
+                "rule_id": "payment_terms_days",
+                "clause_type": "payment_terms",
+                "severity": "medium",
+                "start": 0,
+                "end": 0,
+                "snippet": "VAT invoice requirement missing",
+                "advice": "Require a valid VAT invoice",
+            }
+        )
+    return findings
+
+
+_PY_RULES.extend(
+    [
+        _rule_insurance_limits,
+        _rule_pollution_cap,
+        _rule_property_damage_cap,
+        _rule_service_credits,
+        _rule_payment_terms,
+    ]
+)
+
 
 # ---------------------------------------------------------------------------
 # Public helpers
@@ -59,7 +223,7 @@ def discover_rules() -> List[Dict[str, Any]]:
 
 def rules_count() -> int:
     """Return the number of loaded rules."""
-    return len(_RULES)
+    return len(_RULES) + len(_PY_RULES)
 
 
 def match_text(text: str) -> List[Dict[str, Any]]:
@@ -81,5 +245,10 @@ def match_text(text: str) -> List[Dict[str, Any]]:
                         "advice": r.get("advice"),
                     }
                 )
+    for func in _PY_RULES:
+        try:
+            findings.extend(func(text))
+        except Exception:
+            continue
     return findings
 

--- a/contract_review_app/tests/rules/test_numeric_validators.py
+++ b/contract_review_app/tests/rules/test_numeric_validators.py
@@ -1,0 +1,53 @@
+from contract_review_app.legal_rules.loader import match_text, rules_count
+
+
+def _has(findings, rule_id):
+    return any(f.get("rule_id") == rule_id for f in findings)
+
+
+def test_rules_count_new_rules():
+    assert rules_count() >= 6
+
+
+def test_insurance_limits_min():
+    bad = (
+        "Employers' Liability £5,000,000 and Public Liability £1,000,000 "
+        "professional services with Professional Indemnity £1,000,000."
+    )
+    good = (
+        "Employers' Liability £10,000,000 and Public Liability £5,000,000 "
+        "professional services with Professional Indemnity £2,000,000."
+    )
+    assert _has(match_text(bad), "insurance_limits_min")
+    assert not _has(match_text(good), "insurance_limits_min")
+
+
+def test_pollution_cap_present():
+    bad = "Pollution liability cap: TBD."
+    good = "Pollution liability cap: £1,000,000."
+    assert _has(match_text(bad), "pollution_cap_present")
+    assert not _has(match_text(good), "pollution_cap_present")
+
+
+def test_property_damage_cap_present():
+    bad = "Property damage cap: XX."
+    good = "Property damage cap: £500,000."
+    assert _has(match_text(bad), "property_damage_cap_present")
+    assert not _has(match_text(good), "property_damage_cap_present")
+
+
+def test_service_credits_if_sla():
+    bad = "The SLA requires uptime of 99%."
+    good = (
+        "The SLA requires uptime of 99% and service credits will apply. "
+        "Liquidated damages are included."
+    )
+    assert _has(match_text(bad), "service_credits_lds_present_if_sla")
+    assert not _has(match_text(good), "service_credits_lds_present_if_sla")
+
+
+def test_payment_terms_days():
+    bad = "Payment terms: Net 60 days upon receipt of invoice."
+    good = "Payment terms: Net 30 days upon receipt of a valid VAT invoice."
+    assert _has(match_text(bad), "payment_terms_days")
+    assert not _has(match_text(good), "payment_terms_days")


### PR DESCRIPTION
## Summary
- expand rule loader with currency/percent regex helpers and custom numeric validations
- validate insurance minimums, pollution/property caps, SLA service credits, and payment term bounds
- add tests covering boundary cases and updated rule count

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/rules/test_loader_min.py contract_review_app/tests/rules/test_numeric_validators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8077f1408325ab8c0b757f45c8d9