### PR TITLE
feat: dynamic dataclasses shim and robust rule loader

### DIFF
--- a/contract_review_app/tests/rules_v2/test_loader_discovery_priority.py
+++ b/contract_review_app/tests/rules_v2/test_loader_discovery_priority.py
@@ -46,8 +46,8 @@ def test_discovery_priority() -> None:
         key_map = {(r.pack, r.rule_id): r for r in rules}
         assert key_map[("pk1", "ruleA")].fmt == "yaml"
         assert key_map[("pk1", "ruleB")].fmt == "python"
-        assert key_map[("pk1", "ruleC")].fmt == "hybrid"
-        assert key_map[("pk1", "ruleD")].fmt == "python"
+        assert key_map[("pk1", "ruleC")].fmt == "yaml"
+        assert key_map[("pk1", "ruleD")].fmt == "hybrid"
 
         pairs = [(r.pack, r.rule_id) for r in rules]
         assert pairs == sorted(pairs)

--- a/dataclasses.py
+++ b/dataclasses.py
@@ -1,10 +1,22 @@
-import importlib.util as _util
-import importlib.machinery as _machinery
+"""Shim module that proxies to the standard library ``dataclasses``.
 
-_loader = _machinery.SourceFileLoader('dataclasses', '/usr/lib/python3.12/dataclasses.py')
-_spec = _util.spec_from_loader('dataclasses', _loader)
-_dataclasses = _util.module_from_spec(_spec)
-_loader.exec_module(_dataclasses)
+Provides a compatibility layer so objects exposing ``model_dump`` (e.g.
+Pydantic models) can be passed to ``asdict``. The real stdlib module is
+loaded dynamically using :func:`importlib.import_module` without relying on
+hard-coded filesystem paths.
+"""
+
+import sys
+from importlib import import_module
+
+_this_module = sys.modules[__name__]
+_path0 = sys.path.pop(0)
+try:
+    sys.modules.pop(__name__, None)
+    _dataclasses = import_module("dataclasses")
+finally:
+    sys.path.insert(0, _path0)
+    sys.modules[__name__] = _this_module
 
 __all__ = _dataclasses.__all__
 for _name in __all__:
@@ -12,6 +24,6 @@ for _name in __all__:
 
 
 def asdict(obj, *, dict_factory=dict):  # type: ignore[override]
-    if hasattr(obj, 'model_dump'):
+    if hasattr(obj, "model_dump"):
         return obj.model_dump()
     return _dataclasses.asdict(obj, dict_factory=dict_factory)


### PR DESCRIPTION
## Summary
- proxy stdlib dataclasses dynamically and preserve `model_dump` compatibility
- detect HYBRID rules by file presence and normalize rule execution results
- update discovery tests for new HYBRID semantics

## Testing
- `PYTHONPATH=. pytest -q contract_review_app/tests/rules_v2 --maxfail=1`
- `PYTHONPATH=. pytest -q contract_review_app/tests/llm -k "provider or orchestrator or proxy" --maxfail=1`
- `PYTHONPATH=. pytest -q contract_review_app/tests/intake --maxfail=1`
- `PYTHONPATH=. pytest -q contract_review_app/tests/test_citations_block1.py tests/codex/test_citations_doctor.py --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b09be2aa8083258d46bf8216627349