### PR TITLE
Add language and script segmentation utilities

### DIFF
--- a/contract_review_app/intake/langseg.py
+++ b/contract_review_app/intake/langseg.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+_LATIN_RANGES = [
+    (0x0080, 0x00FF),
+    (0x0100, 0x017F),
+    (0x0180, 0x024F),
+    (0x1E00, 0x1EFF),
+]
+_CYRILLIC_RANGES = [
+    (0x0400, 0x04FF),
+    (0x0500, 0x052F),
+    (0x2DE0, 0x2DFF),
+    (0xA640, 0xA69F),
+]
+_GREEK_RANGES = [
+    (0x0370, 0x03FF),
+    (0x1F00, 0x1FFF),
+]
+_ARABIC_RANGES = [
+    (0x0600, 0x06FF),
+    (0x0750, 0x077F),
+    (0x08A0, 0x08FF),
+]
+_HEBREW_RANGES = [(0x0590, 0x05FF)]
+
+
+def _in_ranges(cp: int, ranges: List[tuple[int, int]]) -> bool:
+    return any(start <= cp <= end for start, end in ranges)
+
+
+def detect_script(ch: str) -> str:
+    """Return script label for a single character using Unicode ranges.
+    Returns: one of {"Latin","Cyrillic","Greek","Arabic","Hebrew","Common"}.
+    """
+
+    if not ch:
+        return "Common"
+
+    cp = ord(ch)
+
+    if ch.isalpha():
+        if cp <= 0x007F:
+            return "Latin"
+        if _in_ranges(cp, _LATIN_RANGES):
+            return "Latin"
+        if _in_ranges(cp, _CYRILLIC_RANGES):
+            return "Cyrillic"
+        if _in_ranges(cp, _GREEK_RANGES):
+            return "Greek"
+        if _in_ranges(cp, _ARABIC_RANGES):
+            return "Arabic"
+        if _in_ranges(cp, _HEBREW_RANGES):
+            return "Hebrew"
+    return "Common"
+
+
+def script_to_lang(script: str) -> str:
+    """Map script to lightweight language tag. Deterministic and total mapping."""
+
+    mapping = {
+        "Latin": "en",
+        "Cyrillic": "uk",
+        "Greek": "el",
+        "Arabic": "ar",
+        "Hebrew": "he",
+        "Common": "und",
+    }
+    return mapping[script]
+
+
+def segment_lang_script(text: str) -> List[Dict[str, object]]:
+    """Return list of segments [{start:int, end:int, lang:str, script:str}] for the whole text.
+    - start inclusive, end exclusive
+    - segments are contiguous and non-overlapping
+    - merges adjacent runs with same (lang, script)
+    - O(n) single pass
+    """
+
+    if not text:
+        return []
+
+    segments: List[Dict[str, object]] = []
+    start = 0
+    current_script = detect_script(text[0])
+    current_lang = script_to_lang(current_script)
+
+    for idx in range(1, len(text)):
+        ch = text[idx]
+        script = detect_script(ch)
+        if script != current_script:
+            segments.append(
+                {
+                    "start": start,
+                    "end": idx,
+                    "script": current_script,
+                    "lang": current_lang,
+                }
+            )
+            start = idx
+            current_script = script
+            current_lang = script_to_lang(script)
+
+    segments.append(
+        {
+            "start": start,
+            "end": len(text),
+            "script": current_script,
+            "lang": current_lang,
+        }
+    )
+    return segments

--- a/contract_review_app/tests/intake/test_langseg.py
+++ b/contract_review_app/tests/intake/test_langseg.py
@@ -1,0 +1,121 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contract_review_app.intake.langseg import (  # noqa: E402
+    detect_script,
+    script_to_lang,
+    segment_lang_script,
+)
+
+
+def assert_invariants(text: str, segs):
+    last_end = 0
+    rebuilt = []
+    for seg in segs:
+        start = seg["start"]
+        end = seg["end"]
+        assert 0 <= start < end <= len(text)
+        assert start == last_end
+        rebuilt.append(text[start:end])
+        last_end = end
+    assert last_end == len(text)
+    assert "".join(rebuilt) == text
+
+
+def test_basic_single_scripts():
+    cases = [
+        ("Hello", "Latin", "en"),
+        ("Привіт", "Cyrillic", "uk"),
+        ("γειά", "Greek", "el"),
+        ("שלום", "Hebrew", "he"),
+        ("مرحبا", "Arabic", "ar"),
+    ]
+    for text, script, lang in cases:
+        segs = segment_lang_script(text)
+        assert segs == [{"start": 0, "end": len(text), "script": script, "lang": lang}]
+        assert_invariants(text, segs)
+
+
+def test_mixed_scripts():
+    text = "Hello Привіт"
+    segs = segment_lang_script(text)
+    expected = [
+        {"start": 0, "end": 5, "script": "Latin", "lang": "en"},
+        {"start": 5, "end": 6, "script": "Common", "lang": "und"},
+        {"start": 6, "end": len(text), "script": "Cyrillic", "lang": "uk"},
+    ]
+    assert segs == expected
+    assert_invariants(text, segs)
+
+
+def test_mixed_scripts_complex():
+    text = "AβΓ Привіт!"
+    segs = segment_lang_script(text)
+    expected = [
+        {"start": 0, "end": 1, "script": "Latin", "lang": "en"},
+        {"start": 1, "end": 3, "script": "Greek", "lang": "el"},
+        {"start": 3, "end": 4, "script": "Common", "lang": "und"},
+        {"start": 4, "end": 10, "script": "Cyrillic", "lang": "uk"},
+        {"start": 10, "end": 11, "script": "Common", "lang": "und"},
+    ]
+    assert segs == expected
+    assert_invariants(text, segs)
+
+
+def test_common_only():
+    text = "12345 !!! 👍"
+    segs = segment_lang_script(text)
+    assert segs == [{"start": 0, "end": len(text), "script": "Common", "lang": "und"}]
+    assert_invariants(text, segs)
+
+
+def test_merging_logic():
+    text = "Hello!!"
+    segs = segment_lang_script(text)
+    expected = [
+        {"start": 0, "end": 5, "script": "Latin", "lang": "en"},
+        {"start": 5, "end": len(text), "script": "Common", "lang": "und"},
+    ]
+    assert segs == expected
+    assert_invariants(text, segs)
+
+    text2 = "Hi  there"
+    segs2 = segment_lang_script(text2)
+    expected2 = [
+        {"start": 0, "end": 2, "script": "Latin", "lang": "en"},
+        {"start": 2, "end": 4, "script": "Common", "lang": "und"},
+        {"start": 4, "end": len(text2), "script": "Latin", "lang": "en"},
+    ]
+    assert segs2 == expected2
+    assert_invariants(text2, segs2)
+
+
+def test_edge_cases_common_chars():
+    text = "A\u200d👍B"  # contains ZWJ and emoji
+    segs = segment_lang_script(text)
+    expected = [
+        {"start": 0, "end": 1, "script": "Latin", "lang": "en"},
+        {"start": 1, "end": 3, "script": "Common", "lang": "und"},
+        {"start": 3, "end": 4, "script": "Latin", "lang": "en"},
+    ]
+    assert segs == expected
+    assert_invariants(text, segs)
+
+
+def test_detect_script_basic():
+    assert detect_script("A") == "Latin"
+    assert detect_script("Ж") == "Cyrillic"
+    assert detect_script("β") == "Greek"
+    assert detect_script("ش") == "Arabic"
+    assert detect_script("ש") == "Hebrew"
+    assert detect_script("1") == "Common"
+
+
+def test_script_to_lang_mapping_total():
+    scripts = ["Latin", "Cyrillic", "Greek", "Arabic", "Hebrew", "Common"]
+    for script in scripts:
+        assert script_to_lang(script) in {"en", "uk", "el", "ar", "he", "und"}


### PR DESCRIPTION
## Summary
- add Unicode range–based script detection and language mapping
- provide single-pass segmenter returning contiguous language/script runs
- test segmentation across mixed scripts, common characters, and edge cases

## Testing
- `pre-commit run --files contract_review_app/intake/langseg.py contract_review_app/tests/intake/test_langseg.py`
- `pytest -q contract_review_app/tests/intake/test_langseg.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0479f96b08325a981dd51a4049c20