### PR TITLE
feat: add adapter for rule engine v2

### DIFF
--- a/contract_review_app/rules_v2/adapter.py
+++ b/contract_review_app/rules_v2/adapter.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List
+
+from contract_review_app.rules_v2.i18n import resolve_locale
+from contract_review_app.rules_v2.models import ENGINE_VERSION, FindingV2
+
+
+# --- helpers ---
+
+
+def _norm_severity(v: str | None) -> str:
+    """Map common v1 severities to V2 values."""
+    s = (v or "").strip().lower()
+    if s in {"critical", "blocker", "high", "severe"}:
+        return "High"
+    if s in {"medium", "moderate", "warning"}:
+        return "Medium"
+    if s in {"low", "minor", "info", "informational"}:
+        return "Low"
+    return "Medium"
+
+
+def _to_list(x: Any) -> List[str]:
+    if x is None:
+        return []
+    if isinstance(x, list):
+        return [str(i) for i in x if i is not None]
+    return [str(x)]
+
+
+def _collapse_citations(cits: Any) -> List[str]:
+    """Accepts None | str | dict | list[mixed]; returns list[str]."""
+    out: List[str] = []
+    if cits is None:
+        return out
+    src: Iterable[Any] = cits if isinstance(cits, list) else [cits]
+    for it in src:
+        if it is None:
+            continue
+        if isinstance(it, str):
+            out.append(it)
+        elif isinstance(it, dict):
+            url = it.get("url") or it.get("link")
+            if isinstance(url, str) and url.strip():
+                out.append(url.strip())
+                continue
+            inst = str(it.get("instrument") or "").strip()
+            sec = str(it.get("section") or "").strip()
+            if inst and sec:
+                out.append(f"{inst} §{sec}")
+                continue
+            title = str(it.get("title") or "").strip()
+            if title:
+                out.append(title)
+        else:
+            out.append(str(it))
+    return out
+
+
+# --- core API ---
+
+
+def adapt_finding_v1_to_v2(v1: Any, *, pack: str, rule_id: str) -> FindingV2:
+    """Convert a legacy v1 finding-like object to FindingV2."""
+    as_dict: Dict[str, Any] = {}
+    if hasattr(v1, "model_dump"):
+        as_dict = v1.model_dump()
+    elif hasattr(v1, "dict"):
+        as_dict = v1.dict()
+    elif isinstance(v1, dict):
+        as_dict = v1
+    else:
+        as_dict = {"message": str(v1)}
+
+    code = str(as_dict.get("code") or rule_id or "LEGACY").strip() or "LEGACY"
+    msg = str(as_dict.get("message") or "").strip()
+    sev = _norm_severity(as_dict.get("severity") or as_dict.get("severity_level"))
+    evidence = _to_list(as_dict.get("evidence"))
+    citations = _collapse_citations(as_dict.get("citations"))
+    flags = _to_list(as_dict.get("tags"))
+
+    now = datetime.now(timezone.utc)
+
+    locale = resolve_locale()
+    title = {locale: code, "uk": code}
+    message = {locale: msg or code, "uk": msg or code}
+    explain = {locale: "", "uk": ""}
+    suggestion = {locale: "", "uk": ""}
+
+    f2 = FindingV2(
+        id=code,
+        pack=pack,
+        rule_id=rule_id or code,
+        title=title,
+        severity=sev,
+        category=str(as_dict.get("category") or "General"),
+        message=message,
+        explain=explain,
+        suggestion=suggestion,
+        evidence=evidence,
+        citation=citations,
+        flags=flags,
+        meta={},
+        version=str(as_dict.get("version") or "2.0.0"),
+        created_at=now,
+        engine_version=ENGINE_VERSION,
+    )
+    return f2
+
+
+def run_legacy_rule(
+    rule_fn, context: Dict[str, Any], *, pack: str, rule_id: str
+) -> List[FindingV2]:
+    """Execute a legacy rule function and adapt its outputs."""
+    try:
+        res = rule_fn(context)
+    except Exception as e:  # pragma: no cover - deterministic path
+        return [
+            FindingV2(
+                id=f"{rule_id}:error",
+                pack=pack,
+                rule_id=rule_id,
+                title={"en": f"{rule_id} failed", "uk": f"{rule_id} failed"},
+                severity="High",
+                category="System",
+                message={"en": str(e), "uk": str(e)},
+                explain={
+                    "en": "Legacy rule execution failed",
+                    "uk": "Legacy rule execution failed",
+                },
+                suggestion={
+                    "en": "Check rule compatibility/migration",
+                    "uk": "Check rule compatibility/migration",
+                },
+                evidence=[],
+                citation=[],
+                flags=["legacy", "error"],
+                meta={},
+                version="2.0.0",
+                created_at=datetime.now(timezone.utc),
+                engine_version=ENGINE_VERSION,
+            )
+        ]
+
+    if res is None:
+        items: List[Any] = []
+    elif isinstance(res, list):
+        items = res
+    else:
+        items = [res]
+
+    out: List[FindingV2] = []
+    for it in items:
+        out.append(adapt_finding_v1_to_v2(it, pack=pack, rule_id=rule_id))
+    return out

--- a/contract_review_app/tests/rules_v2/test_adapter_migration.py
+++ b/contract_review_app/tests/rules_v2/test_adapter_migration.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime
+from typing import Any, Dict, List
+
+from contract_review_app.rules_v2.adapter import (
+    adapt_finding_v1_to_v2,
+    run_legacy_rule,
+)
+from contract_review_app.rules_v2.models import FindingV2
+
+
+def test_basic_mapping():
+    v1 = {
+        "code": "C1",
+        "message": "msg",
+        "severity_level": "warning",
+        "evidence": "proof",
+        "citations": [
+            {"url": "http://example.com"},
+            {"instrument": "Law", "section": "10"},
+            "extra",
+        ],
+        "tags": ["t1", None, "t2"],
+    }
+    f2 = adapt_finding_v1_to_v2(v1, pack="pack", rule_id="rule")
+    assert f2.id == "C1"
+    assert f2.severity == "Medium"
+    assert f2.evidence == ["proof"]
+    assert f2.citation == ["http://example.com", "Law §10", "extra"]
+    assert f2.flags == ["t1", "t2"]
+    assert f2.title["en"] == "C1"
+    assert f2.title["uk"] == "C1"
+    assert f2.message["en"] == "msg"
+    assert f2.message["uk"] == "msg"
+    assert f2.category == "General"
+    assert isinstance(f2.created_at, datetime)
+
+
+class ObjV2:
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+
+    def model_dump(self) -> Dict[str, Any]:
+        return self._data
+
+
+class ObjV1:
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+
+    def dict(self) -> Dict[str, Any]:
+        return self._data
+
+
+def test_pydantic_like_objects():
+    data = {"code": "X", "message": "mm"}
+    for obj in [ObjV2(data), ObjV1(data)]:
+        f2 = adapt_finding_v1_to_v2(obj, pack="p", rule_id="r")
+        assert f2.id == "X"
+        assert f2.message["en"] == "mm"
+
+
+def test_string_input():
+    f2 = adapt_finding_v1_to_v2("hello", pack="p", rule_id="r1")
+    assert f2.id == "r1"
+    assert f2.message["en"] == "hello"
+    assert f2.message["uk"] == "hello"
+    assert f2.severity == "Medium"
+
+
+def test_run_legacy_rule_variants():
+    def rule_single(ctx: Dict[str, Any]) -> Dict[str, Any]:
+        return {"code": "S", "message": "one"}
+
+    def rule_list(ctx: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return [{"code": "A"}, {"code": "B"}]
+
+    def rule_none(ctx: Dict[str, Any]) -> None:
+        return None
+
+    def rule_fail(ctx: Dict[str, Any]) -> None:
+        raise ValueError("boom")
+
+    out_single = run_legacy_rule(rule_single, {}, pack="p", rule_id="r1")
+    assert len(out_single) == 1 and isinstance(out_single[0], FindingV2)
+
+    out_list = run_legacy_rule(rule_list, {}, pack="p", rule_id="r2")
+    assert [f.id for f in out_list] == ["A", "B"]
+
+    out_none = run_legacy_rule(rule_none, {}, pack="p", rule_id="r3")
+    assert out_none == []
+
+    out_fail = run_legacy_rule(rule_fail, {}, pack="p", rule_id="r4")
+    assert len(out_fail) == 1
+    err = out_fail[0]
+    assert err.severity == "High"
+    assert "boom" in err.message["en"]
+    assert err.flags == ["legacy", "error"]
+
+
+def test_determinism():
+    v1 = {"code": "D", "message": "m"}
+    f2a = adapt_finding_v1_to_v2(v1, pack="p", rule_id="r")
+    f2b = adapt_finding_v1_to_v2(v1, pack="p", rule_id="r")
+    da = asdict(f2a)
+    db = asdict(f2b)
+    da.pop("created_at")
+    db.pop("created_at")
+    assert da == db
+    assert isinstance(f2a.created_at, datetime)


### PR DESCRIPTION
## Summary
- add adapter translating legacy rule findings to `FindingV2`
- wrap legacy rules to emit `FindingV2`
- test migration adapter for mapping, error handling, and determinism

## Testing
- `python -m black contract_review_app/rules_v2 contract_review_app/tests/rules_v2/test_adapter_migration.py`
- `ruff check contract_review_app/rules_v2 contract_review_app/tests/rules_v2/test_adapter_migration.py`
- `mypy --explicit-package-bases contract_review_app/rules_v2 contract_review_app/tests/rules_v2/test_adapter_migration.py`
- `PYTHONPATH=. pytest -q contract_review_app/tests/rules_v2/test_adapter_migration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b04b4ea2148325a8db92700afb9ae1