### PR TITLE
feat: add yaml rule vm

### DIFF
--- a/contract_review_app/rules_v2/__init__.py
+++ b/contract_review_app/rules_v2/__init__.py
@@ -1,0 +1,1 @@
+"""Rule engine v2 package."""

--- a/contract_review_app/rules_v2/loader.py
+++ b/contract_review_app/rules_v2/loader.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+from .models import FindingV2, ENGINE_VERSION
+from .types import RuleFormat, RuleSource
+from .vm import RuleVM
+from .yaml_schema import RuleYaml
+
+
+def discover(root: Path) -> List[RuleSource]:
+    """Discover rule sources under *root*.
+
+    Discovery favors hybrid (py+yaml) over python over yaml.
+    """
+
+    root_path = Path(root)
+    file_map: Dict[tuple[str, str], Dict[str, Path]] = {}
+
+    for path in root_path.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in {".py", ".yaml"}:
+            continue
+        base = path.with_suffix("")
+        key = (str(base), path.parent.name)
+        entry = file_map.setdefault(key, {})
+        if path.suffix == ".py":
+            entry["py"] = path
+        else:
+            entry["yaml"] = path
+
+    sources: List[RuleSource] = []
+    for (base, pack), files in sorted(file_map.items()):
+        if "py" in files and "yaml" in files:
+            sources.append(
+                RuleSource(
+                    id=Path(base).name,
+                    pack=pack,
+                    format=RuleFormat.HYBRID,
+                    path=files["yaml"],
+                    py_path=files["py"],
+                    yaml_path=files["yaml"],
+                )
+            )
+        elif "py" in files:
+            sources.append(
+                RuleSource(
+                    id=Path(base).name,
+                    pack=pack,
+                    format=RuleFormat.PYTHON,
+                    path=files["py"],
+                    py_path=files["py"],
+                )
+            )
+        else:
+            sources.append(
+                RuleSource(
+                    id=Path(base).name,
+                    pack=pack,
+                    format=RuleFormat.YAML,
+                    path=files["yaml"],
+                    yaml_path=files["yaml"],
+                )
+            )
+
+    return sources
+
+
+def _load_python(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise ImportError(f"Cannot import rule from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def execute(source: RuleSource, context: Dict[str, Any]) -> List[FindingV2]:
+    """Execute *source* with given *context*."""
+
+    if source.format in {RuleFormat.PYTHON, RuleFormat.HYBRID}:
+        module = _load_python(source.py_path or source.path)
+        if not hasattr(module, "apply"):
+            return []
+        result = module.apply(context)
+        return result or []
+
+    if source.format is RuleFormat.YAML:
+        data = yaml.safe_load(source.path.read_text())
+        rule = RuleYaml.model_validate(data)
+        if rule.engine_version != ENGINE_VERSION:
+            raise ValueError("engine_version mismatch")
+        vm = RuleVM(rule)
+        return vm.evaluate(context)
+
+    raise NotImplementedError(source.format)

--- a/contract_review_app/rules_v2/models.py
+++ b/contract_review_app/rules_v2/models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+ENGINE_VERSION = "2.0.0"
+
+
+class FindingV2(BaseModel):
+    """Result produced by rule evaluation."""
+
+    id: str
+    pack: str
+    severity: str
+    category: str
+    title: Dict[str, str]
+    message: Optional[Dict[str, str]] = None
+    explain: Optional[Dict[str, str]] = None
+    suggestion: Optional[Dict[str, str]] = None
+    evidence: List[str] = Field(default_factory=list)
+    citation: List[str] = Field(default_factory=list)
+    flags: List[str] = Field(default_factory=list)
+    version: str
+    engine_version: str = ENGINE_VERSION
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/contract_review_app/rules_v2/types.py
+++ b/contract_review_app/rules_v2/types.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class RuleFormat(str, Enum):
+    PYTHON = "python"
+    YAML = "yaml"
+    HYBRID = "hybrid"
+
+
+@dataclass
+class RuleSource:
+    id: str
+    pack: str
+    format: RuleFormat
+    path: Path
+    py_path: Optional[Path] = None
+    yaml_path: Optional[Path] = None

--- a/contract_review_app/rules_v2/vm.py
+++ b/contract_review_app/rules_v2/vm.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from .models import ENGINE_VERSION, FindingV2
+from .yaml_schema import RuleYaml
+
+
+def _get_path(data: Dict[str, Any], path: str) -> Any:
+    parts = path.split(".")
+    value: Any = data
+    for part in parts:
+        if isinstance(value, dict) and part in value:
+            value = value[part]
+        else:
+            return None
+    return value
+
+
+def eval_cond(expr: str | bool, context: Dict[str, Any]) -> bool:
+    if isinstance(expr, bool):
+        return expr
+
+    expr = expr.strip()
+
+    m = re.fullmatch(r"len\((context\.[^)]+)\)\s*>\s*(\d+)", expr)
+    if m:
+        val = _get_path(context, m.group(1)[len("context.") :])
+        try:
+            return len(val) > int(m.group(2))
+        except Exception:
+            return False
+
+    m = re.fullmatch(r"(context\.[^ ]+)\s+contains\s+'([^']*)'", expr)
+    if m:
+        val = _get_path(context, m.group(1)[len("context.") :])
+        return isinstance(val, str) and m.group(2) in val
+
+    m = re.fullmatch(r"(context\.[^ ]+)\s*(==|!=)\s*'([^']*)'", expr)
+    if m:
+        val = _get_path(context, m.group(1)[len("context.") :])
+        if m.group(2) == "==":
+            return val == m.group(3)
+        return val != m.group(3)
+
+    if expr.startswith("context."):
+        val = _get_path(context, expr[len("context.") :])
+        return bool(val)
+
+    raise ValueError(f"Unsupported expression: {expr}")
+
+
+def _merge(*lists: List[str]) -> List[str]:
+    result: List[str] = []
+    seen = set()
+    for lst in lists:
+        for item in lst or []:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+    return result
+
+
+class RuleVM:
+    def __init__(self, rule: RuleYaml) -> None:
+        self.rule = rule
+
+    def evaluate(self, context: Dict[str, Any]) -> List[FindingV2]:
+        findings: List[FindingV2] = []
+        for check in self.rule.checks:
+            cond = eval_cond(check.when, context)
+            if cond and check.any_of:
+                cond = cond and any(eval_cond(expr, context) for expr in check.any_of)
+            if cond and check.all_of:
+                cond = cond and all(eval_cond(expr, context) for expr in check.all_of)
+            if cond:
+                produce = check.produce or {}
+                evidence = _merge(self.rule.evidence, getattr(produce, "evidence", []))
+                citation = _merge(self.rule.citation, getattr(produce, "citation", []))
+                flags = _merge(self.rule.flags, getattr(produce, "flags", []))
+                findings.append(
+                    FindingV2(
+                        id=self.rule.id,
+                        pack=self.rule.pack,
+                        severity=self.rule.severity,
+                        category=self.rule.category,
+                        title=self.rule.title,
+                        message=self.rule.message,
+                        explain=self.rule.explain,
+                        suggestion=self.rule.suggestion,
+                        evidence=evidence,
+                        citation=citation,
+                        flags=flags,
+                        version=self.rule.version,
+                        engine_version=ENGINE_VERSION,
+                        created_at=datetime.now(timezone.utc),
+                    )
+                )
+        return findings

--- a/contract_review_app/rules_v2/yaml_schema.py
+++ b/contract_review_app/rules_v2/yaml_schema.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+LocaleDict = Dict[str, str]
+
+
+class Produce(BaseModel):
+    evidence: List[str] = Field(default_factory=list)
+    citation: List[str] = Field(default_factory=list)
+    flags: List[str] = Field(default_factory=list)
+
+
+class CheckItem(BaseModel):
+    when: str | bool
+    any_of: Optional[List[str]] = None
+    all_of: Optional[List[str]] = None
+    produce: Optional[Produce] = None
+
+
+class RuleYaml(BaseModel):
+    id: str
+    pack: str
+    severity: str
+    category: str
+    title: LocaleDict
+    message: Optional[LocaleDict] = None
+    explain: Optional[LocaleDict] = None
+    suggestion: Optional[LocaleDict] = None
+    evidence: List[str] = Field(default_factory=list)
+    citation: List[str] = Field(default_factory=list)
+    flags: List[str] = Field(default_factory=list)
+    version: str
+    engine_version: str
+    checks: List[CheckItem]
+
+    @validator("title")
+    def _title_has_en(cls, v: LocaleDict) -> LocaleDict:
+        if "en" not in v:
+            raise ValueError("title must include 'en'")
+        return v
+
+    @validator("message", "explain", "suggestion")
+    def _locale_has_en(cls, v: Optional[LocaleDict]) -> Optional[LocaleDict]:
+        if v is not None and "en" not in v:
+            raise ValueError("locale dict must include 'en'")
+        return v
+
+    @validator("severity")
+    def _severity_valid(cls, v: str) -> str:
+        if v not in {"High", "Medium", "Low"}:
+            raise ValueError("invalid severity")
+        return v
+
+    @validator("version", "engine_version")
+    def _non_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("must be non-empty")
+        return v

--- a/contract_review_app/tests/rules_v2/test_loader_execute_python_and_hybrid.py
+++ b/contract_review_app/tests/rules_v2/test_loader_execute_python_and_hybrid.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+import yaml
+
+from contract_review_app.rules_v2 import loader, models, types
+
+
+def create_rules(tmp_path: Path):
+    pack = tmp_path / "pack"
+    pack.mkdir()
+
+    # python-only rule
+    (pack / "py_rule.py").write_text(
+        """
+from contract_review_app.rules_v2 import models
+
+def apply(context):
+    return [models.FindingV2(id='py', pack='pack', severity='Low', category='c', title={'en':'t'}, version='2.0.0')]
+"""
+    )
+
+    # hybrid rule: both .py and .yaml
+    (pack / "hybrid_rule.py").write_text(
+        """
+from contract_review_app.rules_v2 import models
+
+def apply(context):
+    return [models.FindingV2(id='hy', pack='pack', severity='Low', category='c', title={'en':'t'}, version='2.0.0')]
+"""
+    )
+    (pack / "hybrid_rule.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "id": "hy",
+                "pack": "pack",
+                "severity": "Low",
+                "category": "c",
+                "title": {"en": "t"},
+                "version": "2.0.0",
+                "engine_version": models.ENGINE_VERSION,
+                "checks": [{"when": True}],
+            }
+        )
+    )
+
+    # yaml-only rule
+    (pack / "yaml_rule.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "id": "yaml",
+                "pack": "pack",
+                "severity": "Low",
+                "category": "c",
+                "title": {"en": "t"},
+                "version": "2.0.0",
+                "engine_version": models.ENGINE_VERSION,
+                "checks": [{"when": False}],
+            }
+        )
+    )
+
+    return pack
+
+
+def test_discover_and_execute(tmp_path):
+    create_rules(tmp_path)
+    rules = loader.discover(tmp_path)
+    assert {r.id: r.format for r in rules} == {
+        "hybrid_rule": types.RuleFormat.HYBRID,
+        "py_rule": types.RuleFormat.PYTHON,
+        "yaml_rule": types.RuleFormat.YAML,
+    }
+
+    for rule in rules:
+        loader.execute(rule, {"text": "NDA", "meta": {"type": "confidentiality"}})

--- a/contract_review_app/tests/rules_v2/test_loader_execute_yaml_vm.py
+++ b/contract_review_app/tests/rules_v2/test_loader_execute_yaml_vm.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+from contract_review_app.rules_v2 import loader, models
+
+
+def create_pack(tmp_path: Path):
+    pack = tmp_path / "pack"
+    pack.mkdir()
+    content = {
+        "id": "r1",
+        "pack": "pack",
+        "severity": "Medium",
+        "category": "cat",
+        "title": {"en": "Title"},
+        "version": "2.0.0",
+        "engine_version": models.ENGINE_VERSION,
+        "checks": [
+            {
+                "when": "context.text contains 'NDA'",
+                "any_of": ["context.meta.type == 'confidentiality'"],
+                "produce": {"evidence": ["hit"], "citation": ["http://example.com"]},
+            }
+        ],
+    }
+    (pack / "rule.yaml").write_text(yaml.safe_dump(content))
+    return pack
+
+
+def test_loader_execute_yaml(tmp_path):
+    create_pack(tmp_path)
+    discovered = loader.discover(tmp_path)
+    assert discovered and discovered[0].format.value == "yaml"
+    findings = loader.execute(
+        discovered[0], {"text": "NDA draft", "meta": {"type": "confidentiality"}}
+    )
+    assert findings
+    f = findings[0]
+    assert isinstance(f.created_at, datetime)
+    assert f.engine_version == models.ENGINE_VERSION

--- a/contract_review_app/tests/rules_v2/test_yaml_vm_schema.py
+++ b/contract_review_app/tests/rules_v2/test_yaml_vm_schema.py
@@ -1,0 +1,46 @@
+import yaml
+
+from contract_review_app.rules_v2 import models, vm, yaml_schema
+
+
+def build_yaml(tmp_path):
+    content = {
+        "id": "rule1",
+        "pack": "pack1",
+        "severity": "High",
+        "category": "cat",
+        "title": {"en": "Title EN"},
+        "message": {"en": "Message EN"},
+        "explain": {"en": "Explain EN"},
+        "suggestion": {"en": "Suggestion EN"},
+        "version": "2.0.0",
+        "engine_version": models.ENGINE_VERSION,
+        "checks": [
+            {
+                "when": "context.text contains 'NDA'",
+                "all_of": ["context.meta.type == 'confidentiality'"],
+                "produce": {"evidence": ["found A"], "flags": ["dsl"]},
+            }
+        ],
+    }
+    path = tmp_path / "rule.yaml"
+    path.write_text(yaml.safe_dump(content))
+    return path
+
+
+def test_schema_and_vm(tmp_path):
+    path = build_yaml(tmp_path)
+    data = yaml.safe_load(path.read_text())
+    rule = yaml_schema.RuleYaml.model_validate(data)
+    machine = vm.RuleVM(rule)
+
+    context = {"text": "NDA draft", "meta": {"type": "confidentiality"}}
+    findings = machine.evaluate(context)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.severity == "High"
+    assert f.title["en"] == "Title EN"
+    assert f.engine_version == models.ENGINE_VERSION
+
+    context = {"text": "draft", "meta": {"type": "confidentiality"}}
+    assert machine.evaluate(context) == []


### PR DESCRIPTION
## Summary
- add Pydantic schema for YAML-based rules
- implement safe RuleVM to evaluate YAML rules
- extend loader to run YAML rules and add comprehensive tests

## Testing
- `ruff check contract_review_app/rules_v2 contract_review_app/tests/rules_v2`
- `python -m black contract_review_app/rules_v2 contract_review_app/tests/rules_v2`
- `PYTHONPATH=. pytest -q contract_review_app/tests/rules_v2`


------
https://chatgpt.com/codex/tasks/task_e_68b04a79a2ac8325b3a1fa4d319df7e5