### PR TITLE
Add LLM environment diagnostics

### DIFF
--- a/tests/codex/test_doctor_smoke.py
+++ b/tests/codex/test_doctor_smoke.py
@@ -12,6 +12,9 @@ def test_doctor_generates_report(tmp_path, monkeypatch):
     assert rc == 0
     data = json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
     assert "backend" in data and "rules" in data and "env" in data
+    assert "llm" in data
+    for key in ["provider", "model", "timeout_s", "mode_is_mock"]:
+        assert key in data["llm"], f"missing llm.{key}"
     eps = {(e.get("method"), e.get("path")) for e in data["backend"].get("endpoints", [])}
     assert ("POST", "/api/analyze") in eps
     assert data["rules"]["python"]["count"] >= 8

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -100,6 +100,27 @@ def gather_backend() -> Dict[str, Any]:
 def gather_llm(backend: Dict[str, Any]) -> Dict[str, Any]:
     info: Dict[str, Any] = {}
     try:
+        provider = os.getenv("LLM_PROVIDER", "")
+        model = os.getenv("LLM_MODEL", "")
+        timeout_raw = os.getenv("LLM_TIMEOUT", "")
+        try:
+            timeout_s = int(timeout_raw) if timeout_raw else 5
+        except ValueError:
+            timeout_s = 5
+        mode_is_mock = (not provider and not model) or provider == "mock" or model == "mock"
+        if not provider and not model:
+            provider = "mock"
+            model = "mock"
+            timeout_s = 5
+        info.update(
+            {
+                "provider": provider,
+                "model": model,
+                "timeout_s": timeout_s,
+                "mode_is_mock": mode_is_mock,
+            }
+        )
+
         clients_dir = ROOT / "contract_review_app" / "gpt" / "clients"
         providers: List[str] = []
         if clients_dir.exists():


### PR DESCRIPTION
## Summary
- record LLM provider, model, timeout and mock mode in doctor report
- include default mock values when env vars are absent
- expand doctor smoke test to verify new LLM env section

## Testing
- `pytest tests/codex -q`


------
https://chatgpt.com/codex/tasks/task_e_68adbdb102888325ab9ad98811820aa4