### PR TITLE
test: add doctor json section snapshot

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,16 @@
+import contract_review_app.api.app as app_mod
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def patch_analyze(monkeypatch):
+    def fake(text: str):
+        return {
+            "analysis": {"issues": ["dummy"]},
+            "results": {},
+            "clauses": [],
+            "document": {"text": text},
+        }
+
+    monkeypatch.setattr(app_mod, "_analyze_document", fake, raising=True)
+    yield

--- a/tests/codex/doctor_sections_snapshot.json
+++ b/tests/codex/doctor_sections_snapshot.json
@@ -1,0 +1,27 @@
+{
+  "git": {
+    "branch": "str",
+    "head": "str",
+    "status": "str"
+  },
+  "llm": {
+    "has_draft_endpoint": "bool",
+    "providers_detected": [
+      "str"
+    ]
+  },
+  "addin": {
+    "cert": "str",
+    "manifest": "str",
+    "taskpane": "str"
+  },
+  "inventory": {
+    "files": {
+      "js": "int",
+      "py": "int"
+    },
+    "ignored_dirs": [
+      "str"
+    ]
+  }
+}

--- a/tests/codex/test_doctor_snapshot.py
+++ b/tests/codex/test_doctor_snapshot.py
@@ -1,0 +1,26 @@
+import json, subprocess, sys
+from pathlib import Path
+
+
+def _shape(obj):
+    if isinstance(obj, dict):
+        return {k: _shape(v) for k, v in sorted(obj.items())}
+    if isinstance(obj, list):
+        return [_shape(obj[0])] if obj else []
+    return type(obj).__name__
+
+
+def test_doctor_sections_shape(tmp_path, monkeypatch):
+    out_dir = tmp_path / "diag"
+    out_dir.mkdir()
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("LLM_MODEL", "mock")
+    monkeypatch.setenv("LLM_TIMEOUT", "5")
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(out_dir), "--json"]
+    rc = subprocess.call(cmd)
+    assert rc == 0
+    data = json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+    sections = {name: _shape(data[name]) for name in ["git", "llm", "addin", "inventory"]}
+    snapshot_path = Path(__file__).with_name("doctor_sections_snapshot.json")
+    expected = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert sections == expected


### PR DESCRIPTION
## Summary
- add snapshot test to guard doctor JSON sections structure
- provide snapshot fixture for git/llm/addin/inventory sections
- patch analyze hook in API tests with dummy issues

## Testing
- `pytest tests/codex tests/api -q`

------
https://chatgpt.com/codex/tasks/task_e_68adbe27c9d88325998386ad24bfb977