### PR TITLE
Add gated LLM API routes and tests

### DIFF
--- a/contract_review_app/llm/api_dto.py
+++ b/contract_review_app/llm/api_dto.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class CitationIn(BaseModel):
+    system: Optional[str] = None
+    instrument: Optional[str] = None
+    section: Optional[str] = None
+    url: Optional[HttpUrl] = None
+    title: Optional[str] = None
+    source: Optional[str] = None
+
+
+class DraftRequest(BaseModel):
+    question: str = Field(default="")
+    context_text: str = Field(default="")
+    citations: List[CitationIn] = Field(default_factory=list)
+
+
+class SuggestEditsRequest(BaseModel):
+    question: str = Field(default="")
+    context_text: str = Field(default="")
+    citations: List[CitationIn] = Field(default_factory=list)
+
+
+class LLMResponse(BaseModel):
+    provider: str
+    model: str
+    result: str
+    prompt: str
+    verification_status: Optional[str] = None
+    grounding_trace: Dict[str, Any] = Field(default_factory=dict)
+    usage: Dict[str, int] = Field(default_factory=dict)

--- a/contract_review_app/llm/api_router.py
+++ b/contract_review_app/llm/api_router.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter
+
+from .api_dto import DraftRequest, SuggestEditsRequest, LLMResponse
+
+try:  # pragma: no cover - prefer real orchestrator if available
+    from .orchestrator import Orchestrator  # type: ignore
+except Exception:  # pragma: no cover - fallback mock
+
+    class Orchestrator:  # type: ignore
+        """Deterministic mock orchestrator used in tests."""
+
+        provider = "mock"
+        model = "mock-legal-v1"
+
+        def _build_prompt(
+            self, question: str, context_text: str, citations: List[Dict[str, Any]]
+        ) -> str:
+            labels = [
+                f"{c.get('instrument', '')} §{c.get('section', '')}".strip()
+                for c in citations
+            ]
+            evidence = "\n".join(labels)
+            return f"{question}\n\n<<EVIDENCE>>\n{evidence}".strip()
+
+        def draft(
+            self,
+            question: str,
+            context_text: str,
+            citations: List[Dict[str, Any]],
+        ) -> Dict[str, Any]:
+            prompt = self._build_prompt(question, context_text, citations)
+            return {
+                "provider": self.provider,
+                "model": self.model,
+                "result": f"Draft: {question}",
+                "prompt": prompt,
+                "verification_status": "unverified",
+                "grounding_trace": {"citations": citations},
+                "usage": {},
+            }
+
+        def suggest_edits(
+            self,
+            question: str,
+            context_text: str,
+            citations: List[Dict[str, Any]],
+        ) -> Dict[str, Any]:
+            prompt = self._build_prompt(question, context_text, citations)
+            return {
+                "provider": self.provider,
+                "model": self.model,
+                "result": f"Suggest: {question}",
+                "prompt": prompt,
+                "verification_status": "unverified",
+                "grounding_trace": {"citations": citations},
+                "usage": {},
+            }
+
+
+router = APIRouter(tags=["llm"])
+
+
+@router.post("/draft", response_model=LLMResponse)
+def api_draft(req: DraftRequest) -> LLMResponse:
+    orch = Orchestrator()  # ProxyProvider → Mock by default
+    out = orch.draft(
+        question=req.question,
+        context_text=req.context_text,
+        citations=[c.model_dump() for c in req.citations],
+    )
+    return LLMResponse(**out)
+
+
+@router.post("/suggest_edits", response_model=LLMResponse)
+def api_suggest(req: SuggestEditsRequest) -> LLMResponse:
+    orch = Orchestrator()
+    out = orch.suggest_edits(
+        question=req.question,
+        context_text=req.context_text,
+        citations=[c.model_dump() for c in req.citations],
+    )
+    return LLMResponse(**out)

--- a/contract_review_app/tests/api/test_llm_api_routes.py
+++ b/contract_review_app/tests/api/test_llm_api_routes.py
@@ -1,0 +1,69 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+
+def test_routes_absent_by_default():
+    os.environ.pop("CONTRACTAI_LLM_API", None)
+    from contract_review_app.api import app as app_mod
+
+    client = TestClient(app_mod.app)
+    r = client.get("/openapi.json")
+    assert r.status_code == 200
+    r2 = client.post("/api/gpt/draft", json={})
+    assert r2.status_code == 404
+
+
+def build_client() -> TestClient:
+    os.environ["CONTRACTAI_LLM_API"] = "1"
+    mod = importlib.import_module("contract_review_app.api.app")
+    importlib.reload(mod)
+    return TestClient(mod.app)
+
+
+def test_routes_enabled(monkeypatch):
+    client = build_client()
+    body = {
+        "question": "What is the term?",
+        "context_text": "The term is five years.",
+        "citations": [
+            {
+                "instrument": "NDA",
+                "section": "5",
+                "system": "us",
+                "url": "https://example.com/nda#5",
+            }
+        ],
+    }
+    resp = client.post("/api/gpt/draft", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["provider"] == "mock"
+    assert data["model"] == "mock-legal-v1"
+    assert data["verification_status"] in {
+        "verified",
+        "partially_verified",
+        "unverified",
+        "failed",
+    }
+    assert "<<EVIDENCE>>" in data["prompt"]
+    assert "NDA §5" in data["prompt"]
+
+    resp2 = client.post("/api/gpt/suggest_edits", json=body)
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    assert data2["provider"] == "mock"
+    assert data2["model"] == "mock-legal-v1"
+    assert data2["verification_status"] in {
+        "verified",
+        "partially_verified",
+        "unverified",
+        "failed",
+    }
+    assert "<<EVIDENCE>>" in data2["prompt"]
+    assert "NDA §5" in data2["prompt"]


### PR DESCRIPTION
## Summary
- add Pydantic DTOs for LLM draft/suggest requests and responses
- wire FastAPI router for `/api/gpt/draft` and `/api/gpt/suggest_edits` behind `CONTRACTAI_LLM_API`
- cover new LLM routes with tests for flag-off and flag-on scenarios

## Testing
- `black contract_review_app/llm/api_dto.py contract_review_app/llm/api_router.py contract_review_app/api/app.py contract_review_app/tests/api/test_llm_api_routes.py`
- `ruff check contract_review_app/llm/api_dto.py contract_review_app/llm/api_router.py contract_review_app/api/app.py contract_review_app/tests/api/test_llm_api_routes.py`
- `mypy --explicit-package-bases contract_review_app/llm/api_dto.py contract_review_app/llm/api_router.py contract_review_app/api/app.py contract_review_app/tests/api/test_llm_api_routes.py` *(fails: missing type stubs in unrelated modules)*
- `pytest -q contract_review_app/tests/api/test_llm_api_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b04e9ccd0483259822ec70269f49cd