### PR TITLE
Harden QA prompt formatting and add QA self-test

### DIFF
--- a/contract_review_app/gpt/prompts/qa.txt
+++ b/contract_review_app/gpt/prompts/qa.txt
@@ -1,7 +1,18 @@
-Check the clause against the provided rules context and respond with a JSON array of objects {id, status (ok|warn|fail), note}.
+You are a contract QA checker.
 
-Rules:
+Context rules:
 {rules}
+
+Task:
+Review the clause below and produce JSON with an "issues" array.
+Each element: id, status (ok|warn|fail), note.
 
 Clause:
 {text}
+
+Output JSON (strict, no prose):
+{{
+  "issues": [
+    {{ "id": "QA_001", "status": "warn", "note": "…" }}
+  ]
+}}


### PR DESCRIPTION
## Summary
- revise QA prompt to only expose `{text}` and `{rules}` placeholders
- add `_safe_format_prompt` to validate prompt fields and surface unknown placeholders
- log invalid QA prompts and include QA recheck case in panel self-tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'contract_review_app')*

------
https://chatgpt.com/codex/tasks/task_e_68ac4ef44118832582a7dc10ca974240