### PR TITLE
feat: expand summary schema and diagnostics

### DIFF
--- a/contract_review_app/tests/examples/analyze_out_min.json
+++ b/contract_review_app/tests/examples/analyze_out_min.json
@@ -12,7 +12,7 @@
   "results": {},
   "clauses": [],
   "document": {
-    "schema_version": "1.1",
+    "schema_version": "1.2",
     "document_name": "contract.docx",
     "summary_score": 78,
     "summary_risk": "medium",

--- a/contract_review_app/tests/test_api_health_schema.py
+++ b/contract_review_app/tests/test_api_health_schema.py
@@ -1,14 +1,14 @@
 import json
 from fastapi.testclient import TestClient
-from contract_review_app.api.app import app
+from contract_review_app.api.app import app, SCHEMA_VERSION
 
 client = TestClient(app)
 
 def test_health_has_status_schema_and_header():
     r = client.get("/health")
     assert r.status_code == 200
-    assert r.headers.get("x-schema-version") == "1.1"
+    assert r.headers.get("x-schema-version") == SCHEMA_VERSION
     data = r.json()
     assert data.get("status") == "ok"
-    assert data.get("schema") == "1.1"
+    assert data.get("schema") == SCHEMA_VERSION
     assert isinstance(data.get("rules_count"), int)

--- a/contract_review_app/tests/test_api_summary_schema.py
+++ b/contract_review_app/tests/test_api_summary_schema.py
@@ -1,6 +1,6 @@
 import json
 from fastapi.testclient import TestClient
-from contract_review_app.api.app import app
+from contract_review_app.api.app import app, SCHEMA_VERSION
 
 client = TestClient(app)
 
@@ -8,8 +8,22 @@ def test_summary_has_status_and_schema_version():
     payload = {"text":"This Agreement shall be governed by the laws of England and Wales."}
     r = client.post("/api/summary", json=payload)
     assert r.status_code == 200
-    assert r.headers.get("x-schema-version") == "1.1"
+    assert r.headers.get("x-schema-version") == SCHEMA_VERSION
     data = r.json()
     assert data.get("status") == "ok"
-    assert "summary" in data
-    assert data.get("schema_version") == "1.1"
+    assert data.get("schema_version") == SCHEMA_VERSION
+    summary = data.get("summary")
+    for key in [
+        "type",
+        "parties",
+        "dates",
+        "signatures",
+        "term",
+        "governing_law",
+        "jurisdiction",
+        "liability",
+        "carveouts",
+        "conditions_vs_warranties",
+        "hints",
+    ]:
+        assert key in summary


### PR DESCRIPTION
## Summary
- extend `/api/summary` to schema v1.2 with richer fields and headers
- surface full document snapshot in taskpane with copy/insert actions and schema version badge
- enhance offline analyzer to map endpoints, tests, frontend calls and unwired summary fields

## Testing
- `PYTHONPATH=$PWD pytest -q contract_review_app/tests/test_api_summary_schema.py`
- `PYTHONPATH=$PWD pytest -q contract_review_app/tests/api/test_api_summary.py`
- `PYTHONPATH=$PWD pytest -q contract_review_app/tests/test_summary_api.py`
- `PYTHONPATH=$PWD pytest -q contract_review_app/tests/test_api_health_schema.py`
- `python tools/analyze_project.py --html tools/out/analysis.html`


------
https://chatgpt.com/codex/tasks/task_e_68ac460876008325bcbc886bad419205