### PR TITLE
Add repo hygiene diagnostics

### DIFF
--- a/tests/codex/test_doctor_repo_hygiene.py
+++ b/tests/codex/test_doctor_repo_hygiene.py
@@ -1,0 +1,19 @@
+import json
+import subprocess
+import sys
+
+
+def test_doctor_repo_hygiene(tmp_path, monkeypatch):
+    out_dir = tmp_path / "diag"
+    out_dir.mkdir()
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("LLM_MODEL", "mock")
+    monkeypatch.setenv("LLM_TIMEOUT", "5")
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(out_dir), "--json"]
+    rc = subprocess.call(cmd)
+    assert rc == 0
+    data = json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+    assert "repo" in data
+    repo = data["repo"]
+    assert "tracked_pyc" in repo
+    assert "suggestions" in repo

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -175,6 +175,21 @@ def gather_inventory() -> Dict[str, Any]:
     return {"files": counts, "ignored_dirs": sorted(IGNORED_DIRS)}
 
 
+def gather_repo() -> Dict[str, Any]:
+    info: Dict[str, Any] = {}
+    try:
+        files = _run_cmd(["git", "ls-files"]).splitlines()
+        tracked_pyc = [f for f in files if f.endswith(".pyc")]
+        info["tracked_pyc"] = len(tracked_pyc)
+        info["suggestions"] = [
+            "Add __pycache__/ and *.pyc to .gitignore",
+            "To purge cached: git rm -r --cached **/__pycache__ *.pyc && git commit -m 'purge pyc'",
+        ]
+    except Exception:
+        info["error"] = traceback.format_exc()
+    return info
+
+
 def generate_report() -> Dict[str, Any]:
     data: Dict[str, Any] = {}
     data["env"] = gather_env()
@@ -185,6 +200,7 @@ def generate_report() -> Dict[str, Any]:
     data["rules"] = gather_rules()
     data["addin"] = gather_addin()
     data["inventory"] = gather_inventory()
+    data["repo"] = gather_repo()
     return data
 
 


### PR DESCRIPTION
## Summary
- count tracked `.pyc` files and recommend cleanup in doctor report
- add tests for repo hygiene report section

## Testing
- `pytest tests/codex/test_doctor_repo_hygiene.py tests/codex/test_doctor_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adbde71f008325acd210eab6e7d115