### PR TITLE
Fix/codex review feedback

### DIFF
--- a/contract_review_app/rules_v2/loader.py
+++ b/contract_review_app/rules_v2/loader.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 import yaml
 
@@ -12,78 +12,60 @@ from .vm import RuleVM
 from .yaml_schema import RuleYaml
 
 
+# ---------- Discover: no YAML parsing, detect by file presence ----------
 def discover(root: Path) -> List[RuleSource]:
     root_path = Path(root)
     file_map: Dict[Tuple[str, str], Dict[str, Path]] = {}
+
     for path in root_path.rglob("*"):
         if not path.is_file() or path.suffix not in {".py", ".yaml"}:
             continue
-        base = path.with_suffix("")
+        base = path.with_suffix("")  # same basename for .py / .yaml
         key = (str(base), path.parent.name)
         entry = file_map.setdefault(key, {})
         entry["py" if path.suffix == ".py" else "yaml"] = path
+
     sources: List[RuleSource] = []
     for (base, pack), files in sorted(file_map.items()):
-        yaml_file = files.get("yaml")
+        name = Path(base).name
         py_file = files.get("py")
-        py_ref = None
-        if yaml_file:
-            raw_yaml = yaml_file.read_text(encoding="utf-8").replace(":{", ": {")
-            try:
-                data = yaml.safe_load(raw_yaml) or {}
-                ref = data.get("python")
-                if isinstance(ref, str) and ref.strip():
-                    py_ref = yaml_file.parent / ref.strip()
-            except Exception:
-                py_ref = None
+        yaml_file = files.get("yaml")
+
         if py_file and yaml_file:
-            valid_yaml = bool(data and isinstance(data, dict) and data.get("id") and data.get("pack"))
-            if py_ref or valid_yaml:
-                sources.append(
-                    RuleSource(
-                        id=Path(base).name,
-                        pack=pack,
-                        format=RuleFormat.HYBRID,
-                        path=yaml_file,
-                        py_path=py_ref or py_file,
-                        yaml_path=yaml_file,
-                    )
+            sources.append(
+                RuleSource(
+                    id=name,
+                    pack=pack,
+                    format=RuleFormat.HYBRID,
+                    path=yaml_file,            # основная точка — YAML
+                    py_path=py_file,
+                    yaml_path=yaml_file,
                 )
-            else:
-                sources.append(
-                    RuleSource(
-                        id=Path(base).name,
-                        pack=pack,
-                        format=RuleFormat.PYTHON,
-                        path=py_file,
-                        py_path=py_file,
-                    )
-                )
+            )
         elif py_file:
             sources.append(
                 RuleSource(
-                    id=Path(base).name,
+                    id=name,
                     pack=pack,
                     format=RuleFormat.PYTHON,
                     path=py_file,
                     py_path=py_file,
                 )
             )
-        else:
-            fmt = RuleFormat.HYBRID if py_ref else RuleFormat.YAML
+        else:  # yaml only
             sources.append(
                 RuleSource(
-                    id=Path(base).name,
+                    id=name,
                     pack=pack,
-                    format=fmt,
-                    path=yaml_file,
-                    py_path=py_ref,
+                    format=RuleFormat.YAML,
+                    path=yaml_file,            # type: ignore[arg-type]
                     yaml_path=yaml_file,
                 )
             )
     return sources
 
 
+# ---------- Python rule loader ----------
 def _load_python(path: Path):
     spec = importlib.util.spec_from_file_location(path.stem, path)
     if spec is None or spec.loader is None:
@@ -93,23 +75,54 @@ def _load_python(path: Path):
     return module
 
 
+# ---------- Coercion helpers for Python rule return values ----------
+def _coerce_one(obj: Any) -> FindingV2:
+    if isinstance(obj, FindingV2):
+        return obj
+    if isinstance(obj, dict):
+        # pydantic v2 first (model_validate), fallback to constructor
+        if hasattr(FindingV2, "model_validate"):
+            return FindingV2.model_validate(obj)  # type: ignore[attr-defined]
+        return FindingV2(**obj)
+    raise TypeError(f"Invalid finding item: {type(obj)!r}")
+
+
+def _coerce_findings(ret: Any) -> List[FindingV2]:
+    if ret is None:
+        return []
+    items: Iterable[Any] = ret if isinstance(ret, list) else [ret]
+    out: List[FindingV2] = []
+    for it in items:
+        try:
+            out.append(_coerce_one(it))
+        except Exception:
+            # мягкая устойчивость к мусорным элементам во имя обратной совместимости
+            continue
+    return out
+
+
+# ---------- Execute ----------
 def execute(source: RuleSource, context: Dict[str, Any]) -> List[FindingV2]:
     if source.format in {RuleFormat.PYTHON, RuleFormat.HYBRID}:
         module = _load_python(source.py_path or source.path)
         fn = getattr(module, "apply", None) or getattr(module, "rule_main", None)
         if not callable(fn):
             return []
-        return fn(context) or []
+        ret = fn(context)
+        return _coerce_findings(ret)
+
     if source.format is RuleFormat.YAML:
-        raw = source.path.read_text(encoding="utf-8").replace(":{", ": {")
+        raw = source.path.read_text(encoding="utf-8")
         data = yaml.safe_load(raw)
         rule = RuleYaml.model_validate(data)
         if rule.engine_version != ENGINE_VERSION:
             raise ValueError("engine_version mismatch")
         return RuleVM(rule).evaluate(context)
+
     raise NotImplementedError(str(source.format))
 
 
+# ---------- High-level wrapper ----------
 class PolicyPackLoader:
     def __init__(self, root: Path):
         self.root = Path(root)

--- a/dataclasses.py
+++ b/dataclasses.py
@@ -1,17 +1,1 @@
-import importlib.util as _util
-import importlib.machinery as _machinery
 
-_loader = _machinery.SourceFileLoader('dataclasses', '/usr/lib/python3.12/dataclasses.py')
-_spec = _util.spec_from_loader('dataclasses', _loader)
-_dataclasses = _util.module_from_spec(_spec)
-_loader.exec_module(_dataclasses)
-
-__all__ = _dataclasses.__all__
-for _name in __all__:
-    globals()[_name] = getattr(_dataclasses, _name)
-
-
-def asdict(obj, *, dict_factory=dict):  # type: ignore[override]
-    if hasattr(obj, 'model_dump'):
-        return obj.model_dump()
-    return _dataclasses.asdict(obj, dict_factory=dict_factory)


### PR DESCRIPTION
@codex implement the following fixes and open a PR:

1) Replace the top-level dataclasses.py with a dynamic stdlib shim (or delete if unused).
   - No hardcoded path to /usr/lib/python3.12. Use importlib.import_module("dataclasses") and re-export.

2) In contract_review_app/rules_v2/loader.py:
   - discover(): do not parse YAML; detect HYBRID by presence of .py and .yaml files; avoid UnboundLocalError.
   - execute(): reintroduce result coercion so dict/single item returns are normalized to List[FindingV2]
     (prefer FindingV2.model_validate if available; fallback to constructor).

3) Run tests:
   pytest -q contract_review_app/tests/rules_v2 --maxfail=1
   pytest -q contract_review_app/tests/llm -k "provider or orchestrator or proxy" --maxfail=1
   pytest -q contract_review_app/tests/intake --maxfail=1
   pytest -q contract_review_app/tests/test_citations_block1.py tests/codex/test_citations_doctor.py --maxfail=1

Ensure no SyntaxError and no merge markers remain.
@codex review