### PR TITLE
Normalize legal_rules formatting and expand one-liners

### DIFF
--- a/contract_ai_doctor.py
+++ b/contract_ai_doctor.py
@@ -19,7 +19,9 @@ try:
 except Exception:
     requests = None
 
-OK = "PASS"; WARN = "WARN"; FAIL = "FAIL"
+OK = "PASS"
+WARN = "WARN"
+FAIL = "FAIL"
 
 @dataclass
 class Check:
@@ -152,7 +154,8 @@ def _to_dict(obj):
                 return getattr(obj, m)()
             except Exception:
                 pass
-    if isinstance(obj, dict): return obj
+    if isinstance(obj, dict):
+        return obj
     try:
         return dict(obj)
     except Exception:

--- a/contract_review_app/learning/replay_io.py
+++ b/contract_review_app/learning/replay_io.py
@@ -46,7 +46,8 @@ def _rotate_if_needed(rotation_mb: int) -> None:
                 with open(REPLAY_FILE, "rb") as src, gzip.open(dst, "wb", compresslevel=6) as gz:
                     while True:
                         chunk = src.read(1 << 20)
-                        if not chunk: break
+                        if not chunk:
+                            break
                         gz.write(chunk)
                 open(REPLAY_FILE, "w").close()
     except Exception:

--- a/contract_review_app/legal_rules/legal_rules.py
+++ b/contract_review_app/legal_rules/legal_rules.py
@@ -1,5 +1,4 @@
-```python
-# legal_rules.py — dispatcher/normalizers + registry helpers (fixed)
+"""legal_rules.py — dispatcher/normalizers + registry helpers (fixed)."""
 from __future__ import annotations
 from typing import Any, Dict, List, Union, Iterable
 
@@ -15,11 +14,20 @@ try:
         Suggestion,
     )
 except Exception:
-    class AnalysisInput(dict): pass
-    class AnalysisOutput(dict): pass
-    class Finding(dict): pass
-    class Diagnostic(dict): pass
-    class Suggestion(dict): pass
+    class AnalysisInput(dict):
+        pass
+
+    class AnalysisOutput(dict):
+        pass
+
+    class Finding(dict):
+        pass
+
+    class Diagnostic(dict):
+        pass
+
+    class Suggestion(dict):
+        pass
 
 def list_rule_names() -> List[str]:
     """
@@ -56,44 +64,72 @@ def _coerce_severity(val: Any) -> str:
     return s2 if s2 in _ALLOWED_SEVERITIES else "minor"
 
 def _normalize_findings(raw: Union[None, List[Any]]) -> List[Finding]:
-    if not raw: return []
+    if not raw:
+        return []
     out: List[Finding] = []
     for it in raw:
         try:
             if isinstance(it, Finding):
-                sev = _coerce_severity(getattr(it, "severity", getattr(it, "severity_level", None)))
-                out.append(Finding(
-                    code=getattr(it, "code", ""), message=getattr(it, "message", ""),
-                    severity=sev, evidence=getattr(it, "evidence", None),
-                    span=getattr(it, "span", None), citations=getattr(it, "citations", []),
-                    tags=getattr(it, "tags", []), legal_basis=getattr(it, "legal_basis", []),
-                ))
+                sev = _coerce_severity(
+                    getattr(it, "severity", getattr(it, "severity_level", None))
+                )
+                out.append(
+                    Finding(
+                        code=getattr(it, "code", ""),
+                        message=getattr(it, "message", ""),
+                        severity=sev,
+                        evidence=getattr(it, "evidence", None),
+                        span=getattr(it, "span", None),
+                        citations=getattr(it, "citations", []),
+                        tags=getattr(it, "tags", []),
+                        legal_basis=getattr(it, "legal_basis", []),
+                    )
+                )
             elif isinstance(it, dict):
-                d = dict(it); d["severity"] = _coerce_severity(d.get("severity", d.get("severity_level")))
+                d = dict(it)
+                d["severity"] = _coerce_severity(
+                    d.get("severity", d.get("severity_level"))
+                )
                 out.append(Finding(**d))
             else:
-                out.append(Finding(code="GEN", message=str(it), severity="minor"))
+                out.append(
+                    Finding(code="GEN", message=str(it), severity="minor")
+                )
         except Exception:
-            out.append(Finding(code="GEN_ERR", message=str(it), severity="minor"))
+            out.append(
+                Finding(code="GEN_ERR", message=str(it), severity="minor")
+            )
     return out
 
 def _normalize_diagnostics(raw: Union[None, List[Any]]) -> List[Diagnostic]:
-    if not raw: return []
+    if not raw:
+        return []
     out: List[Diagnostic] = []
     for item in raw:
         if isinstance(item, Diagnostic):
             out.append(item)
         elif isinstance(item, str):
-            out.append(Diagnostic(rule="ENGINE", message=item, severity="info"))
+            out.append(
+                Diagnostic(rule="ENGINE", message=item, severity="info")
+            )
         elif isinstance(item, dict):
-            out.append(Diagnostic(rule=str(item.get("rule","ENGINE")), message=str(item.get("message","")),
-                                  severity=item.get("severity","info"), legal_basis=item.get("legal_basis",[])))
+            out.append(
+                Diagnostic(
+                    rule=str(item.get("rule", "ENGINE")),
+                    message=str(item.get("message", "")),
+                    severity=item.get("severity", "info"),
+                    legal_basis=item.get("legal_basis", []),
+                )
+            )
         else:
-            out.append(Diagnostic(rule="ENGINE", message=str(item), severity="info"))
+            out.append(
+                Diagnostic(rule="ENGINE", message=str(item), severity="info")
+            )
     return out
 
 def _normalize_suggestions(raw: Union[None, List[Any]]) -> List[Suggestion]:
-    if not raw: return []
+    if not raw:
+        return []
     out: List[Suggestion] = []
     for item in raw:
         if isinstance(item, Suggestion):
@@ -109,9 +145,12 @@ def _normalize_suggestions(raw: Union[None, List[Any]]) -> List[Suggestion]:
 
 def _map_status(val: str) -> str:
     v = (val or "").strip().upper()
-    if v in {"✅","OK","PASS"}: return "OK"
-    if v in {"⚠️","WARN","WARNING"}: return "WARN"
-    if v in {"❌","FAIL","ERROR"}: return "FAIL"
+    if v in {"✅", "OK", "PASS"}:
+        return "OK"
+    if v in {"⚠️", "WARN", "WARNING"}:
+        return "WARN"
+    if v in {"❌", "FAIL", "ERROR"}:
+        return "FAIL"
     return "WARN"
 
 def default_checker(input_data: AnalysisInput) -> AnalysisOutput:
@@ -153,12 +192,16 @@ def analyze(input_data: AnalysisInput) -> AnalysisOutput:
             rule_trace = result.get("trace", [])
             trace_final = trace + (rule_trace if isinstance(rule_trace, list) else [])
             recs = result.get("recommendations", [])
-            if isinstance(recs, str): recs = [recs]
-            elif not isinstance(recs, list): recs = []
+            if isinstance(recs, str):
+                recs = [recs]
+            elif not isinstance(recs, list):
+                recs = []
             legacy_rec = result.get("recommendation")
-            if isinstance(legacy_rec, str) and legacy_rec: recs.append(legacy_rec)
+            if isinstance(legacy_rec, str) and legacy_rec:
+                recs.append(legacy_rec)
             citations = result.get("citations") or []
-            if isinstance(citations, str): citations = [citations]
+            if isinstance(citations, str):
+                citations = [citations]
             findings_norm = _normalize_findings(result.get("findings", []))
             return AnalysisOutput(
                 clause_type=clause_type_norm,
@@ -196,5 +239,9 @@ def analyze(input_data: AnalysisInput) -> AnalysisOutput:
     result.trace = trace + result.trace
     return result
 
-__all__ = ["list_rule_names","normalize_clause_type","default_checker","analyze"]
-```
+__all__ = [
+    "list_rule_names",
+    "normalize_clause_type",
+    "default_checker",
+    "analyze",
+]

--- a/contract_review_app/legal_rules/rules/oilgas_master_agreement.py
+++ b/contract_review_app/legal_rules/rules/oilgas_master_agreement.py
@@ -13,8 +13,10 @@ def _risk_to_ord(s: str) -> int:
     return _RISK_ORD.get((s or "medium").lower(), 1)
 
 def _ord_to_risk(i: int) -> str:
-    if i < 0: i = 0
-    if i >= len(_ORD_RISK): i = len(_ORD_RISK) - 1
+    if i < 0:
+        i = 0
+    if i >= len(_ORD_RISK):
+        i = len(_ORD_RISK) - 1
     return _ORD_RISK[i]
 
 def _clamp(v: int, lo: int, hi: int) -> int:
@@ -411,10 +413,14 @@ def _check_call_off(text: str, sections: List[Dict[str, Any]]) -> Dict[str, Any]
     else:
         status, risk, score = "WARN", "medium", -10
         missing_msgs = []
-        if not has_nonexclusive: missing_msgs.append("non-exclusive")
-        if not has_calloff: missing_msgs.append("call-off")
-        if not has_separate: missing_msgs.append("separate contracts")
-        if not has_precedence: missing_msgs.append("order of precedence")
+        if not has_nonexclusive:
+            missing_msgs.append("non-exclusive")
+        if not has_calloff:
+            missing_msgs.append("call-off")
+        if not has_separate:
+            missing_msgs.append("separate contracts")
+        if not has_precedence:
+            missing_msgs.append("order of precedence")
         findings.append(_mk_finding("CO-MISSING-ELEMS", f"Missing elements: {', '.join(missing_msgs)}.", "medium", None, span))
     return _mk_analysis(clause_type, title or "Call-Off / Ordering", span, status, risk, score, findings)
 

--- a/patch_taskpane_apply.py
+++ b/patch_taskpane_apply.py
@@ -80,7 +80,8 @@ def find_func_bounds(src: str, name: str):
         return None
     # знайти першу '{' після сигнатури
     brace = src.find("{", start)
-    if brace < 0: return None
+    if brace < 0:
+        return None
     i = brace
     n = len(src)
     depth = 0


### PR DESCRIPTION
## Summary
- remove stray markdown fencing and expand placeholder classes in legal_rules helpers
- rewrite normalization helpers and status mapping with multiline control flow
- split colon/semicolon one-liners across doctor, patch utility, replay IO, and oil-gas rule

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac90b695c88325ae8bc12cd205c139