### PR TITLE
feat: add llm proxy with provider registry

### DIFF
--- a/contract_review_app/llm/__init__.py
+++ b/contract_review_app/llm/__init__.py
@@ -1,0 +1,4 @@
+from .orchestrator import Orchestrator
+from .provider import LLMConfig, LLMResult, LLMProvider, MockProvider
+
+__all__ = ["Orchestrator", "LLMConfig", "LLMResult", "LLMProvider", "MockProvider"]

--- a/contract_review_app/llm/orchestrator.py
+++ b/contract_review_app/llm/orchestrator.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .provider import LLMConfig, LLMProvider, LLMResult
+from .provider.proxy import ProxyProvider
+
+
+@dataclass
+class Query:
+    question: str
+    context: str
+
+
+class Orchestrator:
+    """Simple orchestrator routing prompts through an LLM provider."""
+
+    def __init__(
+        self,
+        provider: Optional[LLMProvider] = None,
+        config: Optional[LLMConfig] = None,
+    ) -> None:
+        self.provider = provider or ProxyProvider()
+        self.config = config or LLMConfig()
+
+    def _compose_prompt(self, question: str, context: str) -> str:
+        return f"{question}\n{context}".strip()
+
+    def draft(self, question: str, context: str) -> LLMResult:
+        prompt = self._compose_prompt(question, context)
+        return self.provider.generate(prompt, self.config)
+
+    def suggest_edits(self, question: str, context: str) -> LLMResult:
+        prompt = self._compose_prompt(question, context)
+        return self.provider.generate(prompt, self.config)

--- a/contract_review_app/llm/provider/__init__.py
+++ b/contract_review_app/llm/provider/__init__.py
@@ -1,0 +1,4 @@
+from .base import LLMProvider, LLMConfig, LLMResult
+from .mock_provider import MockProvider
+
+__all__ = ["LLMProvider", "LLMConfig", "LLMResult", "MockProvider"]

--- a/contract_review_app/llm/provider/base.py
+++ b/contract_review_app/llm/provider/base.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class LLMConfig:
+    """Configuration for LLM providers.
+
+    For now this class is intentionally minimal; fields can be extended later
+    without breaking compatibility.
+    """
+
+    pass
+
+
+@dataclass
+class LLMResult:
+    text: str
+    provider: str
+
+
+class LLMProvider:
+    """Abstract base class for all LLM providers."""
+
+    def generate(
+        self, prompt: str, config: LLMConfig
+    ) -> LLMResult:  # pragma: no cover - interface
+        raise NotImplementedError

--- a/contract_review_app/llm/provider/mock_provider.py
+++ b/contract_review_app/llm/provider/mock_provider.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from .base import LLMProvider, LLMConfig, LLMResult
+
+
+class MockProvider(LLMProvider):
+    """Deterministic mock provider used for tests and local development."""
+
+    def generate(self, prompt: str, config: LLMConfig) -> LLMResult:
+        return LLMResult(text=f"MOCK:{prompt}", provider="mock")

--- a/contract_review_app/llm/provider/proxy.py
+++ b/contract_review_app/llm/provider/proxy.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Dict, List, Optional
+
+from .base import LLMProvider, LLMConfig, LLMResult
+from .mock_provider import MockProvider
+
+
+# Stub providers ------------------------------------------------------------
+
+
+class OpenAIProvider(LLMProvider):
+    def generate(
+        self, prompt: str, config: LLMConfig
+    ) -> LLMResult:  # pragma: no cover - stub
+        raise NotImplementedError("OpenAIProvider not yet implemented")
+
+
+class AzureProvider(LLMProvider):
+    def generate(
+        self, prompt: str, config: LLMConfig
+    ) -> LLMResult:  # pragma: no cover - stub
+        raise NotImplementedError("AzureProvider not yet implemented")
+
+
+class AnthropicProvider(LLMProvider):
+    def generate(
+        self, prompt: str, config: LLMConfig
+    ) -> LLMResult:  # pragma: no cover - stub
+        raise NotImplementedError("AnthropicProvider not yet implemented")
+
+
+# Registry -----------------------------------------------------------------
+
+
+class ProviderRegistry:
+    def __init__(self) -> None:
+        self._providers: Dict[str, LLMProvider] = {
+            "mock": MockProvider(),
+            "openai": OpenAIProvider(),
+            "azure": AzureProvider(),
+            "anthropic": AnthropicProvider(),
+        }
+
+    def get(self, name: str) -> LLMProvider:
+        if name not in self._providers:
+            raise KeyError(f"Unknown provider: {name}")
+        return self._providers[name]
+
+
+# Proxy provider ------------------------------------------------------------
+
+
+class ProxyProvider(LLMProvider):
+    def __init__(self, registry: Optional[ProviderRegistry] = None) -> None:
+        self.registry = registry or ProviderRegistry()
+        raw = os.getenv("CONTRACTAI_LLM_PROVIDERS", "mock")
+        self.providers_order: List[str] = [
+            p.strip().lower() for p in raw.split(",") if p.strip()
+        ]
+        self.max_retries: int = int(os.getenv("CONTRACTAI_LLM_MAX_RETRIES", "2"))
+
+    def generate(self, prompt: str, config: LLMConfig) -> LLMResult:
+        last_exc: Optional[Exception] = None
+        for name in self.providers_order:
+            provider = self.registry.get(name)
+            for attempt in range(1, self.max_retries + 1):
+                try:
+                    return provider.generate(prompt, config)
+                except NotImplementedError as e:
+                    last_exc = e
+                    break  # provider unsupported; try next
+                except Exception as e:  # pragma: no cover - deterministic retry
+                    last_exc = e
+                    if attempt < self.max_retries:
+                        time.sleep(0.01)
+                        continue
+                    break
+        if last_exc:
+            raise last_exc
+        raise RuntimeError("No providers available")

--- a/contract_review_app/tests/llm/test_orchestrator_proxy_integration.py
+++ b/contract_review_app/tests/llm/test_orchestrator_proxy_integration.py
@@ -1,0 +1,30 @@
+import pytest
+
+from contract_review_app.llm.orchestrator import Orchestrator
+from contract_review_app.llm.provider.proxy import ProxyProvider
+
+
+def test_orchestrator_uses_proxy(monkeypatch):
+    monkeypatch.delenv("CONTRACTAI_LLM_PROVIDERS", raising=False)
+    orch = Orchestrator()
+    assert isinstance(orch.provider, ProxyProvider)
+    res_draft = orch.draft("Q", "C")
+    res_suggest = orch.suggest_edits("Q", "C")
+    for res in (res_draft, res_suggest):
+        assert res.provider == "mock"
+        assert "MOCK:" in res.text
+
+
+def test_orchestrator_no_fallback(monkeypatch):
+    monkeypatch.setenv("CONTRACTAI_LLM_PROVIDERS", "openai")
+    orch = Orchestrator()
+    with pytest.raises(NotImplementedError):
+        orch.draft("Q", "C")
+
+
+def test_orchestrator_fallback(monkeypatch):
+    monkeypatch.setenv("CONTRACTAI_LLM_PROVIDERS", "openai,mock")
+    orch = Orchestrator()
+    res = orch.draft("Q", "C")
+    assert res.provider == "mock"
+    assert res.text.startswith("MOCK:")

--- a/contract_review_app/tests/llm/test_proxy_provider.py
+++ b/contract_review_app/tests/llm/test_proxy_provider.py
@@ -1,0 +1,57 @@
+import pytest
+
+from contract_review_app.llm.provider.proxy import ProxyProvider
+from contract_review_app.llm.provider import LLMConfig, MockProvider
+
+
+def test_default_env_uses_mock(monkeypatch):
+    monkeypatch.delenv("CONTRACTAI_LLM_PROVIDERS", raising=False)
+    proxy = ProxyProvider()
+    assert proxy.providers_order == ["mock"]
+    cfg = LLMConfig()
+    res1 = proxy.generate("hello", cfg)
+    res2 = proxy.generate("hello", cfg)
+    assert res1.text == "MOCK:hello"
+    assert res1 == res2
+    assert res1.provider == "mock"
+
+
+def test_fallback_to_mock(monkeypatch):
+    monkeypatch.setenv("CONTRACTAI_LLM_PROVIDERS", "openai,mock")
+    proxy = ProxyProvider()
+    cfg = LLMConfig()
+    res = proxy.generate("hi", cfg)
+    assert res.provider == "mock"
+    assert res.text.startswith("MOCK:")
+
+
+def test_max_retries(monkeypatch):
+    monkeypatch.setenv("CONTRACTAI_LLM_PROVIDERS", "mock")
+    monkeypatch.setenv("CONTRACTAI_LLM_MAX_RETRIES", "1")
+    calls = {"count": 0}
+
+    def boom(self, prompt, config):
+        calls["count"] += 1
+        raise ValueError("boom")
+
+    monkeypatch.setattr(MockProvider, "generate", boom, raising=False)
+    proxy = ProxyProvider()
+    with pytest.raises(ValueError):
+        proxy.generate("x", LLMConfig())
+    assert calls["count"] == 1
+
+
+def test_no_providers(monkeypatch):
+    monkeypatch.setenv("CONTRACTAI_LLM_PROVIDERS", "")
+    proxy = ProxyProvider()
+    with pytest.raises(RuntimeError):
+        proxy.generate("x", LLMConfig())
+
+
+def test_determinism(monkeypatch):
+    monkeypatch.delenv("CONTRACTAI_LLM_PROVIDERS", raising=False)
+    proxy = ProxyProvider()
+    cfg = LLMConfig()
+    out1 = proxy.generate("foo", cfg)
+    out2 = proxy.generate("foo", cfg)
+    assert out1 == out2


### PR DESCRIPTION
## Summary
- add LLM provider proxy with registry, env-based selection, and retry/fallback
- default orchestrator to use ProxyProvider
- test proxy provider and orchestrator integration

## Testing
- `ruff check contract_review_app/llm contract_review_app/tests/llm`
- `black contract_review_app/llm contract_review_app/tests/llm`
- `mypy contract_review_app/llm`
- `PYTHONPATH=. pytest -q contract_review_app/tests/llm/test_proxy_provider.py`
- `PYTHONPATH=. pytest -q contract_review_app/tests/llm/test_orchestrator_proxy_integration.py`
- `PYTHONPATH=. pytest -q contract_review_app/tests/llm`


------
https://chatgpt.com/codex/tasks/task_e_68b04e370ef083259ae37d69d1305cc8