### PR TITLE
feat(intake): add parsed document builder

### DIFF
--- a/contract_review_app/intake/parser.py
+++ b/contract_review_app/intake/parser.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple, cast
+
+from contract_review_app.intake.normalization import normalize_text
+from contract_review_app.intake.langseg import segment_lang_script
+
+
+@dataclass(frozen=True)
+class ParsedDocument:
+    content: str
+    normalized_text: str
+    offset_map: List[int]
+    segments: List[Dict[str, object]]
+
+    @classmethod
+    def from_text(cls, raw: str) -> "ParsedDocument":
+        if raw is None:
+            raw = ""
+        norm, omap = normalize_text(raw)
+        segs = segment_lang_script(norm)
+        doc = cls(content=raw, normalized_text=norm, offset_map=omap, segments=segs)
+        doc._assert_invariants()
+        return doc
+
+    def map_norm_to_raw(self, i: int) -> Optional[int]:
+        if 0 <= i < len(self.offset_map):
+            return self.offset_map[i]
+        return None
+
+    def map_norm_span_to_raw(self, start: int, end: int) -> Optional[Tuple[int, int]]:
+        if start < 0 or end < 0 or start > end or end > len(self.offset_map):
+            return None
+        if start == end:
+            return None
+        start_raw = self.offset_map[start]
+        end_raw = self.offset_map[end - 1] + 1
+        start_raw = max(0, min(start_raw, len(self.content)))
+        end_raw = max(0, min(end_raw, len(self.content)))
+        if start_raw > end_raw:
+            return None
+        return (start_raw, end_raw)
+
+    def _assert_invariants(self) -> None:
+        om = self.offset_map
+        nt = self.normalized_text
+        assert len(om) == len(nt), "offset_map length must equal normalized_text length"
+        prev = -1
+        n_raw = len(self.content)
+        for j, r in enumerate(om):
+            assert 0 <= r < n_raw, f"raw index out of bounds at normalized {j}: {r}"
+            assert r >= prev, f"offset_map must be non-decreasing at {j}: {r} < {prev}"
+            prev = r
+        if len(nt) == 0:
+            assert self.segments == [] or all(
+                s.get("start", 0) == 0 and s.get("end", 0) == 0 for s in self.segments
+            ), "empty text must yield empty segments"
+        else:
+            assert (
+                len(self.segments) >= 1
+            ), "non-empty normalized_text must have at least 1 segment"
+            cur = 0
+            for s in self.segments:
+                a = cast(int, s["start"])
+                b = cast(int, s["end"])
+                assert (
+                    a == cur
+                ), f"segments must be contiguous; expected start {cur}, got {a}"
+                assert (
+                    0 <= a < b <= len(nt)
+                ), f"segment bounds invalid: {a}, {b}, len={len(nt)}"
+                cur = b
+            assert cur == len(
+                nt
+            ), f"segments must cover the full normalized_text; ended at {cur}"

--- a/contract_review_app/tests/intake/test_parsed_document.py
+++ b/contract_review_app/tests/intake/test_parsed_document.py
@@ -1,0 +1,69 @@
+from contract_review_app.intake.parser import ParsedDocument
+
+
+def test_empty_text() -> None:
+    doc = ParsedDocument.from_text("")
+    assert doc.content == ""
+    assert doc.normalized_text == ""
+    assert doc.offset_map == []
+    assert doc.segments == []
+
+
+def test_basic_latin() -> None:
+    raw = "Hello world."
+    doc = ParsedDocument.from_text(raw)
+    assert doc.normalized_text == raw
+    assert doc.offset_map == list(range(len(raw)))
+    assert doc.map_norm_to_raw(3) == 3
+    assert doc.map_norm_span_to_raw(0, 5) == (0, 5)
+    assert len(doc.segments) == 1
+    seg = doc.segments[0]
+    assert seg["start"] == 0 and seg["end"] == len(raw)
+    assert seg["lang"] == "en" and seg["script"] == "Latin"
+
+
+def test_normalization_and_offset_map() -> None:
+    raw = "“Hello\u00a0World”—A\u200dB"
+    expected = '"Hello World"-AB'
+    doc = ParsedDocument.from_text(raw)
+    assert doc.normalized_text == expected
+    assert len(doc.offset_map) == len(expected)
+    assert all(
+        doc.offset_map[i] <= doc.offset_map[i + 1]
+        for i in range(len(doc.offset_map) - 1)
+    )
+    span = doc.map_norm_span_to_raw(0, len(expected))
+    assert span == (0, len(raw))
+
+
+def test_mixed_scripts() -> None:
+    raw = "Hello Привіт!"
+    doc = ParsedDocument.from_text(raw)
+    assert doc.normalized_text == raw
+    assert doc.offset_map == list(range(len(raw)))
+    expected = [
+        {"start": 0, "end": 5, "lang": "en", "script": "Latin"},
+        {"start": 5, "end": 6, "lang": "und", "script": "Common"},
+        {"start": 6, "end": 12, "lang": "uk", "script": "Cyrillic"},
+        {"start": 12, "end": 13, "lang": "und", "script": "Common"},
+    ]
+    assert doc.segments == expected
+    assert doc.offset_map == sorted(doc.offset_map)
+
+
+def test_emoji_mapping() -> None:
+    raw = "OK 👍"
+    doc = ParsedDocument.from_text(raw)
+    assert doc.normalized_text == raw
+    idx = doc.normalized_text.index("👍")
+    assert doc.map_norm_to_raw(idx) == raw.index("👍")
+    assert doc.map_norm_span_to_raw(idx, idx + 1) == (idx, idx + 1)
+
+
+def test_idempotence() -> None:
+    raw = "“Hello World”—A‍B"
+    doc1 = ParsedDocument.from_text(raw)
+    doc2 = ParsedDocument.from_text(doc1.normalized_text)
+    assert doc2.normalized_text == doc1.normalized_text
+    assert doc2.offset_map == list(range(len(doc2.normalized_text)))
+    assert doc2.segments == doc1.segments


### PR DESCRIPTION
## Summary
- add immutable ParsedDocument builder with normalization and language segmentation
- add tests for ParsedDocument mapping and normalization behavior

## Testing
- `python -m black contract_review_app/intake/parser.py contract_review_app/tests/intake/test_parsed_document.py`
- `python -m ruff check contract_review_app/intake/parser.py contract_review_app/tests/intake/test_parsed_document.py`
- `PYTHONPATH=. python -m mypy contract_review_app/intake/parser.py contract_review_app/tests/intake/test_parsed_document.py --ignore-missing-imports --explicit-package-bases`
- `PYTHONPATH=/workspace python -m pytest -q contract_review_app/tests/intake/test_parsed_document.py` *(fails: ModuleNotFoundError: No module named 'contract_review_app.intake.normalization')*


------
https://chatgpt.com/codex/tasks/task_e_68b0480f72888325bfc5fcd770dd71ad