### PR TITLE
Add document type and QA mock API tests

### DIFF
--- a/tests/api/test_qa_recheck_mock.py
+++ b/tests/api/test_qa_recheck_mock.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+
+def _create_client():
+    modules = ['contract_review_app.api',
+        
+        'contract_review_app.api.app',
+        'contract_review_app.api.orchestrator',
+        'contract_review_app.gpt.service',
+        'contract_review_app.gpt.clients.mock_client',
+    ]
+    for m in modules:
+        sys.modules.pop(m, None)
+    os.environ.setdefault('AI_PROVIDER', 'mock')
+    from contract_review_app.api import app as app_module
+    importlib.reload(app_module)
+    client = TestClient(app_module.app)
+    return client, modules
+
+
+@pytest.fixture()
+def client():
+    client, modules = _create_client()
+    try:
+        yield client
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+def test_qa_recheck_mock_returns_ok(client):
+    payload = {'text': 'hello', 'rules': {}}
+    resp = client.post('/api/qa-recheck', json=payload)
+    assert resp.status_code == 200
+    assert resp.json()['status'] == 'ok'

--- a/tests/test_doc_type_api.py
+++ b/tests/test_doc_type_api.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+
+def _create_client():
+    modules = ['contract_review_app.api',
+        
+        'contract_review_app.api.app',
+        'contract_review_app.api.orchestrator',
+        'contract_review_app.gpt.service',
+        'contract_review_app.gpt.clients.mock_client',
+    ]
+    for m in modules:
+        sys.modules.pop(m, None)
+    os.environ.setdefault('AI_PROVIDER', 'mock')
+    from contract_review_app.api import app as app_module
+    importlib.reload(app_module)
+    client = TestClient(app_module.app)
+    return client, modules
+
+
+@pytest.fixture()
+def client():
+    client, modules = _create_client()
+    try:
+        yield client
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+TEXT = (
+    'NON-DISCLOSURE AGREEMENT\n'
+    'Confidential Information may be used only for the Permitted Purpose.'
+)
+
+
+def test_summary_returns_doc_type_and_confidence(client):
+    resp = client.post('/api/summary', json={'text': TEXT})
+    assert resp.status_code == 200
+    summary = resp.json()['summary']
+    assert summary['type'] == 'NDA'
+    assert isinstance(summary.get('type_confidence'), float)
+    assert summary['type_confidence'] >= 0.0
+
+
+def test_analyze_returns_type_confidence_and_candidates(client):
+    resp = client.post('/api/analyze', json={'text': TEXT})
+    assert resp.status_code == 200
+    summary = resp.json()['results']['summary']
+    assert summary['type'] == 'NDA'
+    assert isinstance(summary.get('type_confidence'), float)
+    cand = summary.get('debug', {}).get('doctype_top')
+    assert isinstance(cand, list) and cand and all('type' in c and 'score' in c for c in cand)
+    assert cand[0]['type'] == 'NDA'

--- a/tests/test_doc_type_uk_samples.py
+++ b/tests/test_doc_type_uk_samples.py
@@ -1,0 +1,24 @@
+import pytest
+from contract_review_app.analysis.extract_summary import extract_document_snapshot
+
+CASES = [
+    (
+        "DPA",
+        "Background:\nData Processing Agreement for UK GDPR compliance.\nThe Processor shall assist the Controller.",
+    ),
+    (
+        "Consultancy",
+        "Scope:\nThis Consultancy Agreement outlines services for the Client by the Consultant.",
+    ),
+    (
+        "Agency",
+        "Purpose:\nAgency Agreement appointing an Agent to solicit orders in the UK for the Principal.",
+    ),
+]
+
+
+@pytest.mark.parametrize("expected,text", CASES)
+def test_doc_type_uk_samples(expected: str, text: str):
+    snap = extract_document_snapshot(text)
+    assert snap.type == expected
+    assert snap.type_confidence >= 0.6


### PR DESCRIPTION
## Summary
- test `/api/summary` and `/api/analyze` document type responses and candidate metadata
- add UK-centric document type samples for subject-based classification
- ensure mock QA recheck endpoint returns ok status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad60361d14832589797611c46ce7bc