### PR TITLE
doctor: report registry contents

### DIFF
--- a/tests/codex/test_doctor_smoke.py
+++ b/tests/codex/test_doctor_smoke.py
@@ -14,4 +14,5 @@ def test_doctor_generates_report(tmp_path, monkeypatch):
     assert "backend" in data and "rules" in data and "env" in data
     eps = {(e.get("method"), e.get("path")) for e in data["backend"].get("endpoints", [])}
     assert ("POST", "/api/analyze") in eps
-    assert data["rules"]["python"]["count"] >= 8
+    assert data["rules"]["python"]["count"] >= 15
+    assert len(data["rules"]["python"]["samples"]) <= 8

--- a/tests/codex/test_registry_imports.py
+++ b/tests/codex/test_registry_imports.py
@@ -15,5 +15,14 @@ def test_registry_is_exposed_and_aliases():
         "oilgas_master_agreement",
     ]:
         assert k in registry
-    # аліаси працюють
-    assert normalize_clause_type("NDA") == "confidentiality"
+    # аліаси присутні як ключі та нормалізуються
+    for alias, target in [
+        ("nda", "confidentiality"),
+        ("dispute_resolution", "jurisdiction"),
+        ("force_majeur", "force_majeure"),
+        ("ogma", "oilgas_master_agreement"),
+    ]:
+        assert alias in registry
+        assert normalize_clause_type(alias.upper()) == target
+
+    assert len(registry) >= 15

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -116,32 +116,29 @@ def gather_llm(backend: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def gather_rules() -> Dict[str, Any]:
+    """Collect statistics about available rule handlers and policy packs."""
     info: Dict[str, Any] = {
-        "python": {"count": 0, "names": []},
-        "aliases_present": {},
+        "python": {"count": 0, "samples": []},
+        "yaml": {"count": 0, "samples": []},
     }
     try:
-        rules_dir = ROOT / "contract_review_app" / "legal_rules" / "rules"
-        names = [p.stem for p in rules_dir.glob("*.py") if p.name != "__init__.py"]
-        info["python"] = {"count": len(names), "names": sorted(names)}
-        from contract_review_app.legal_rules import registry as rules_registry  # type: ignore
+        # The registry re-export includes both canonical rule names and aliases.
+        from contract_review_app.legal_rules.rules import registry  # type: ignore
 
-        aliases_to_check = [
-            "dispute_resolution",
-            "indemnification",
-            "nda",
-            "force_majeur",
-            "ogma",
-        ]
-        for alias in aliases_to_check:
-            try:
-                info["aliases_present"][alias] = rules_registry.normalize_clause_type(alias)
-            except Exception:
-                info["aliases_present"][alias] = None
+        rule_keys = sorted(registry.keys())
+        info["python"] = {"count": len(rule_keys), "samples": rule_keys[:8]}
+
         yaml_dir = ROOT / "contract_review_app" / "legal_rules" / "policy_packs"
-        yaml_files = list(yaml_dir.glob("**/*.yml")) + list(yaml_dir.glob("**/*.yaml"))
-        if yaml_files:
-            info["yaml"] = [str(p.relative_to(ROOT)) for p in yaml_files]
+        if yaml_dir.exists():
+            yaml_files = [
+                p.relative_to(yaml_dir).as_posix()
+                for p in yaml_dir.rglob("*.yml")
+            ] + [
+                p.relative_to(yaml_dir).as_posix()
+                for p in yaml_dir.rglob("*.yaml")
+            ]
+            yaml_files = sorted({*yaml_files})
+            info["yaml"] = {"count": len(yaml_files), "samples": yaml_files[:8]}
     except Exception:
         info["error"] = traceback.format_exc()
     return info


### PR DESCRIPTION
## Summary
- expose real rule count and sample keys from legal_rules registry in doctor report
- verify registry exposes aliases and update doctor test for registry count

## Testing
- `python -m pytest tests/codex -q`

------
https://chatgpt.com/codex/tasks/task_e_68adbdc2dba08325a4dbc41f5566afea