### PR TITLE
Expose analysis hook and GPT error re-exports

### DIFF
--- a/contract_review_app/gpt/clients/mock_client.py
+++ b/contract_review_app/gpt/clients/mock_client.py
@@ -1,5 +1,10 @@
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from ..interfaces import (
+    BaseClient,
+    DraftResult,
+    SuggestResult,
+    QAResult,
+    ProviderTimeoutError,
+)
 
 
 class MockClient(BaseClient):

--- a/contract_review_app/gpt/service.py
+++ b/contract_review_app/gpt/service.py
@@ -4,7 +4,15 @@ from string import Formatter
 from typing import Any, Dict, Optional, Set
 
 from .config import LLMConfig, load_llm_config
-from .interfaces import BaseClient, DraftResult, QAResult, SuggestResult
+from .interfaces import (
+    BaseClient,
+    DraftResult,
+    SuggestResult,
+    QAResult,
+    ProviderAuthError,
+    ProviderTimeoutError,
+    ProviderConfigError,
+)
 from .clients.mock_client import MockClient
 
 
@@ -84,3 +92,16 @@ class LLMService:
 def create_llm_service() -> LLMService:
     cfg = load_llm_config()
     return LLMService(cfg)
+
+
+__all__ = [
+    "LLMService",
+    "load_llm_config",
+    "BaseClient",
+    "DraftResult",
+    "SuggestResult",
+    "QAResult",
+    "ProviderAuthError",
+    "ProviderTimeoutError",
+    "ProviderConfigError",
+]


### PR DESCRIPTION
## Summary
- re-export GPT client types and provider exceptions in `gpt.service`
- add `_analyze_document` hook and use it in `/api/analyze`
- simplify GPT config imports and delegate GPT draft endpoint to orchestrator when available
- fix mock client imports

## Testing
- `python -c "from contract_review_app.gpt.service import ProviderTimeoutError; print('OK', ProviderTimeoutError.__name__)"`
- `python -c "import contract_review_app.api.app as app; print('has _analyze_document:', hasattr(app, '_analyze_document'))"`
- `ruff check contract_review_app/api/app.py --select F401,F402,F811`
- `python -m pytest -q contract_review_app/tests/api/test_api_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68acaea0042c8325b6dadd8f09377761