### PR TITLE
feat: enable doctor autosmoke and env mirroring

### DIFF
--- a/tests/codex/doctor_sections_snapshot.json
+++ b/tests/codex/doctor_sections_snapshot.json
@@ -6,14 +6,27 @@
   },
   "llm": {
     "has_draft_endpoint": "bool",
+    "model": "str",
+    "node_is_mock": "bool",
+    "provider": "str",
     "providers_detected": [
       "str"
-    ]
+    ],
+    "timeout_s": "int"
   },
   "addin": {
-    "cert": "str",
-    "manifest": "str",
-    "taskpane": "str"
+    "bundle": {
+      "exists": "bool",
+      "mtime": "str",
+      "size": "int"
+    },
+    "manifest": {
+      "exists": "bool",
+      "id": "str",
+      "permissions": "str",
+      "source": "str",
+      "version": "str"
+    }
   },
   "inventory": {
     "files": {

--- a/tests/codex/test_doctor_autosmoke_and_env.py
+++ b/tests/codex/test_doctor_autosmoke_and_env.py
@@ -1,0 +1,52 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_doctor(tmp_path):
+    out = tmp_path / "diag"
+    out.mkdir()
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    env["LLM_PROVIDER"] = "mock"
+    env["LLM_MODEL"] = "mock"
+    env["LLM_TIMEOUT"] = "5"
+    # smoke за замовчуванням вмикається, нічого не виставляємо
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(out), "--json"]
+    rc = subprocess.call(cmd, cwd=str(ROOT), env=env)
+    assert rc == 0
+    data = json.loads((out / "analysis.json").read_text(encoding="utf-8"))
+    return data
+
+
+@pytest.mark.skipif(os.getenv("DOCTOR_SMOKE_ACTIVE") == "1", reason="avoid recursion")
+def test_env_has_llm_keys_and_smoke_runs(tmp_path):
+    d = _run_doctor(tmp_path)
+
+    # LLM ключі продубльовані в env (бек-компат з існуючими тестами)
+    for k in ("provider", "model", "timeout_s", "node_is_mock"):
+        assert k in d["env"], f"missing {k} in env"
+    assert d["env"]["provider"] == "mock"
+    assert d["env"]["model"] == "mock"
+
+    # smoke за замовчуванням має бути enabled, без фейлів
+    smoke = d.get("smoke", {})
+    assert smoke.get("enabled") is True
+    assert smoke.get("failed", 0) == 0
+
+    # якість: ruff зібраний (будь-яке не-негативне число)
+    quality = d.get("quality", {})
+    ruff = quality.get("ruff", {})
+    assert ruff.get("status") == "ok"
+    assert isinstance(ruff.get("issues_total"), int)
+    assert ruff["issues_total"] >= 0
+
+    # runtime health перевірка
+    runtime = d.get("runtime_checks", {})
+    assert runtime.get("health", {}).get("status") == 200
+    assert runtime.get("openapi", {}).get("status") == 200


### PR DESCRIPTION
## Summary
- run ruff via statistics and conditionally run mypy
- enable doctor smoke tests by default with recursion guard
- mirror LLM config into env for backward compatibility
- add regression tests for env keys and autosmoke

## Testing
- `pre-commit run --files tools/doctor.py tests/codex/test_doctor_smoke.py tests/codex/test_doctor_autosmoke_and_env.py tests/codex/doctor_sections_snapshot.json`
- `pytest tests/codex -q`
- `python tools/doctor.py --out reports/diag_20250826_211602 --json`

------
https://chatgpt.com/codex/tasks/task_e_68ae215fb2b88325a17a7e24bebaa8e8