### PR TITLE
doctor: check service exports and API hook

### DIFF
--- a/tests/codex/test_app_analyze_hook.py
+++ b/tests/codex/test_app_analyze_hook.py
@@ -1,5 +1,20 @@
+import json, subprocess, sys
+
+
+def _run_doctor(tmp_path, monkeypatch):
+    out_dir = tmp_path / "diag"
+    out_dir.mkdir()
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("LLM_MODEL", "mock")
+    monkeypatch.setenv("LLM_TIMEOUT", "5")
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(out_dir), "--json"]
+    assert subprocess.call(cmd) == 0
+    return json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+
+
 def test_app_has_analyze_hook(monkeypatch):
     import contract_review_app.api.app as app_mod
+
     assert hasattr(app_mod, "_analyze_document")
 
     def fake(text: str):
@@ -9,4 +24,10 @@ def test_app_has_analyze_hook(monkeypatch):
 
     # перевіримо, що ендпоїнт існує у маршрутах
     from contract_review_app.api.app import app
+
     assert any(getattr(r, "path", None) == "/api/analyze" for r in app.routes)
+
+
+def test_doctor_reports_analyze_hook(tmp_path, monkeypatch):
+    data = _run_doctor(tmp_path, monkeypatch)
+    assert data["api"]["has__analyze_document"] is True

--- a/tests/codex/test_service_exports.py
+++ b/tests/codex/test_service_exports.py
@@ -1,4 +1,28 @@
+import json, subprocess, sys
+
+
+def _run_doctor(tmp_path, monkeypatch):
+    out_dir = tmp_path / "diag"
+    out_dir.mkdir()
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("LLM_MODEL", "mock")
+    monkeypatch.setenv("LLM_TIMEOUT", "5")
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(out_dir), "--json"]
+    assert subprocess.call(cmd) == 0
+    return json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+
+
 def test_exceptions_available_both_places():
     from contract_review_app.gpt.interfaces import ProviderTimeoutError as A
     from contract_review_app.gpt.service import ProviderTimeoutError as B
+
     assert A is B
+
+
+def test_doctor_reports_service_exports(tmp_path, monkeypatch):
+    data = _run_doctor(tmp_path, monkeypatch)
+    exports = data["service"]["exports"]
+    assert exports["LLMService"]
+    assert exports["load_llm_config"]
+    assert exports["ProviderTimeoutError"]
+    assert exports["ProviderConfigError"]

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -115,6 +115,34 @@ def gather_llm(backend: Dict[str, Any]) -> Dict[str, Any]:
     return info
 
 
+def gather_service() -> Dict[str, Any]:
+    info: Dict[str, Any] = {"exports": {}}
+    try:
+        import contract_review_app.gpt.service as svc  # type: ignore
+
+        names = [
+            "LLMService",
+            "load_llm_config",
+            "ProviderTimeoutError",
+            "ProviderConfigError",
+        ]
+        info["exports"] = {name: hasattr(svc, name) for name in names}
+    except Exception:
+        info["error"] = traceback.format_exc()
+    return info
+
+
+def gather_api() -> Dict[str, Any]:
+    info: Dict[str, Any] = {}
+    try:
+        import contract_review_app.api.app as app_mod  # type: ignore
+
+        info["has__analyze_document"] = hasattr(app_mod, "_analyze_document")
+    except Exception:
+        info["error"] = traceback.format_exc()
+    return info
+
+
 def gather_rules() -> Dict[str, Any]:
     info: Dict[str, Any] = {
         "python": {"count": 0, "names": []},
@@ -182,6 +210,8 @@ def generate_report() -> Dict[str, Any]:
     backend = gather_backend()
     data["backend"] = backend
     data["llm"] = gather_llm(backend)
+    data["service"] = gather_service()
+    data["api"] = gather_api()
     data["rules"] = gather_rules()
     data["addin"] = gather_addin()
     data["inventory"] = gather_inventory()


### PR DESCRIPTION
## Summary
- capture gpt.service exports and API _analyze_document hook in doctor diagnostics
- test doctor output for service exports and analyze hook presence

## Testing
- `pytest tests/codex`


------
https://chatgpt.com/codex/tasks/task_e_68adbdbb1b688325bff1141a37f002a6