### PR TITLE
SNAP-003: expose schema version header and fix health endpoint

### DIFF
--- a/contract_review_app/tests/api/test_app_contract.py
+++ b/contract_review_app/tests/api/test_app_contract.py
@@ -23,7 +23,10 @@ def test_health_shape():
     r = client.get("/health")
     assert r.status_code == 200
     data = r.json()
+    assert data.get("status") == "ok"
+    assert data.get("schema") == SCHEMA_VERSION
     assert isinstance(data.get("rules_count"), int)
+    assert r.headers.get("x-schema-version") == SCHEMA_VERSION
 
 
 def test_analyze_idempotent_cache_hit_on_second_call():

--- a/contract_review_app/tests/examples/analyze_out_min.json
+++ b/contract_review_app/tests/examples/analyze_out_min.json
@@ -12,7 +12,7 @@
   "results": {},
   "clauses": [],
   "document": {
-    "schema_version": "1.0",
+    "schema_version": "1.1",
     "document_name": "contract.docx",
     "summary_score": 78,
     "summary_risk": "medium",

--- a/contract_review_app/tests/test_api_contract_ssot.py
+++ b/contract_review_app/tests/test_api_contract_ssot.py
@@ -1,6 +1,6 @@
 import json
 from fastapi.testclient import TestClient
-from contract_review_app.api.app import app
+from contract_review_app.api.app import app, SCHEMA_VERSION
 
 client = TestClient(app)
 
@@ -54,4 +54,4 @@ def test_analyze_cache_idempotency_headers():
     r2 = client.post("/api/analyze", data=json.dumps(body))
     assert r2.status_code == 200
     assert r2.headers.get("x-cache").lower() == "hit"
-    assert r1.headers.get("x-schema-version") == r2.headers.get("x-schema-version") == "1.0"
+    assert r1.headers.get("x-schema-version") == r2.headers.get("x-schema-version") == SCHEMA_VERSION

--- a/contract_review_app/tests/test_api_headers_and_qarecheck.py
+++ b/contract_review_app/tests/test_api_headers_and_qarecheck.py
@@ -1,15 +1,18 @@
 import json
 from fastapi.testclient import TestClient
-from contract_review_app.api.app import app
+from contract_review_app.api.app import app, SCHEMA_VERSION
 
 client = TestClient(app)
 
 
-def test_health_has_rulecount():
+def test_health_has_status_schema_and_header():
     r = client.get("/health")
     assert r.status_code == 200
     j = r.json()
+    assert j.get("status") == "ok"
+    assert j.get("schema") == SCHEMA_VERSION
     assert isinstance(j.get("rules_count"), int)
+    assert r.headers.get("x-schema-version") == SCHEMA_VERSION
 
 def test_trace_has_headers_and_shape():
     r = client.get("/api/trace/some-cid")
@@ -18,7 +21,7 @@ def test_trace_has_headers_and_shape():
     assert j["status"] == "ok"
     assert j["cid"] == "some-cid"
     assert isinstance(j["events"], list)
-    assert r.headers.get("x-schema-version") == "1.0"
+    assert r.headers.get("x-schema-version") == SCHEMA_VERSION
     assert r.headers.get("x-cache") == "miss"
     assert r.headers.get("x-cid") == "some-cid"
 
@@ -28,7 +31,7 @@ def test_trace_index_has_headers_and_shape():
     j = r.json()
     assert j["status"] == "ok"
     assert "cids" in j and isinstance(j["cids"], list)
-    assert r.headers.get("x-schema-version") == "1.0"
+    assert r.headers.get("x-schema-version") == SCHEMA_VERSION
     assert r.headers.get("x-cache") == "miss"
     assert r.headers.get("x-cid") in (None, "trace-index", "")
 

--- a/contract_review_app/tests/test_api_health_schema.py
+++ b/contract_review_app/tests/test_api_health_schema.py
@@ -1,0 +1,14 @@
+import json
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+def test_health_has_status_schema_and_header():
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.headers.get("x-schema-version") == "1.1"
+    data = r.json()
+    assert data.get("status") == "ok"
+    assert data.get("schema") == "1.1"
+    assert isinstance(data.get("rules_count"), int)

--- a/contract_review_app/tests/test_api_integration.py
+++ b/contract_review_app/tests/test_api_integration.py
@@ -1,6 +1,6 @@
 import json
 from fastapi.testclient import TestClient
-from contract_review_app.api.app import app
+from contract_review_app.api.app import app, SCHEMA_VERSION
 
 client = TestClient(app)
 
@@ -8,7 +8,11 @@ client = TestClient(app)
 def test_health():
     r = client.get("/health")
     assert r.status_code == 200
-    assert isinstance(r.json().get("rules_count"), int)
+    data = r.json()
+    assert data.get("status") == "ok"
+    assert data.get("schema") == SCHEMA_VERSION
+    assert isinstance(data.get("rules_count"), int)
+    assert r.headers.get("x-schema-version") == SCHEMA_VERSION
 
 def test_analyze_envelope_and_keys():
     r = client.post("/api/analyze", data=json.dumps({"text": "Some clause text."}))

--- a/contract_review_app/tests/test_api_summary_schema.py
+++ b/contract_review_app/tests/test_api_summary_schema.py
@@ -1,0 +1,15 @@
+import json
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+def test_summary_has_status_and_schema_version():
+    payload = {"text":"This Agreement shall be governed by the laws of England and Wales."}
+    r = client.post("/api/summary", json=payload)
+    assert r.status_code == 200
+    assert r.headers.get("x-schema-version") == "1.1"
+    data = r.json()
+    assert data.get("status") == "ok"
+    assert "summary" in data
+    assert data.get("schema_version") == "1.1"


### PR DESCRIPTION
## Summary
- bump API schema version to 1.1 and expose `x-schema-version` header from all endpoints
- return status and schema metadata from `/health`
- ensure summary endpoint reports schema version and provide regression tests

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/test_api_health_schema.py contract_review_app/tests/test_api_summary_schema.py contract_review_app/tests/api/test_app_contract.py contract_review_app/tests/test_api_headers_and_qarecheck.py contract_review_app/tests/test_api_integration.py contract_review_app/tests/test_api_contract_ssot.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac3a9873f08325840fab5796ea9ed1