### PR TITLE
refactor: clarify variable names and control flow

### DIFF
--- a/contract_review_app/engine/pipeline.py
+++ b/contract_review_app/engine/pipeline.py
@@ -222,14 +222,14 @@ def _safe_get(obj, key, *alts, default=None):
 
 def _span_start_len(obj) -> Tuple[int, int]:
     sp = _safe_get(obj, "span", default=None)
-    s = int(_safe_get(sp, "start", default=0))
-    l = _safe_get(sp, "length", default=None)
-    if l is None:
-        e = int(_safe_get(sp, "end", default=s))
-        l = max(0, e - s)
+    start = int(_safe_get(sp, "start", default=0))
+    length = _safe_get(sp, "length", default=None)
+    if length is None:
+        end = int(_safe_get(sp, "end", default=start))
+        length = max(0, end - start)
     else:
-        l = int(l or 0)
-    return s, l
+        length = int(length or 0)
+    return start, length
 
 def _map_clause_id_for_analysis(analysis: Dict[str, Any], index: DocIndex) -> Tuple[Optional[str], str]:
     a_span = _norm_span(_safe_get(analysis, "span", default={}))

--- a/contract_review_app/learning/replay_buffer.jsonl
+++ b/contract_review_app/learning/replay_buffer.jsonl
@@ -199,10 +199,13 @@ def _sanitize_event(evt: dict) -> dict:
     # limit span size fields
     span = e.get("span") or {}
     try:
-        s = int(span.get("start", 0)); l = int(span.get("length", 0))
-        if s < 0: s = 0
-        if l < 0: l = 0
-        e["span"] = {"start": s, "length": l}
+        start = int(span.get("start", 0))
+        length = int(span.get("length", 0))
+        if start < 0:
+            start = 0
+        if length < 0:
+            length = 0
+        e["span"] = {"start": start, "length": length}
     except Exception:
         e["span"] = {"start": 0, "length": 0}
     return e

--- a/contract_review_app/legal_rules/rules/confidentiality.py
+++ b/contract_review_app/legal_rules/rules/confidentiality.py
@@ -60,7 +60,7 @@ def _risk_from_findings(findings: List[Finding]) -> str:
 
 def _status_from_findings(findings: List[Finding]) -> str:
     levels = [getattr(f, "severity_level", None) or "minor" for f in findings]
-    if any(l == "critical" for l in levels):
+    if any(level == "critical" for level in levels):
         return "FAIL"
     if findings:
         return "WARN"

--- a/contract_review_app/legal_rules/rules/definitions.py
+++ b/contract_review_app/legal_rules/rules/definitions.py
@@ -20,7 +20,15 @@ def analyze(inp: AnalysisInput) -> AnalysisOutput:
 
     # “Confidential Information” consistency example
     if re.search(r"confidential information", text, flags=re.I) and not re.search(r"means|shall mean|is defined as", text, flags=re.I):
-        s,l = re.search(r"confidential information", text, flags=re.I).span()
-        findings.append(mk_finding("DEF-CI-DEF", "Confidential Information mentioned but not clearly defined", "high", s, l))
+        start, end = re.search(r"confidential information", text, flags=re.I).span()
+        findings.append(
+            mk_finding(
+                "DEF-CI-DEF",
+                "Confidential Information mentioned but not clearly defined",
+                "high",
+                start,
+                end,
+            )
+        )
 
     return make_output(rule_name, inp, findings, "Definitions", "Definitions")

--- a/contract_review_app/legal_rules/rules/force_majeure.py
+++ b/contract_review_app/legal_rules/rules/force_majeure.py
@@ -14,8 +14,10 @@ def analyze(inp: AnalysisInput) -> AnalysisOutput:
     else:
         # Notice requirement
         if not re.search(r"\bnotice\b", text, flags=re.I):
-            s,l = find_span(text, r"force majeure")
-            findings.append(mk_finding("FM-NOTICE", "No notice obligation during force majeure", "medium", s, l))
+            start, length = find_span(text, r"force majeure")
+            findings.append(
+                mk_finding("FM-NOTICE", "No notice obligation during force majeure", "medium", start, length)
+            )
         # Mitigation duty
         if not re.search(r"\bmitigat(e|ion)\b", text, flags=re.I):
             findings.append(mk_finding("FM-MITIG", "No duty to mitigate effects of force majeure", "low"))


### PR DESCRIPTION
## Summary
- rename single-letter variables to descriptive names
- expand inline conditionals into full blocks
- maintain line lengths under 160 characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac90b7b228832598b38f3ee329cfd7