### PR TITLE
feat: add citation resolver and verification

### DIFF
--- a/contract_review_app/llm/__init__.py
+++ b/contract_review_app/llm/__init__.py
@@ -1,0 +1,1 @@
+"""Lightweight LLM utilities and orchestrator."""

--- a/contract_review_app/llm/citation_resolver.py
+++ b/contract_review_app/llm/citation_resolver.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urlparse
+
+_ALLOWED_DOMAINS = {
+    "www.legislation.gov.uk",
+    "www.courtservice.gov.uk",
+    "ico.org.uk",
+    "www.gov.uk",
+    "eur-lex.europa.eu",
+    "www.legislationline.org",
+}
+
+
+@dataclass(frozen=True)
+class ResolvedCitation:
+    id: str
+    system: str
+    instrument: str
+    section: str
+    url: Optional[str] = None
+    source: Optional[str] = None
+    title: Optional[str] = None
+
+
+def _norm_str(x: Any) -> str:
+    return (str(x or "")).strip()
+
+
+def _domain_ok(u: str) -> bool:
+    try:
+        netloc = urlparse(u).netloc.lower()
+    except Exception:
+        return False
+    return bool(netloc) and (netloc in _ALLOWED_DOMAINS)
+
+
+def normalize_citations(items: Any) -> List[ResolvedCitation]:
+    """
+    Accepts None|str|dict|list[mixed]; returns unique list of ResolvedCitation with whitelist filtering.
+    Dedup key: (system,instrument,section,url or '').
+    """
+    if items is None:
+        return []
+    src: Iterable[Any] = items if isinstance(items, list) else [items]
+    out: List[ResolvedCitation] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    idx = 1
+    for it in src:
+        sys = inst = sec = url = title = src_name = ""
+        if isinstance(it, str):
+            inst = _norm_str(it)
+        elif isinstance(it, dict):
+            sys = _norm_str(it.get("system"))
+            inst = _norm_str(it.get("instrument"))
+            sec = _norm_str(it.get("section"))
+            url = _norm_str(it.get("url") or it.get("link"))
+            title = _norm_str(it.get("title"))
+            src_name = _norm_str(it.get("source"))
+        else:
+            inst = _norm_str(it)
+        # URL whitelist (if present)
+        if url and not _domain_ok(url):
+            url = ""
+        key = (sys or "UK", inst, sec, url)
+        if key in seen:
+            continue
+        seen.add(key)
+        cid = f"c{idx}"
+        idx += 1
+        out.append(
+            ResolvedCitation(
+                id=cid,
+                system=sys or "UK",
+                instrument=inst or "unknown",
+                section=sec,
+                url=url or None,
+                source=src_name or None,
+                title=title or None,
+            )
+        )
+    return out
+
+
+def make_grounding_pack(
+    question: str, context_text: str, citations: Any
+) -> Dict[str, Any]:
+    """
+    Build a deterministic grounding package for prompt_builder.
+    Evidence items are derived from normalized citations.
+    """
+    norm = normalize_citations(citations)
+    evidence: List[Dict[str, Any]] = []
+    for rc in norm:
+        label = f"{rc.instrument} §{rc.section}".strip()
+        src = rc.url or rc.source or rc.system
+        evidence.append({"id": rc.id, "text": label, "source": src})
+    return {
+        "question": question or "",
+        "context": context_text or "",
+        "citations": [c.__dict__ for c in norm],
+        "evidence": evidence,
+    }

--- a/contract_review_app/llm/orchestrator.py
+++ b/contract_review_app/llm/orchestrator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .provider import LLMConfig, LLMProvider
+from .prompt_builder import build_prompt
+from .citation_resolver import make_grounding_pack
+from .verification import verify_output_contains_citations
+
+
+class Orchestrator:
+    def __init__(self, provider: LLMProvider, config: LLMConfig | None = None):
+        self.provider = provider
+        self.config = config or LLMConfig()
+
+    def draft(
+        self, *, question: str = "", context_text: str = "", citations: Any = None
+    ) -> Dict[str, Any]:
+        gp = make_grounding_pack(question, context_text, citations)
+        prompt = build_prompt("draft", gp)
+        res = self.provider.generate(prompt, self.config)
+        status = verify_output_contains_citations(res.text, gp.get("evidence") or [])
+        return {
+            "prompt": prompt,
+            "result": res.text,
+            "usage": res.usage,
+            "model": res.model,
+            "provider": res.provider,
+            "verification_status": status,
+            "grounding_trace": {
+                "citations": gp.get("citations", []),
+                "evidence": gp.get("evidence", []),
+            },
+        }
+
+    def suggest_edits(
+        self, *, question: str = "", context_text: str = "", citations: Any = None
+    ) -> Dict[str, Any]:
+        gp = make_grounding_pack(question, context_text, citations)
+        prompt = build_prompt("suggest_edits", gp)
+        res = self.provider.generate(prompt, self.config)
+        status = verify_output_contains_citations(res.text, gp.get("evidence") or [])
+        return {
+            "prompt": prompt,
+            "result": res.text,
+            "usage": res.usage,
+            "model": res.model,
+            "provider": res.provider,
+            "verification_status": status,
+            "grounding_trace": {
+                "citations": gp.get("citations", []),
+                "evidence": gp.get("evidence", []),
+            },
+        }

--- a/contract_review_app/llm/prompt_builder.py
+++ b/contract_review_app/llm/prompt_builder.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def build_prompt(mode: str, grounding: Dict[str, Any]) -> str:
+    """Build a deterministic prompt using the grounding package."""
+    lines: List[str] = []
+    lines.append(f"mode: {mode}")
+    lines.append(f"question: {grounding.get('question', '')}")
+    lines.append(f"context: {grounding.get('context', '')}")
+    evidence = grounding.get("evidence") or []
+    if evidence:
+        lines.append("EVIDENCE:")
+        for ev in evidence:
+            src = ev.get("source", "")
+            lines.append(f"> [{ev.get('id')}] {ev.get('text')} ({src})")
+    return "\n".join(lines)

--- a/contract_review_app/llm/provider.py
+++ b/contract_review_app/llm/provider.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass
+class LLMConfig:
+    """Minimal configuration for LLM requests."""
+
+    temperature: float = 0.0
+    top_p: float = 1.0
+
+
+@dataclass
+class LLMResult:
+    """Container for LLM responses."""
+
+    text: str
+    usage: Any
+    model: str = ""
+    provider: str = ""
+
+
+class LLMProvider(Protocol):
+    """Protocol for LLM providers."""
+
+    def generate(self, prompt: str, config: LLMConfig) -> LLMResult: ...

--- a/contract_review_app/llm/verification.py
+++ b/contract_review_app/llm/verification.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal
+
+Status = Literal["verified", "partially_verified", "unverified", "failed"]
+
+
+def verify_output_contains_citations(
+    result_text: str, evidence: List[Dict[str, Any]]
+) -> Status:
+    """
+    Heuristic: 'verified' if all evidence ids like [c1],[c2] appear; 'partially_verified' if some;
+    'unverified' if none. 'failed' only if result_text empty.
+    """
+    if not (result_text or "").strip():
+        return "failed"
+    ids = [str(e.get("id") or "").strip() for e in evidence if e.get("id")]
+    if not ids:
+        return "unverified"
+    found = 0
+    for cid in ids:
+        marker = f"[{cid}]"
+        if marker in result_text:
+            found += 1
+    if found == len(ids):
+        return "verified"
+    if found == 0:
+        return "unverified"
+    return "partially_verified"

--- a/contract_review_app/tests/llm/test_citation_resolver.py
+++ b/contract_review_app/tests/llm/test_citation_resolver.py
@@ -1,0 +1,49 @@
+from contract_review_app.llm.citation_resolver import (
+    make_grounding_pack,
+    normalize_citations,
+)
+
+
+def test_normalize_citations_dedup_and_whitelist():
+    items = [
+        {
+            "system": "UK",
+            "instrument": "Data Protection Act 2018",
+            "section": "1",
+            "url": "https://www.legislation.gov.uk/ukpga/2018/12/section/1",
+        },
+        {
+            "system": "UK",
+            "instrument": "Data Protection Act 2018",
+            "section": "1",
+            "url": "https://www.legislation.gov.uk/ukpga/2018/12/section/1",
+        },
+        {
+            "instrument": "Unlisted Act",
+            "section": "10",
+            "url": "https://example.com/bad",
+        },
+        "Plain Instrument",
+    ]
+    norm = normalize_citations(items)
+    assert [c.id for c in norm] == ["c1", "c2", "c3"]
+    assert norm[0].url and "legislation.gov.uk" in norm[0].url
+    assert norm[1].url is None
+    assert norm[2].instrument == "Plain Instrument"
+
+
+def test_make_grounding_pack_builds_evidence():
+    items = [
+        {
+            "instrument": "Act A",
+            "section": "10",
+            "url": "https://www.legislation.gov.uk/a",
+        },
+        "Act B",
+    ]
+    gp = make_grounding_pack("What?", "Context", items)
+    assert gp["question"] == "What?"
+    assert gp["context"] == "Context"
+    assert [e["id"] for e in gp["evidence"]] == ["c1", "c2"]
+    assert gp["evidence"][0]["source"] == "https://www.legislation.gov.uk/a"
+    assert gp["evidence"][1]["source"] == "UK"

--- a/contract_review_app/tests/llm/test_orchestrator_integration_cmd2.py
+++ b/contract_review_app/tests/llm/test_orchestrator_integration_cmd2.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+from contract_review_app.llm.orchestrator import Orchestrator
+from contract_review_app.llm.provider import LLMConfig
+
+
+class EchoProvider:
+    def __init__(self, include_markers: bool = True):
+        self.include_markers = include_markers
+
+    def generate(self, prompt: str, config: LLMConfig):
+        text = prompt
+        if not self.include_markers:
+            import re
+
+            text = re.sub(r"\[c\d+\]", "", text)
+        return SimpleNamespace(text=text, usage={}, model="mock", provider="mock")
+
+
+def _sample_citations():
+    return [
+        {
+            "system": "UK",
+            "instrument": "Act1",
+            "section": "10",
+            "url": "https://www.legislation.gov.uk/a",
+        },
+        {
+            "system": "UK",
+            "instrument": "Act2",
+            "section": "20",
+            "url": "https://example.com/bad",
+        },
+        "Act3",
+    ]
+
+
+def test_draft_with_citations_verified():
+    orch = Orchestrator(EchoProvider(True))
+    out = orch.draft(question="Q", context_text="Ctx", citations=_sample_citations())
+    assert "> [c1]" in out["prompt"]
+    assert [e["id"] for e in out["grounding_trace"]["evidence"]] == ["c1", "c2", "c3"]
+    assert out["verification_status"] == "verified"
+
+
+def test_suggest_edits_unverified_when_markers_absent():
+    orch = Orchestrator(EchoProvider(False))
+    out = orch.suggest_edits(
+        question="Q", context_text="Ctx", citations=_sample_citations()
+    )
+    assert out["verification_status"] == "unverified"
+    assert "> [c1]" in out["prompt"]

--- a/contract_review_app/tests/llm/test_verification_stub.py
+++ b/contract_review_app/tests/llm/test_verification_stub.py
@@ -1,0 +1,24 @@
+from contract_review_app.llm.verification import verify_output_contains_citations
+
+
+def test_verification_all_ids_present():
+    evidence = [{"id": "c1"}, {"id": "c2"}]
+    text = "See [c1] and [c2] for details."
+    assert verify_output_contains_citations(text, evidence) == "verified"
+
+
+def test_verification_none_present():
+    evidence = [{"id": "c1"}, {"id": "c2"}]
+    text = "No markers here."
+    assert verify_output_contains_citations(text, evidence) == "unverified"
+
+
+def test_verification_partial():
+    evidence = [{"id": "c1"}, {"id": "c2"}]
+    text = "Only [c1] present."
+    assert verify_output_contains_citations(text, evidence) == "partially_verified"
+
+
+def test_verification_failed_if_empty():
+    evidence = [{"id": "c1"}]
+    assert verify_output_contains_citations(" ", evidence) == "failed"


### PR DESCRIPTION
## Summary
- add deterministic citation resolver and grounding pack builder
- add simple citation verification and expose in orchestrator outputs
- wire citation handling and verification into draft and suggest edits flows

## Testing
- `black contract_review_app/llm contract_review_app/tests/llm`
- `ruff check contract_review_app/llm contract_review_app/tests/llm`
- `mypy contract_review_app/llm`
- `PYTHONPATH=. pytest -q contract_review_app/tests/llm/test_citation_resolver.py`
- `PYTHONPATH=. pytest -q contract_review_app/tests/llm/test_verification_stub.py`
- `PYTHONPATH=. pytest -q contract_review_app/tests/llm/test_orchestrator_integration_cmd2.py`
- `PYTHONPATH=. pytest -q contract_review_app/tests/llm`

------
https://chatgpt.com/codex/tasks/task_e_68b04e04cbe88325b7f96c246973ead8