### PR TITLE
Refactor import order in calloff validator

### DIFF
--- a/contract_review_app/api/calloff_validator.py
+++ b/contract_review_app/api/calloff_validator.py
@@ -1,8 +1,9 @@
-from __future__ import annotations
 """Simple rule-based validator for Call-Off details."""
 
-from typing import Any, Dict, List
+from __future__ import annotations
+
 import re
+from typing import Any, Dict, List
 
 REQUIRED_FIELDS = {
     "term": "Term",


### PR DESCRIPTION
## Summary
- Move module docstring to the top of `calloff_validator`
- Place `from __future__ import annotations` below the docstring
- Group and reorder imports to place standard library before typing imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac90ae86f48325af68193820c62c9c