### PR TITLE
Add text normalization helper with offset tracking

### DIFF
--- a/contract_review_app/core/__init__.py
+++ b/contract_review_app/core/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["schemas", "interfaces"]
+__all__ = ["schemas", "interfaces", "normalize"]

--- a/contract_review_app/core/normalize.py
+++ b/contract_review_app/core/normalize.py
@@ -1,0 +1,29 @@
+"""Text normalization utilities with offset mapping."""
+
+REPLACEMENTS = {
+    "“": '"',
+    "”": '"',
+    "«": '"',
+    "»": '"',
+    "‚": '"',
+    "‘": '"',
+    "’": '"',
+    "–": "-",
+    "—": "-",
+    "−": "-",
+    "\u00a0": " ",
+    "\u202f": " ",
+}
+
+
+def normalize_with_offsets(s: str) -> tuple[str, list[int]]:
+    """Normalize text and record the index of each original character."""
+
+    normalized_chars: list[str] = []
+    offsets: list[int] = []
+
+    for idx, ch in enumerate(s):
+        normalized_chars.append(REPLACEMENTS.get(ch, ch))
+        offsets.append(idx)
+
+    return "".join(normalized_chars), offsets

--- a/contract_review_app/tests/test_core_normalize.py
+++ b/contract_review_app/tests/test_core_normalize.py
@@ -1,0 +1,8 @@
+from contract_review_app.core.normalize import normalize_with_offsets
+
+
+def test_normalize_with_offsets() -> None:
+    raw = "“Hello\u00a0World”—she\u202fsaid–indeed"
+    normalized, offsets = normalize_with_offsets(raw)
+    assert normalized == '"Hello World"-she said-indeed'
+    assert offsets == list(range(len(raw)))


### PR DESCRIPTION
## Summary
- add core.normalize.normalize_with_offsets to map smart punctuation and spaces while tracking original offsets
- expose normalize module in core package
- test normalization on mixed punctuation string

## Testing
- `pre-commit run --files contract_review_app/core/normalize.py contract_review_app/core/__init__.py contract_review_app/tests/test_core_normalize.py`
- `PYTHONPATH=. pytest contract_review_app/tests/test_core_normalize.py`


------
https://chatgpt.com/codex/tasks/task_e_68b178bd4d0c8325a8ab8705701e8da3