### PR TITLE
Add PolicyPack loader and FindingV2 model

### DIFF
--- a/contract_review_app/rules_v2/__init__.py
+++ b/contract_review_app/rules_v2/__init__.py
@@ -1,0 +1,13 @@
+# contract_review_app/rules_v2/__init__.py
+"""Unified rules v2 loader and models."""
+from .models import FindingV2, ENGINE_VERSION
+from .types import Rule, LoadedRule
+from .loader import PolicyPackLoader
+
+__all__ = [
+    "FindingV2",
+    "ENGINE_VERSION",
+    "Rule",
+    "LoadedRule",
+    "PolicyPackLoader",
+]

--- a/contract_review_app/rules_v2/loader.py
+++ b/contract_review_app/rules_v2/loader.py
@@ -1,0 +1,105 @@
+# contract_review_app/rules_v2/loader.py
+"""Policy pack loader for rules v2."""
+from __future__ import annotations
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .models import FindingV2
+from .types import LoadedRule
+
+__all__ = ["PolicyPackLoader"]
+
+
+class PolicyPackLoader:
+    """Discover and execute rules for packs."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+
+    def discover(self) -> List[LoadedRule]:
+        rules: List[LoadedRule] = []
+        for pack_dir in sorted(p for p in self.root.iterdir() if p.is_dir()):
+            pack = pack_dir.name
+            yaml_files = {p.stem: p for p in pack_dir.glob("*.yaml")}
+            py_files = {p.stem: p for p in pack_dir.glob("*.py")}
+            for rule_id in sorted(set(yaml_files) | set(py_files)):
+                y_path = yaml_files.get(rule_id)
+                p_path = py_files.get(rule_id)
+                if y_path:
+                    py_ref = _extract_python_reference(y_path)
+                    if py_ref:
+                        rules.append(
+                            LoadedRule(
+                                fmt="hybrid",
+                                pack=pack,
+                                rule_id=rule_id,
+                                impl=py_ref,
+                                path=y_path,
+                            )
+                        )
+                        continue
+                if p_path:
+                    rules.append(
+                        LoadedRule(
+                            fmt="python",
+                            pack=pack,
+                            rule_id=rule_id,
+                            impl=p_path,
+                            path=p_path,
+                        )
+                    )
+                elif y_path:
+                    rules.append(
+                        LoadedRule(
+                            fmt="yaml",
+                            pack=pack,
+                            rule_id=rule_id,
+                            impl=None,
+                            path=y_path,
+                        )
+                    )
+        return rules
+
+    def execute(self, rules: List[LoadedRule], ctx: Dict[str, Any]) -> List[FindingV2]:
+        findings: List[FindingV2] = []
+        for rule in rules:
+            if rule.fmt == "yaml":
+                raise NotImplementedError(
+                    f"YAML-only rule execution not implemented for {rule.pack}/{rule.rule_id}"
+                )
+            py_path = Path(rule.impl)
+            module_name = f"{rule.pack}_{rule.rule_id}".replace("-", "_")
+            loader = SourceFileLoader(module_name, str(py_path))
+            spec = importlib.util.spec_from_loader(module_name, loader)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Cannot load module {module_name}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)  # type: ignore[attr-defined]
+            rule_main = getattr(module, "rule_main")
+            result = rule_main(ctx)
+            if not isinstance(result, list):
+                raise TypeError("rule_main must return a list")
+            for item in result:
+                if isinstance(item, FindingV2):
+                    findings.append(item)
+                elif isinstance(item, dict):
+                    findings.append(FindingV2(**item))
+                else:
+                    raise TypeError(f"Unsupported finding type: {type(item)!r}")
+        return findings
+
+
+def _extract_python_reference(yaml_path: Path) -> Path | None:
+    try:
+        text = yaml_path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("python:"):
+            ref = s.split(":", 1)[1].strip().strip('"').strip("'")
+            return (yaml_path.parent / ref).resolve()
+    return None

--- a/contract_review_app/rules_v2/models.py
+++ b/contract_review_app/rules_v2/models.py
@@ -1,0 +1,47 @@
+# contract_review_app/rules_v2/models.py
+"""Finding model for rules v2."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal
+
+from pydantic import BaseModel, field_validator
+
+try:  # pragma: no cover - pydantic v1 fallback
+    from pydantic import ConfigDict
+except Exception:  # pragma: no cover
+    ConfigDict = dict  # type: ignore[misc, assignment]
+
+__all__ = ["FindingV2", "ENGINE_VERSION"]
+
+ENGINE_VERSION = "2.0.0"
+
+
+class FindingV2(BaseModel):
+    """Minimal Finding model used by rules v2."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    pack: str
+    rule_id: str
+    title: Dict[str, str]
+    severity: Literal["High", "Medium", "Low"]
+    category: str
+    message: Dict[str, str]
+    explain: Dict[str, str]
+    suggestion: Dict[str, str]
+    evidence: List[str] = []
+    citation: List[str] = []
+    flags: List[str] = []
+    meta: Dict[str, Any] = {}
+    version: str
+    created_at: datetime
+    engine_version: str
+
+    @field_validator("title", "message", "explain", "suggestion")
+    @classmethod
+    def _ensure_en(cls, v: Dict[str, str]) -> Dict[str, str]:
+        if "en" not in v:
+            raise ValueError("missing 'en' localization")
+        return v

--- a/contract_review_app/rules_v2/types.py
+++ b/contract_review_app/rules_v2/types.py
@@ -1,0 +1,27 @@
+# contract_review_app/rules_v2/types.py
+"""Typing helpers for rules v2."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Protocol
+
+from .models import FindingV2
+
+__all__ = ["Rule", "LoadedRule"]
+
+
+class Rule(Protocol):
+    pack: str
+    rule_id: str
+
+    def evaluate(self, context: Dict[str, Any]) -> List[FindingV2]: ...
+
+
+@dataclass
+class LoadedRule:
+    fmt: Literal["yaml", "python", "hybrid"]
+    pack: str
+    rule_id: str
+    impl: Any
+    path: Path

--- a/contract_review_app/tests/rules_v2/test_finding_model_v2.py
+++ b/contract_review_app/tests/rules_v2/test_finding_model_v2.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from contract_review_app.rules_v2 import ENGINE_VERSION, FindingV2
+
+
+def build_valid_finding() -> FindingV2:
+    return FindingV2(
+        id="1",
+        pack="pk",
+        rule_id="r1",
+        title={"en": "Title"},
+        severity="High",
+        category="cat",
+        message={"en": "msg"},
+        explain={"en": "exp"},
+        suggestion={"en": "sug"},
+        version="0",
+        created_at=datetime.utcnow(),
+        engine_version=ENGINE_VERSION,
+    )
+
+
+def test_valid_finding_model() -> None:
+    finding = build_valid_finding()
+    assert finding.severity == "High"
+    assert finding.title["en"] == "Title"
+
+
+def test_severity_constraint() -> None:
+    with pytest.raises(ValidationError):
+        FindingV2(
+            id="1",
+            pack="pk",
+            rule_id="r1",
+            title={"en": "t"},
+            severity="critical",  # type: ignore[arg-type]
+            category="cat",
+            message={"en": "m"},
+            explain={"en": "e"},
+            suggestion={"en": "s"},
+            version="0",
+            created_at=datetime.utcnow(),
+            engine_version=ENGINE_VERSION,
+        )
+
+
+def test_en_required() -> None:
+    with pytest.raises(ValidationError):
+        FindingV2(
+            id="1",
+            pack="pk",
+            rule_id="r1",
+            title={"uk": "t"},
+            severity="Low",
+            category="cat",
+            message={"en": "m"},
+            explain={"en": "e"},
+            suggestion={"en": "s"},
+            version="0",
+            created_at=datetime.utcnow(),
+            engine_version=ENGINE_VERSION,
+        )

--- a/contract_review_app/tests/rules_v2/test_loader_discovery_priority.py
+++ b/contract_review_app/tests/rules_v2/test_loader_discovery_priority.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from tempfile import TemporaryDirectory
+
+from contract_review_app.rules_v2 import PolicyPackLoader
+
+
+def create_file(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def test_discovery_priority() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        pk1 = root / "pk1"
+        pk1.mkdir()
+        pk2 = root / "pk2"
+        pk2.mkdir()
+
+        create_file(pk1 / "ruleA.yaml", "title: A\n")
+        create_file(
+            pk1 / "ruleB.py",
+            "def rule_main(ctx):\n    return []\n",
+        )
+        create_file(pk1 / "ruleC.yaml", 'python: "ruleC_impl.py"\n')
+        create_file(
+            pk1 / "ruleC_impl.py",
+            "def rule_main(ctx):\n    return []\n",
+        )
+        create_file(pk1 / "ruleD.yaml", "title: D\n")
+        create_file(
+            pk1 / "ruleD.py",
+            "def rule_main(ctx):\n    return []\n",
+        )
+        create_file(
+            pk2 / "ruleX.py",
+            "def rule_main(ctx):\n    return []\n",
+        )
+
+        loader = PolicyPackLoader(root)
+        rules = loader.discover()
+
+        key_map = {(r.pack, r.rule_id): r for r in rules}
+        assert key_map[("pk1", "ruleA")].fmt == "yaml"
+        assert key_map[("pk1", "ruleB")].fmt == "python"
+        assert key_map[("pk1", "ruleC")].fmt == "hybrid"
+        assert key_map[("pk1", "ruleD")].fmt == "python"
+
+        pairs = [(r.pack, r.rule_id) for r in rules]
+        assert pairs == sorted(pairs)
+        assert len(pairs) == len(set(pairs))

--- a/contract_review_app/tests/rules_v2/test_loader_execute_python_and_hybrid.py
+++ b/contract_review_app/tests/rules_v2/test_loader_execute_python_and_hybrid.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from datetime import datetime
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from contract_review_app.rules_v2 import ENGINE_VERSION, PolicyPackLoader
+
+
+def create_file(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def test_execute_python_and_hybrid() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        pk1 = root / "pk1"
+        pk1.mkdir()
+
+        create_file(pk1 / "ruleA.yaml", "title: A\n")
+        create_file(
+            pk1 / "ruleB.py",
+            (
+                "from contract_review_app.rules_v2 import ENGINE_VERSION, FindingV2\n"
+                "from datetime import datetime\n"
+                "def rule_main(ctx):\n"
+                "    return [FindingV2(id='1', pack='pk1', rule_id='ruleB', title={'en':'t'}, severity='Low',"
+                " category='cat', message={'en':'m'}, explain={'en':'e'}, suggestion={'en':'s'},"
+                " version='0', created_at=datetime.utcnow(), engine_version=ENGINE_VERSION)]\n"
+            ),
+        )
+        create_file(pk1 / "ruleC.yaml", 'python: "ruleC_impl.py"\n')
+        create_file(
+            pk1 / "ruleC_impl.py",
+            (
+                "def rule_main(ctx):\n"
+                "    return [{'id':'2','pack':'pk1','rule_id':'ruleC','title':{'en':'t'},"
+                "'severity':'High','category':'cat','message':{'en':'m'},'explain':{'en':'e'},"
+                "'suggestion':{'en':'s'},'version':'0','created_at':ctx['now'],'engine_version':ctx['engine_version']}]\n"
+            ),
+        )
+
+        loader = PolicyPackLoader(root)
+        rules = loader.discover()
+        ctx = {"now": datetime.utcnow(), "engine_version": ENGINE_VERSION}
+        py_rules = [r for r in rules if r.fmt != "yaml"]
+        findings = loader.execute(py_rules, ctx)
+
+        assert findings
+        f = findings[0]
+        assert f.pack == "pk1"
+        assert f.severity in {"High", "Medium", "Low"}
+        assert isinstance(f.created_at, datetime)
+        assert f.engine_version == ENGINE_VERSION
+
+        yaml_rule = [r for r in rules if r.fmt == "yaml"]
+        with pytest.raises(NotImplementedError):
+            loader.execute(yaml_rule, ctx)


### PR DESCRIPTION
## Summary
- add FindingV2 Pydantic model and ENGINE_VERSION constant
- implement PolicyPackLoader for discovering and executing policy pack rules
- cover loader and model behavior with unit tests

## Testing
- `ruff check contract_review_app/rules_v2 contract_review_app/tests/rules_v2`
- `black --check contract_review_app/rules_v2 contract_review_app/tests/rules_v2`
- `mypy --explicit-package-bases contract_review_app/rules_v2 contract_review_app/tests/rules_v2`
- `pytest -q contract_review_app/tests/rules_v2`


------
https://chatgpt.com/codex/tasks/task_e_68b049bbe4408325bba9c87614427fc6