### PR TITLE
Fix GPT client interface imports

### DIFF
--- a/contract_review_app/gpt/clients/anthropic_client.py
+++ b/contract_review_app/gpt/clients/anthropic_client.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import requests
 
 from ..config import LLMConfig
-
+from ..interfaces import (
     BaseClient,
     DraftResult,
     QAResult,
     SuggestResult,
     ProviderTimeoutError,
-
+    ProviderAuthError,
+    ProviderConfigError,
 )
 
 

--- a/contract_review_app/gpt/clients/azure_client.py
+++ b/contract_review_app/gpt/clients/azure_client.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import requests
 
 from ..config import LLMConfig
-
+from ..interfaces import (
     BaseClient,
     DraftResult,
     QAResult,
     SuggestResult,
     ProviderTimeoutError,
-
+    ProviderAuthError,
+    ProviderConfigError,
 )
 
 

--- a/contract_review_app/gpt/clients/openai_client.py
+++ b/contract_review_app/gpt/clients/openai_client.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import requests
 
 from ..config import LLMConfig
-
+from ..interfaces import (
     BaseClient,
     DraftResult,
     QAResult,
     SuggestResult,
     ProviderTimeoutError,
-
+    ProviderAuthError,
+    ProviderConfigError,
 )
 
 

--- a/contract_review_app/gpt/clients/openrouter_client.py
+++ b/contract_review_app/gpt/clients/openrouter_client.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import requests
 
 from ..config import LLMConfig
-
+from ..interfaces import (
     BaseClient,
     DraftResult,
     QAResult,
     SuggestResult,
     ProviderTimeoutError,
-
+    ProviderAuthError,
+    ProviderConfigError,
 )
 
 


### PR DESCRIPTION
## Summary
- repair broken imports for GPT client modules
- include interface classes and error types in each client

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac90b1567c8325bd5bd3b7a8a3157d