### PR TITLE
Order future imports and imports groups

### DIFF
--- a/contract_ai_doctor.py
+++ b/contract_ai_doctor.py
@@ -1,13 +1,22 @@
-
 #!/usr/bin/env python3
-# Contract AI — Doctor v2
-# End-to-end diagnostics across: Front (manifest+taskpane), Network/TLS/CORS, Backend, Pipeline, Rules, Response shape.
-# Outputs markdown+json with a stage-by-stage chain view and suggested fixes.
-
 from __future__ import annotations
 
-import argparse, json, os, re, sys, time, socket, ssl
-from dataclasses import dataclass, asdict
+"""Contract AI — Doctor v2.
+
+End-to-end diagnostics across: Front (manifest+taskpane), Network/TLS/CORS,
+Backend, Pipeline, Rules, Response shape. Outputs markdown+json with a
+stage-by-stage chain view and suggested fixes.
+"""
+
+import argparse
+import json
+import os
+import re
+import socket
+import ssl
+import sys
+import time
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -15,6 +24,7 @@ from typing import Any, Dict, List, Optional, Tuple
 try:
     import requests
     from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
     requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 except Exception:
     requests = None

--- a/main.py
+++ b/main.py
@@ -1,13 +1,15 @@
-# main.py
 from __future__ import annotations
+
+"""Demo entry point for Contract AI rule analysis."""
+
 import logging
 import os
 import sys
 
 from contract_review_app.core.schemas import AnalysisInput
-from contract_review_app.legal_rules.legal_rules import analyze as run_rule  # центральний диспетчер
-from contract_review_app.legal_rules.registry import RULES_REGISTRY
 from contract_review_app.generate_report import generate_report
+from contract_review_app.legal_rules.legal_rules import analyze as run_rule
+from contract_review_app.legal_rules.registry import RULES_REGISTRY
 
 # спробуємо взяти зручний лоадер DOCX, якщо є
 try:

--- a/tools/analyze_project.py
+++ b/tools/analyze_project.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 """Offline repository analyzer for contract_ai (v2).
 Generates JSON and HTML reports summarising backend, LLM, rule engine
 and Word add‑in readiness. Designed for one‑click execution via PowerShell.
 """
-from __future__ import annotations
 
 import argparse
 import ast
@@ -13,9 +14,9 @@ import html
 import json
 import os
 import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
-import xml.etree.ElementTree as ET
 
 try:  # optional dependency
     import yaml  # type: ignore


### PR DESCRIPTION
## Summary
- place `from __future__ import annotations` directly after the shebang
- move module docstrings beneath the future import
- group standard-library imports before third-party ones

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac90bb85fc8325949295c4b99e42d1