### PR TITLE
Refactor GPT service to avoid circular imports

### DIFF
--- a/contract_review_app/gpt/clients/anthropic_client.py
+++ b/contract_review_app/gpt/clients/anthropic_client.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import requests
 
 from ..config import LLMConfig
-from ..service import (
+from ..interfaces import (
     BaseClient,
     DraftResult,
     QAResult,
     SuggestResult,
     ProviderTimeoutError,
-    ProviderUnavailableError,
+    ProviderAuthError,
+    ProviderConfigError,
 )
 
 
@@ -31,11 +32,13 @@ class AnthropicClient(BaseClient):
             r = requests.post(f"{self._base}/messages", json=payload, headers=headers, timeout=timeout)
         except requests.Timeout:
             raise ProviderTimeoutError(self.provider, timeout)
+        if r.status_code in (401, 403):
+            raise ProviderAuthError(self.provider, r.text)
         if r.status_code >= 400:
-            raise ProviderUnavailableError(self.provider, r.text)
+            raise ProviderConfigError(self.provider, r.text)
         return r.json()
 
-    def generate_draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
+    def draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
         data = self._post(
             {
                 "model": self.model,

--- a/contract_review_app/gpt/clients/azure_client.py
+++ b/contract_review_app/gpt/clients/azure_client.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import requests
 
 from ..config import LLMConfig
-from ..service import (
+from ..interfaces import (
     BaseClient,
     DraftResult,
     QAResult,
     SuggestResult,
     ProviderTimeoutError,
-    ProviderUnavailableError,
+    ProviderAuthError,
+    ProviderConfigError,
 )
 
 
@@ -30,11 +31,13 @@ class AzureClient(BaseClient):
             r = requests.post(url, json=payload, headers=headers, timeout=timeout)
         except requests.Timeout:
             raise ProviderTimeoutError(self.provider, timeout)
+        if r.status_code in (401, 403):
+            raise ProviderAuthError(self.provider, r.text)
         if r.status_code >= 400:
-            raise ProviderUnavailableError(self.provider, r.text)
+            raise ProviderConfigError(self.provider, r.text)
         return r.json()
 
-    def generate_draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
+    def draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
         data = self._post(
             {
                 "model": self.model,

--- a/contract_review_app/gpt/clients/mock_client.py
+++ b/contract_review_app/gpt/clients/mock_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..service import BaseClient, DraftResult, SuggestResult, QAResult, ProviderTimeoutError
+from ..interfaces import BaseClient, DraftResult, SuggestResult, QAResult, ProviderTimeoutError
 
 
 class MockClient(BaseClient):
@@ -13,9 +13,12 @@ class MockClient(BaseClient):
         if timeout and timeout < 0.05:
             raise ProviderTimeoutError(self.provider, timeout)
 
-    def generate_draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
+    def draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
         self._check_timeout(timeout)
-        text = "[MOCK DRAFT] " + (prompt[: max_tokens] or "placeholder")
+        snippet = prompt[: max_tokens].strip() if prompt else ""
+        if not snippet:
+            snippet = "example"
+        text = f"[MOCK DRAFT] {snippet}"
         return DraftResult(text=text, meta={"provider": self.provider, "model": self.model, "mode": self.mode})
 
     def suggest_edits(self, prompt: str, timeout: float) -> SuggestResult:

--- a/contract_review_app/gpt/clients/openrouter_client.py
+++ b/contract_review_app/gpt/clients/openrouter_client.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import requests
 
 from ..config import LLMConfig
-from ..service import (
+from ..interfaces import (
     BaseClient,
     DraftResult,
     QAResult,
     SuggestResult,
     ProviderTimeoutError,
-    ProviderUnavailableError,
+    ProviderAuthError,
+    ProviderConfigError,
 )
 
 
@@ -27,11 +28,13 @@ class OpenRouterClient(BaseClient):
             r = requests.post(f"{self._base}/chat/completions", json=payload, headers=headers, timeout=timeout)
         except requests.Timeout:
             raise ProviderTimeoutError(self.provider, timeout)
+        if r.status_code in (401, 403):
+            raise ProviderAuthError(self.provider, r.text)
         if r.status_code >= 400:
-            raise ProviderUnavailableError(self.provider, r.text)
+            raise ProviderConfigError(self.provider, r.text)
         return r.json()
 
-    def generate_draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
+    def draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
         data = self._post(
             {
                 "model": self.model,

--- a/contract_review_app/gpt/interfaces.py
+++ b/contract_review_app/gpt/interfaces.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class DraftResult:
+    text: str
+    meta: Dict[str, Any]
+
+
+@dataclass
+class SuggestResult:
+    items: List[Dict[str, Any]]
+    meta: Dict[str, Any]
+
+
+@dataclass
+class QAResult:
+    items: List[Dict[str, Any]]
+    meta: Dict[str, Any]
+
+
+class ProviderError(Exception):
+    def __init__(self, provider: str, detail: str):
+        super().__init__(detail)
+        self.provider = provider
+        self.detail = detail
+
+
+class ProviderTimeoutError(ProviderError):
+    def __init__(self, provider: str, timeout: float):
+        super().__init__(provider, f"{provider} timeout {timeout}s")
+        self.timeout = timeout
+
+
+class ProviderAuthError(ProviderError):
+    pass
+
+
+class ProviderConfigError(ProviderError):
+    pass
+
+
+class BaseClient(ABC):
+    provider: str
+    model: str
+    mode: str
+
+    @abstractmethod
+    def draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:  # pragma: no cover - interface
+        ...
+
+    @abstractmethod
+    def suggest_edits(self, prompt: str, timeout: float) -> SuggestResult:  # pragma: no cover - interface
+        ...
+
+    @abstractmethod
+    def qa_recheck(self, prompt: str, timeout: float) -> QAResult:  # pragma: no cover - interface
+        ...

--- a/contract_review_app/gpt/service.py
+++ b/contract_review_app/gpt/service.py
@@ -1,80 +1,41 @@
 from __future__ import annotations
 
-import dataclasses
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from .config import LLMConfig, load_llm_config
-from .clients.mock_client import MockClient
-from .clients.openai_client import OpenAIClient
-from .clients.azure_client import AzureClient
-from .clients.anthropic_client import AnthropicClient
-from .clients.openrouter_client import OpenRouterClient
+from .interfaces import (
+    BaseClient,
+    DraftResult,
+    SuggestResult,
+    QAResult,
+    ProviderTimeoutError,
+    ProviderAuthError,
+    ProviderConfigError,
+)
 
 
-class ProviderUnavailableError(Exception):
-    def __init__(self, provider: str, detail: str):
-        super().__init__(detail)
-        self.provider = provider
-        self.detail = detail
-
-
-class ProviderTimeoutError(Exception):
-    def __init__(self, provider: str, timeout: float):
-        super().__init__(f"{provider} timeout {timeout}s")
-        self.provider = provider
-        self.timeout = timeout
-
-
-@dataclass
-class DraftResult:
-    text: str
-    meta: Dict[str, Any]
-
-
-@dataclass
-class SuggestResult:
-    items: List[Dict[str, Any]]
-    meta: Dict[str, Any]
-
-
-@dataclass
-class QAResult:
-    items: List[Dict[str, Any]]
-    meta: Dict[str, Any]
-
-
-class BaseClient:
-    provider: str
-    model: str
-    mode: str
-
-    def generate_draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
-        raise NotImplementedError
-
-    def suggest_edits(self, prompt: str, timeout: float) -> SuggestResult:
-        raise NotImplementedError
-
-    def qa_recheck(self, prompt: str, timeout: float) -> QAResult:
-        raise NotImplementedError
+def get_client(provider: str, cfg: LLMConfig) -> BaseClient:
+    if provider == "openai" and cfg.valid:
+        from .clients.openai_client import OpenAIClient
+        return OpenAIClient(cfg)
+    if provider == "azure" and cfg.valid:
+        from .clients.azure_client import AzureClient
+        return AzureClient(cfg)
+    if provider == "anthropic" and cfg.valid:
+        from .clients.anthropic_client import AnthropicClient
+        return AnthropicClient(cfg)
+    if provider == "openrouter" and cfg.valid:
+        from .clients.openrouter_client import OpenRouterClient
+        return OpenRouterClient(cfg)
+    from .clients.mock_client import MockClient
+    return MockClient(cfg.model_draft)
 
 
 class LLMService:
     def __init__(self, cfg: Optional[LLMConfig] = None):
         self.cfg = cfg or load_llm_config()
-        self.client: BaseClient
-        if self.cfg.provider == "openai" and self.cfg.valid:
-            self.client = OpenAIClient(self.cfg)
-        elif self.cfg.provider == "azure" and self.cfg.valid:
-            self.client = AzureClient(self.cfg)
-        elif self.cfg.provider == "anthropic" and self.cfg.valid:
-            self.client = AnthropicClient(self.cfg)
-        elif self.cfg.provider == "openrouter" and self.cfg.valid:
-            self.client = OpenRouterClient(self.cfg)
-        else:
-            self.client = MockClient(self.cfg.model_draft)
+        self.client: BaseClient = get_client(self.cfg.provider, self.cfg)
 
-    # prompt loading helpers
     def _read_prompt(self, name: str) -> str:
         import pkgutil
 
@@ -83,7 +44,7 @@ class LLMService:
             return ""
         return data.decode("utf-8")
 
-    def generate_draft(
+    def draft(
         self,
         text: str,
         clause_type: Optional[str],
@@ -101,15 +62,15 @@ class LLMService:
         max_t = max_tokens or self.cfg.max_tokens
         temp = temperature if temperature is not None else self.cfg.temperature
         to = timeout or self.cfg.timeout_s
-        return self.client.generate_draft(prompt, max_t, temp, to)
+        return self.client.draft(prompt, max_t, temp, to)
 
-    def suggest_edits(self, text: str, risk_level: str, timeout: Optional[float] = None) -> SuggestResult:
+    def suggest(self, text: str, risk_level: str, timeout: Optional[float] = None) -> SuggestResult:
         prompt_tpl = self._read_prompt("suggest")
         prompt = prompt_tpl.format(text=text, risk=risk_level)
         to = timeout or self.cfg.timeout_s
         return self.client.suggest_edits(prompt, to)
 
-    def qa_recheck(self, text: str, rules_context: Dict[str, Any], timeout: Optional[float] = None) -> QAResult:
+    def qa(self, text: str, rules_context: Dict[str, Any], timeout: Optional[float] = None) -> QAResult:
         prompt_tpl = self._read_prompt("qa")
         prompt = prompt_tpl.format(text=text, rules=rules_context)
         to = timeout or self.cfg.timeout_s


### PR DESCRIPTION
## Summary
- Introduce `interfaces` module for GPT contracts and errors
- Update clients and service to use shared interfaces with lazy client factory
- Adjust API to new service methods and error handling

## Testing
- `python -c "import importlib; importlib.import_module('contract_review_app.gpt.service'); print('OK: service import')"`
- `PYTHONPATH=. pytest tests/test_suggest_edits_apply.py tests/test_rules_corpus.py -q`
- `curl -k "https://127.0.0.1:9443/api/gpt/draft" -H "Origin: https://localhost:3000" -H "Content-Type: application/json" -X POST -d '{"text":"sample","clause_type":"governing_law"}'`

------
https://chatgpt.com/codex/tasks/task_e_68ac4c3b5c20832581e3ef98808a8cb6