### PR TITLE
Add i18n fallback and locale validation for FindingV2

### DIFF
--- a/contract_review_app/rules_v2/i18n.py
+++ b/contract_review_app/rules_v2/i18n.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Dict
+
+SUPPORTED = {"en", "uk"}  # extendable later
+
+
+def validate_locale_dict(d: Dict[str, str]) -> None:
+    """Ensure at least 'en' exists and values are non-empty strings; ignore extra keys."""
+    if not isinstance(d, dict):
+        raise TypeError("locale dict expected")
+    if "en" not in d or not isinstance(d["en"], str) or d["en"].strip() == "":
+        raise ValueError("locale dict must contain non-empty 'en'")
+    for k, v in d.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise TypeError("locale dict keys/values must be strings")
+
+
+def resolve_locale(d: Dict[str, str], prefer: str = "uk", fallback: str = "en") -> str:
+    """Return d[prefer] if present/non-empty else d[fallback] if present else '' (deterministic)."""
+    if not isinstance(d, dict):
+        return ""
+    val = (d.get(prefer) or "").strip()
+    if val:
+        return val
+    val2 = (d.get(fallback) or "").strip()
+    return val2
+
+
+def resolve_bundle(
+    bundle: Dict[str, Dict[str, str]],
+    prefer: str = "uk",
+    fallback: str = "en",
+) -> Dict[str, str]:
+    """Resolve a bundle of locale dicts -> flat strings. Expected keys: title, message, explain, suggestion."""
+    out: Dict[str, str] = {}
+    for k in ("title", "message", "explain", "suggestion"):
+        d = bundle.get(k) or {}
+        out[k] = resolve_locale(d, prefer=prefer, fallback=fallback)
+    return out

--- a/contract_review_app/rules_v2/models.py
+++ b/contract_review_app/rules_v2/models.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from pydantic import BaseModel, validator
+
+from .i18n import resolve_bundle, validate_locale_dict
+
+
+class FindingV2(BaseModel):
+    """Simplified finding model with localized fields."""
+
+    rule_id: Optional[str] = None
+    clause_type: Optional[str] = None
+    severity: Optional[str] = None
+    start: Optional[int] = None
+    end: Optional[int] = None
+    snippet: Optional[str] = None
+
+    title: Dict[str, str]
+    message: Dict[str, str]
+    explain: Dict[str, str]
+    suggestion: Dict[str, str]
+
+    # validators ensure 'en' exists and keys/values are strings
+    @validator("title", "message", "explain", "suggestion")
+    def _validate_locale(cls, v: Dict[str, str]) -> Dict[str, str]:
+        validate_locale_dict(v)
+        return v
+
+    def localize(self, prefer: str = "uk", fallback: str = "en") -> Dict[str, str]:
+        """Return dict with resolved title/message/explain/suggestion strings."""
+        return resolve_bundle(
+            {
+                "title": self.title,
+                "message": self.message,
+                "explain": self.explain,
+                "suggestion": self.suggestion,
+            },
+            prefer=prefer,
+            fallback=fallback,
+        )
+
+    def has_locale(self, lang: str) -> bool:
+        """Return True if all locale fields have a non-empty value for ``lang``."""
+        for field in (self.title, self.message, self.explain, self.suggestion):
+            if not isinstance(field, dict):
+                return False
+            val = field.get(lang)
+            if not isinstance(val, str) or not val.strip():
+                return False
+        return True

--- a/contract_review_app/tests/rules_v2/test_i18n_fallback.py
+++ b/contract_review_app/tests/rules_v2/test_i18n_fallback.py
@@ -1,0 +1,102 @@
+import copy
+
+import pytest
+from pydantic import ValidationError
+
+from contract_review_app.rules_v2.i18n import resolve_locale
+from contract_review_app.rules_v2.models import FindingV2
+
+
+# ---------------------------------------------------------------------------
+# Validation behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_missing_en_raises():
+    with pytest.raises(ValidationError):
+        FindingV2(
+            rule_id="r1",
+            title={"uk": "t"},
+            message={"en": "m"},
+            explain={"en": "e"},
+            suggestion={"en": "s"},
+        )
+
+
+def test_extra_keys_and_value_types():
+    # extra keys tolerated
+    f = FindingV2(
+        rule_id="r1",
+        title={"en": "t", "fr": "tfr"},
+        message={"en": "m"},
+        explain={"en": "e"},
+        suggestion={"en": "s"},
+    )
+    assert f.title["fr"] == "tfr"
+
+    # non-string values rejected
+    with pytest.raises(ValidationError):
+        FindingV2(
+            rule_id="r1",
+            title={"en": "t", "fr": 1},
+            message={"en": "m"},
+            explain={"en": "e"},
+            suggestion={"en": "s"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# resolve_locale behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_locale():
+    assert resolve_locale({"en": "hi"}, prefer="uk") == "hi"
+    assert resolve_locale({"en": "hi", "uk": "привіт"}, prefer="uk") == "привіт"
+    assert resolve_locale({"en": "hi", "uk": ""}, prefer="uk") == "hi"
+
+
+# ---------------------------------------------------------------------------
+# FindingV2.localize
+# ---------------------------------------------------------------------------
+
+
+def test_localize_fallback_and_stability():
+    base = {
+        "title": {"en": "Title"},
+        "message": {"en": "Message"},
+        "explain": {"en": "Explain"},
+        "suggestion": {"en": "Suggestion"},
+    }
+    f = FindingV2(rule_id="r1", **base)
+    before = copy.deepcopy(f.dict())
+
+    loc = f.localize(prefer="uk")
+    assert loc == {k: v["en"] for k, v in base.items()}
+    assert f.dict() == before  # no mutation
+
+
+def test_localize_prefer_uk():
+    base = {
+        "title": {"en": "Title", "uk": "Заголовок"},
+        "message": {"en": "Message", "uk": "Повідомлення"},
+        "explain": {"en": "Explain", "uk": "Пояснення"},
+        "suggestion": {"en": "Suggestion", "uk": "Порада"},
+    }
+    f = FindingV2(rule_id="r1", **base)
+    loc = f.localize(prefer="uk")
+    assert loc == {k: v["uk"] for k, v in base.items()}
+    # deterministic
+    assert loc == f.localize(prefer="uk")
+
+
+def test_has_locale():
+    f = FindingV2(
+        rule_id="r1",
+        title={"en": "Title", "uk": "Заголовок"},
+        message={"en": "Message", "uk": "Повідомлення"},
+        explain={"en": "Explain", "uk": "Пояснення"},
+        suggestion={"en": "Suggestion", "uk": "Порада"},
+    )
+    assert f.has_locale("uk")
+    assert not f.has_locale("fr")


### PR DESCRIPTION
## Summary
- add i18n helpers to validate locale bundles and resolve with deterministic fallbacks
- extend FindingV2 with locale dict validators and convenience localization methods
- cover i18n validation and fallback logic with new tests

## Testing
- `black contract_review_app/rules_v2/models.py`
- `ruff check contract_review_app/rules_v2/i18n.py contract_review_app/rules_v2/models.py contract_review_app/tests/rules_v2/test_i18n_fallback.py`
- `mypy --explicit-package-bases contract_review_app/rules_v2/i18n.py contract_review_app/rules_v2/models.py contract_review_app/tests/rules_v2/test_i18n_fallback.py`
- `PYTHONPATH=. pytest -q contract_review_app/tests/rules_v2/test_i18n_fallback.py`
- `PYTHONPATH=. pytest -q contract_review_app/tests/rules_v2`


------
https://chatgpt.com/codex/tasks/task_e_68b04acdb25083259d7a7857c5051338