### PR TITLE
fix: remove incomplete confidentiality entry

### DIFF
--- a/contract_review_app/engine/patterns_oilgas.py
+++ b/contract_review_app/engine/patterns_oilgas.py
@@ -322,4 +322,4 @@ CLAUSE_PATTERNS: Dict[str, dict] = {
         ],
         "aliases": ["fm", "relief_events"],
     },
-    "confidentialit
+}


### PR DESCRIPTION
## Summary
- remove stray `confidentiality` line in `patterns_oilgas` and close clause pattern dictionary

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac90af442c8325853e6c897725b61a