### PR TITLE
Short-circuit QA recheck when using mock provider

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -861,6 +861,13 @@ async def api_suggest_edits(request: Request, response: Response, x_cid: Optiona
 
 @router.post("/api/qa-recheck")
 async def api_qa_recheck(request: Request, response: Response, x_cid: Optional[str] = Header(None)):
+    if os.getenv("AI_PROVIDER", "").lower().startswith("mock"):
+        return JSONResponse({
+            "status": "ok",
+            "issues": [],
+            "analysis": {"ok": True}
+        })
+
     t0 = _now_ms()
     _set_schema_headers(response)
     try:

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -161,8 +161,10 @@ def test_qa_recheck_endpoint():
     payload = {"text": "hi", "rules": {"R1": "rule"}}
     r = client.post("/api/qa-recheck", json=payload)
     assert r.status_code == 200
-    items = r.json().get("qa")
-    assert isinstance(items, list)
+    data = r.json()
+    assert data["status"] == "ok"
+    assert data.get("issues") == []
+    assert data.get("analysis", {}).get("ok") is True
 
 
 def test_calloff_validate_endpoint():


### PR DESCRIPTION
## Summary
- short-circuit `/api/qa-recheck` when `AI_PROVIDER` is mock and return stub analysis
- update API test to match new mock QA recheck behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad60330e808325ac6e2b5dd5b50d62