### PR TITLE
Add heuristic document type classifier and expose via APIs

### DIFF
--- a/contract_review_app/analysis/summary_schemas.py
+++ b/contract_review_app/analysis/summary_schemas.py
@@ -37,7 +37,7 @@ class ConditionsVsWarranties(AppBaseModel):
 
 
 class DocumentSnapshot(AppBaseModel):
-    type: Literal["NDA", "MSA", "DPA", "SaaS", "Supply", "Services", "License", "unknown"] = "unknown"
+    type: str = "unknown"
     type_confidence: float = 0.0
     parties: List[Party] = Field(default_factory=list)
     dates: Dict[str, Optional[str]] = Field(default_factory=dict)

--- a/contract_review_app/engine/doc_type.py
+++ b/contract_review_app/engine/doc_type.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Heuristic document type classifier."""
+
+from typing import Dict, List, Tuple
+
+from .patterns_doctype import DOC_TYPE_PATTERNS
+
+W_TITLE = 0.4
+W_BODY = 0.6
+
+DISPLAY_MAP = {
+    "nda": "NDA",
+    "msa_services": "MSA (Services)",
+    "supply_of_goods": "Supply of Goods",
+    "dpa_uk_gdpr": "DPA",
+    "license_ip": "License (IP)",
+    "distribution": "Distribution",
+    "reseller": "Reseller",
+    "spa_shares": "SPA (Shares)",
+    "employment": "Employment",
+    "loan": "Loan",
+    "lease": "Lease",
+    "saas_subscription": "SaaS Subscription",
+    "consultancy": "Consultancy",
+    "settlement": "Settlement",
+    "shareholders": "Shareholders",
+    "joint_venture": "Joint Venture",
+    "framework_calloff": "Framework Call-Off",
+    "manufacturing": "Manufacturing",
+    "maintenance_support": "Maintenance & Support",
+}
+
+
+def slug_to_display(slug: str) -> str:
+    return DISPLAY_MAP.get(slug, slug.replace("_", " ").title())
+
+
+def _match_keywords(haystack: str, keywords: List[str]) -> Tuple[int, List[str]]:
+    hits: List[str] = []
+    cnt = 0
+    for kw in keywords:
+        if kw and kw.lower() in haystack:
+            cnt += 1
+            hits.append(kw)
+    return cnt, hits
+
+
+def guess_doc_type(text: str) -> Tuple[str, float, List[str], Dict[str, float]]:
+    """Return (slug, confidence, evidence_strings, score_by_type)."""
+    t = text or ""
+    # normalize text
+    lowered = t.lower()
+    lines = [ln.strip() for ln in t.splitlines() if ln.strip()]
+    title = " ".join(lines[:2]).lower()
+
+    score_raw: Dict[str, float] = {}
+    evidences: Dict[str, List[str]] = {}
+
+    for slug, cfg in DOC_TYPE_PATTERNS.items():
+        title_hits, title_ev = _match_keywords(title, cfg.get("title_keywords", []))
+        body_hits, body_ev = _match_keywords(lowered, cfg.get("body_keywords", []))
+        boost = 0.0
+        boost_ev: List[str] = []
+        for phrase, weight in cfg.get("boost_phrases", {}).items():
+            if phrase.lower() in lowered:
+                boost += float(weight)
+                boost_ev.append(phrase)
+        score = W_TITLE * title_hits + W_BODY * (body_hits + boost)
+        must_any = cfg.get("must_have_any")
+        if must_any and not any(m.lower() in lowered for m in must_any):
+            score = 0.0
+        negative = cfg.get("negative")
+        if negative and any(n.lower() in lowered for n in negative):
+            score = 0.0
+        score_raw[slug] = score
+        evidences[slug] = title_ev + body_ev + boost_ev
+
+    max_score = max(score_raw.values()) if score_raw else 0.0
+    score_by_type: Dict[str, float] = {}
+    for slug, sc in score_raw.items():
+        score_by_type[slug] = sc / max_score if max_score else 0.0
+    best_slug = max(score_raw, key=score_raw.get) if score_raw else "unknown"
+    confidence = score_by_type.get(best_slug, 0.0)
+    evidence = evidences.get(best_slug, [])
+    return best_slug, round(confidence, 2), evidence, score_by_type
+

--- a/contract_review_app/engine/patterns_doctype.py
+++ b/contract_review_app/engine/patterns_doctype.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+"""Document type patterns for heuristic classification.
+
+Each key maps to pattern data:
+{
+  "title_keywords": [...],
+  "body_keywords": [...],
+  "must_have_any": [...],           # optional
+  "negative": [...],                # optional
+  "boost_phrases": {phrase: weight} # optional
+}
+"""
+
+from typing import Any, Dict, List
+
+DOC_TYPE_PATTERNS: Dict[str, Dict[str, Any]] = {
+    "nda": {
+        "title_keywords": ["non-disclosure", "confidentiality"],
+        "body_keywords": [
+            "confidential information",
+            "disclosing party",
+            "receiving party",
+            "permitted purpose",
+            "non-disclosure",
+            "term of confidentiality",
+            "return or destroy",
+        ],
+    },
+    "msa_services": {
+        "title_keywords": ["master services", "services agreement"],
+        "body_keywords": [
+            "services",
+            "statement of work",
+            "sow",
+            "service levels",
+            "sla",
+            "change control",
+            "acceptance criteria",
+        ],
+    },
+    "supply_of_goods": {
+        "title_keywords": ["supply agreement", "supply of goods", "supply contract"],
+        "body_keywords": [
+            "delivery",
+            "risk and title",
+            "incoterms",
+            "specifications",
+            "defects",
+            "returns",
+        ],
+    },
+    "dpa_uk_gdpr": {
+        "title_keywords": ["data processing agreement", "dpa"],
+        "body_keywords": [
+            "controller",
+            "processor",
+            "uk gdpr",
+            "data subject",
+            "sub-processor",
+            "international transfers",
+            "annex",
+        ],
+    },
+    "license_ip": {
+        "title_keywords": ["licence", "license"],
+        "body_keywords": [
+            "grant of licence",
+            "licensor",
+            "licensee",
+            "royalty",
+            "territory",
+            "ip ownership",
+        ],
+    },
+    "distribution": {
+        "title_keywords": ["distribution"],
+        "body_keywords": [
+            "distributor",
+            "exclusive",
+            "non-exclusive",
+            "territory",
+            "price list",
+            "sell",
+        ],
+    },
+    "reseller": {
+        "title_keywords": ["reseller"],
+        "body_keywords": [
+            "reseller",
+            "purchase",
+            "sell",
+            "price list",
+            "territory",
+        ],
+    },
+    "spa_shares": {
+        "title_keywords": ["share purchase", "share sale"],
+        "body_keywords": [
+            "seller",
+            "buyer",
+            "sale of the entire issued share capital",
+            "completion",
+            "disclosure letter",
+            "warranties",
+            "indemnities",
+        ],
+    },
+    "employment": {
+        "title_keywords": ["employment"],
+        "body_keywords": [
+            "employer",
+            "employee",
+            "salary",
+            "probationary period",
+            "notice period",
+            "holiday entitlement",
+        ],
+    },
+    "loan": {
+        "title_keywords": ["loan", "facility"],
+        "body_keywords": [
+            "borrower",
+            "lender",
+            "principal",
+            "interest rate",
+            "repayment",
+            "events of default",
+            "security",
+        ],
+    },
+    "lease": {
+        "title_keywords": ["lease", "tenancy"],
+        "body_keywords": [
+            "landlord",
+            "tenant",
+            "premises",
+            "rent",
+            "term",
+            "repair",
+            "insurance",
+        ],
+    },
+    "saas_subscription": {
+        "title_keywords": ["saas", "subscription", "cloud services"],
+        "body_keywords": [
+            "subscription",
+            "cloud service",
+            "availability",
+            "uptime",
+            "support",
+            "user licence",
+            "user license",
+        ],
+    },
+    "consultancy": {
+        "title_keywords": ["consultancy", "consulting"],
+        "body_keywords": [
+            "consultant",
+            "deliverables",
+            "fees",
+            "day rate",
+            "independent contractor",
+            "ip assignment",
+        ],
+    },
+    "settlement": {
+        "title_keywords": ["settlement"],
+        "body_keywords": [
+            "full and final settlement",
+            "waiver",
+            "release",
+            "claims",
+            "without admission",
+        ],
+    },
+    "shareholders": {
+        "title_keywords": ["shareholders", "shareholder"],
+        "body_keywords": [
+            "reserved matters",
+            "board",
+            "drag",
+            "tag",
+            "dividends",
+        ],
+    },
+    "joint_venture": {
+        "title_keywords": ["joint venture"],
+        "body_keywords": [
+            "jv",
+            "contribution of assets",
+            "governance",
+            "distribution of profits",
+        ],
+    },
+    "framework_calloff": {
+        "title_keywords": ["framework"],
+        "body_keywords": [
+            "call-off",
+            "order procedure",
+            "mini-competition",
+        ],
+    },
+    "manufacturing": {
+        "title_keywords": ["manufacturing"],
+        "body_keywords": [
+            "manufacture",
+            "supply",
+            "quality control",
+            "specifications",
+            "tooling",
+        ],
+    },
+    "maintenance_support": {
+        "title_keywords": ["maintenance", "support"],
+        "body_keywords": [
+            "support",
+            "maintenance",
+            "response time",
+            "restore times",
+            "p1",
+            "p2",
+            "updates",
+            "patches",
+        ],
+    },
+}
+

--- a/contract_review_app/tests/api/test_api_analyze_type.py
+++ b/contract_review_app/tests/api/test_api_analyze_type.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_api_analyze_returns_type():
+    text = (
+        "NON-DISCLOSURE AGREEMENT\n"
+        "Confidential Information shall be returned or destroyed by the Receiving Party after the Permitted Purpose."
+    )
+    resp = client.post("/api/analyze", json={"text": text})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["results"]["summary"]["type"] == "NDA"
+    assert data["results"]["summary"]["type_confidence"] >= 0.6

--- a/contract_review_app/tests/api/test_api_summary_type.py
+++ b/contract_review_app/tests/api/test_api_summary_type.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_api_summary_returns_type():
+    text = (
+        "NON-DISCLOSURE AGREEMENT\n"
+        "Confidential Information may be used only for the Permitted Purpose by the Disclosing Party and the Receiving Party."
+    )
+    resp = client.post("/api/summary", json={"text": text})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["summary"]["type"] == "NDA"
+    assert body["summary"]["type_confidence"] >= 0.6

--- a/contract_review_app/tests/summary/test_doctype_classifier.py
+++ b/contract_review_app/tests/summary/test_doctype_classifier.py
@@ -1,0 +1,54 @@
+import pytest
+
+from contract_review_app.analysis.extract_summary import extract_document_snapshot
+
+CASES = [
+    (
+        "NDA",
+        """NON-DISCLOSURE AGREEMENT\nConfidential Information shall be used only for the Permitted Purpose by the Disclosing Party and the Receiving Party and must be returned or destroyed.""",
+    ),
+    (
+        "MSA (Services)",
+        """MASTER SERVICES AGREEMENT\nServices shall be performed under each Statement of Work and subject to the Service Levels and Change Control with Acceptance criteria.""",
+    ),
+    (
+        "Supply of Goods",
+        """SUPPLY OF GOODS AGREEMENT\nDelivery terms and risk and title are defined with Incoterms and Specifications including defects and returns.""",
+    ),
+    (
+        "DPA",
+        """DATA PROCESSING AGREEMENT\nThe Controller and Processor comply with UK GDPR, protect Data Subject rights and manage sub-processor international transfers as in Annex.""",
+    ),
+    (
+        "License (IP)",
+        """IP LICENCE AGREEMENT\nThe Licensor grants the Licensee a royalty bearing licence with defined Territory and IP ownership retained.""",
+    ),
+    (
+        "SPA (Shares)",
+        """SHARE PURCHASE AGREEMENT\nSeller and Buyer agree to the sale of the entire issued share capital with Completion, Disclosure Letter and Warranties and indemnities.""",
+    ),
+    (
+        "Employment",
+        """EMPLOYMENT AGREEMENT\nThe Employer engages the Employee with salary, probationary period, notice period and holiday entitlement.""",
+    ),
+    (
+        "Loan",
+        """LOAN AGREEMENT\nThe Borrower receives the principal with an interest rate and repayment terms; events of default and security apply.""",
+    ),
+    (
+        "Lease",
+        """LEASE AGREEMENT\nThe Landlord lets the premises to the Tenant for a term with rent and repair and insurance obligations.""",
+    ),
+    (
+        "SaaS Subscription",
+        """SAAS SUBSCRIPTION AGREEMENT\nSubscription to the cloud service includes availability uptime commitments, support and user licences.""",
+    ),
+]
+
+
+@pytest.mark.parametrize("expected,text", CASES)
+def test_doctype_classifier(expected: str, text: str):
+    snap = extract_document_snapshot(text)
+    assert snap.type == expected
+    assert snap.type_confidence >= 0.6
+    assert len(snap.hints) >= 1


### PR DESCRIPTION
## Summary
- add patterns and classifier to detect contract type and evidence
- include detected document type and confidence in summary and analyze endpoints
- add subject extraction heuristic and unit tests for document type detection

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb64c763483258bd12fda9b6e29b9