### PR TITLE
feat: validate word add-in in doctor

### DIFF
--- a/tests/codex/test_doctor_addin.py
+++ b/tests/codex/test_doctor_addin.py
@@ -1,0 +1,29 @@
+import json
+import subprocess
+import sys
+
+
+def test_doctor_addin_section(tmp_path):
+    out_dir = tmp_path / "diag"
+    out_dir.mkdir()
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(out_dir), "--json"]
+    rc = subprocess.call(cmd)
+    assert rc == 0
+    data = json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+    addin = data.get("addin", {})
+    assert "manifest" in addin and "bundle" in addin
+
+    manifest = addin["manifest"]
+    assert "exists" in manifest
+    if manifest["exists"]:
+        assert manifest.get("id")
+        assert manifest.get("version")
+        assert manifest.get("source")
+        assert manifest.get("permissions")
+
+    bundle = addin["bundle"]
+    assert "exists" in bundle
+    if bundle["exists"]:
+        assert isinstance(bundle.get("size"), int)
+        assert bundle.get("size", 0) > 0
+        assert isinstance(bundle.get("mtime"), str) and bundle.get("mtime")


### PR DESCRIPTION
## Summary
- extend `doctor` to parse Word add-in manifest and bundle metadata
- add unit test covering new add-in validation output

## Testing
- `python -m pytest tests/codex/test_doctor_addin.py::test_doctor_addin_section -q`
- `python -m pytest -q` *(fails: assert (True and []))*

------
https://chatgpt.com/codex/tasks/task_e_68adbdf133988325aea84e1dc5ad72db