### PR TITLE
feat: add citation evidence and parsed document model

### DIFF
--- a/contract_review_app/legal_rules/cross_checks.py
+++ b/contract_review_app/legal_rules/cross_checks.py
@@ -235,11 +235,11 @@ def cross_check_clauses(
                 _add_finding(o_gl, "GL_103",
                              "Governing law and forum selection appear misaligned; consider aligning law and courts.",
                              severity="major",
-                             citations=[Citation(system="UK", instrument="General contract practice", section="GL↔JUR")])
+                             citations=[Citation(system="UK", instrument="General contract practice", section="GL↔JUR", title="General contract practice", source_type="practice", source_id="gl_jur")])
                 _add_finding(o_jur, "JUR_102",
                              "Jurisdiction clause may conflict with chosen governing law; clarify forum or adjust law.",
                              severity="major",
-                             citations=[Citation(system="UK", instrument="General contract practice", section="GL↔JUR")])
+                             citations=[Citation(system="UK", instrument="General contract practice", section="GL↔JUR", title="General contract practice", source_type="practice", source_id="gl_jur")])
 
     # ---------- 2) TERM <-> NOTICE / LoL -------------------------------------
     term_refs = _all(outputs, by_type, ["termination", "term_and_termination", "termination_clause"])
@@ -294,7 +294,7 @@ def cross_check_clauses(
                 o_conf, "CONF_114",
                 "Confidentiality clause lacks data protection carve-outs/references (UK GDPR/DPA).",
                 severity="major",
-                citations=[Citation(system="UK", instrument="UK GDPR / DPA 2018", section="General reference")],
+                citations=[Citation(system="UK", instrument="UK GDPR / DPA 2018", section="General reference", title="UK GDPR / DPA 2018", source_type="law", source_id="uk_gdpr_dpa_2018")],
             )
 
     # ---------- 5) FM <-> Payment --------------------------------------------

--- a/contract_review_app/legal_rules/rules/confidentiality.py
+++ b/contract_review_app/legal_rules/rules/confidentiality.py
@@ -12,10 +12,38 @@ from contract_review_app.core.schemas import (
 rule_name = "confidentiality"  # used by registry discovery
 
 # --- UK citations (strictly UK) ----------------------------------------------
-CIT_UK_GDPR = Citation(system="UK", instrument="UK GDPR", section="Arts. 5(1)(f), 32")
-CIT_DPA_2018 = Citation(system="UK", instrument="Data Protection Act 2018", section="Part 2")
-CIT_SCA_1981 = Citation(system="UK", instrument="Senior Courts Act 1981", section="s.37")
-CIT_COCO_1969 = Citation(system="UK", instrument="Coco v A N Clark (Engineers) Ltd [1969] RPC 41", section="breach of confidence")
+CIT_UK_GDPR = Citation(
+    system="UK",
+    instrument="UK GDPR",
+    section="Arts. 5(1)(f), 32",
+    title="UK GDPR",
+    source_type="law",
+    source_id="uk_gdpr",
+)
+CIT_DPA_2018 = Citation(
+    system="UK",
+    instrument="Data Protection Act 2018",
+    section="Part 2",
+    title="Data Protection Act 2018",
+    source_type="law",
+    source_id="dpa_2018",
+)
+CIT_SCA_1981 = Citation(
+    system="UK",
+    instrument="Senior Courts Act 1981",
+    section="s.37",
+    title="Senior Courts Act 1981",
+    source_type="law",
+    source_id="sca_1981",
+)
+CIT_COCO_1969 = Citation(
+    system="UK",
+    instrument="Coco v A N Clark (Engineers) Ltd [1969] RPC 41",
+    section="breach of confidence",
+    title="Coco v A N Clark (Engineers) Ltd [1969] RPC 41",
+    source_type="case",
+    source_id="coco_1969",
+)
 
 # --- helpers -----------------------------------------------------------------
 _DURATION_RE = re.compile(

--- a/contract_review_app/tests/legal_rules/test_confidentiality.py
+++ b/contract_review_app/tests/legal_rules/test_confidentiality.py
@@ -29,4 +29,4 @@ def test_personal_data_triggers_gdpr_hint():
     out = conf.analyze(AnalysisInput(clause_type="confidentiality", text=text))
     codes = [f.code for f in out.findings]
     assert "CONF-9" in codes
-    assert any(c.instrument.startswith("UK GDPR") for f in out.findings for c in f.citations)
+    assert any(c.title and c.title.startswith("UK GDPR") for f in out.findings for c in f.citations)

--- a/contract_review_app/tests/test_citations_block1.py
+++ b/contract_review_app/tests/test_citations_block1.py
@@ -1,65 +1,31 @@
-import pytest
-from typing import Any
-from pydantic import ValidationError
 from hypothesis import given, strategies as st
 
-from contract_review_app.core.schemas import Citation, Finding, AnalysisOutput
+from contract_review_app.core.schemas import Citation, Finding, AnalysisOutput, Evidence, TextSpan
 
 
 def test_citation_basic_valid():
-    c = Citation(system="UK", instrument="Law", section="s1", url="https://example.com")
-    assert c.system == "UK"
-    assert c.instrument == "Law"
-    assert c.section == "s1"
-    assert str(c.url).startswith("https://example.com")
+    evid = Evidence(text="Evidence", spans=[TextSpan(start=0, end=7, lang="en", script="Latn")])
+    c = Citation(title="Law", source_type="law", source_id="s1", evidence=[evid], score=0.5, meta={"url": "https://example.com"})
+    assert c.title == "Law"
+    assert c.source_type == "law"
+    assert c.source_id == "s1"
+    assert c.evidence and c.evidence[0].spans[0].start == 0
+    assert c.meta["url"].startswith("https://example.com")
 
 
-def test_citation_optional_fields_tolerated():
-    data = {
-        "system": "UK",
-        "instrument": "Act",
-        "section": "1",
-        "url": "https://example.com",
-        "title": "Example",
-        "source": "Test",
-        "link": "https://example.com/link",
-        "score": 0.5,
-        "evidence_text": "Evidence",
-    }
-    c = Citation(**data)
-    for key, value in data.items():
-        if key in {"system", "instrument", "section", "url"}:
-            continue
-        assert getattr(c, key, value if key == "score" else None) in {value, None}
-
-
-def test_citation_url_validation():
-    with pytest.raises(ValidationError):
-        Citation(system="UK", instrument="Law", section="1", url="not-a-url")
-
-
-@pytest.mark.parametrize("score", [-1.0, 2.0])
-def test_citation_score_bounds(score: float):
-    data = {
-        "system": "UK",
-        "instrument": "Act",
-        "section": "1",
-        "score": score,
-    }
-    c = Citation(**data)
-    val = getattr(c, "score", None)
-    if val is not None:
-        assert 0.0 <= val <= 1.0
+def test_citation_score_bounds():
+    c = Citation(title="A", score=2.0)
+    assert c.score == 1.0
+    c2 = Citation(title="B", score=-0.5)
+    assert c2.score == 0.0
 
 
 def test_backward_compat_str_and_dict():
     f = Finding(code="X", message="m", citations="Law")
-    assert len(f.citations) == 1
-    assert f.citations[0].instrument == "Law"
+    assert f.citations and f.citations[0].title == "Law"
 
-    f2 = Finding(code="X", message="m", citations={"instrument": "Reg", "section": "s"})
-    assert len(f2.citations) == 1
-    assert f2.citations[0].instrument == "Reg"
+    f2 = Finding(code="X", message="m", citations={"title": "Reg", "source_type": "law"})
+    assert f2.citations and f2.citations[0].title == "Reg"
 
     assert Finding(code="X", message="m", citations=None).citations == []
 
@@ -67,8 +33,8 @@ def test_backward_compat_str_and_dict():
 def test_coerce_citations_mixed_and_invalid():
     mixed = [
         "plain",
-        {"instrument": "Dict"},
-        Citation(system="UK", instrument="Obj", section="s"),
+        {"title": "Dict"},
+        Citation(title="Obj"),
         123,
     ]
     out = Finding._coerce_citations(mixed)
@@ -78,8 +44,8 @@ def test_coerce_citations_mixed_and_invalid():
 
 
 def test_integration_with_finding_and_analysis_output():
-    cit = Citation(system="UK", instrument="Act", section="1")
-    f = Finding(code="C", message="M", citations=["law", {"instrument": "Reg", "section": "s"}, cit])
+    cit = Citation(title="Act", source_type="law")
+    f = Finding(code="C", message="M", citations=["law", {"title": "Reg"}, cit])
     assert all(isinstance(c, Citation) for c in f.citations)
 
     ao = AnalysisOutput(
@@ -87,31 +53,25 @@ def test_integration_with_finding_and_analysis_output():
         text="sample",
         status="OK",
         findings=[],
-        citations=["law", {"instrument": "Reg", "section": "s"}, cit],
+        citations=["law", {"title": "Reg"}, cit],
     )
     assert all(isinstance(c, Citation) for c in ao.citations)
 
 
 @given(st.floats(allow_nan=False, allow_infinity=False))
 def test_property_score_clamped(random_score: float):
-    c = Citation(system="UK", instrument="A", section="s", score=random_score)
+    c = Citation(title="A", score=random_score)
     val = getattr(c, "score", None)
     if val is not None:
         assert 0.0 <= val <= 1.0
 
 
-citation_dict_strategy = st.fixed_dictionaries(
-    {
-        "instrument": st.text(min_size=1),
-        "section": st.text(min_size=1),
-        "system": st.sampled_from(["UK", "EU", "UA", "INT"]),
-    }
-)
+citation_dict_strategy = st.fixed_dictionaries({"title": st.text(min_size=1)})
 
 mixed_citation_strategy = st.one_of(
     st.text(min_size=1),
     citation_dict_strategy,
-    st.builds(Citation, system=st.sampled_from(["UK", "EU", "UA", "INT"]), instrument=st.text(min_size=1), section=st.text(min_size=1)),
+    st.builds(Citation, title=st.text(min_size=1)),
     st.integers(),
 )
 

--- a/tests/codex/test_citations_doctor.py
+++ b/tests/codex/test_citations_doctor.py
@@ -17,10 +17,10 @@ def test_confidentiality_citations_present():
     assert out.citations and isinstance(out.citations[0], Citation)
 
     for c in [*out.citations, *first_finding.citations]:
-        assert isinstance(c.system, str) and c.system
-        assert isinstance(c.instrument, str) and c.instrument
-        assert isinstance(c.section, str)
-        assert c.url is None or isinstance(c.url, str)
+        assert isinstance(c.title, str) and c.title
+        assert c.source_type is None or isinstance(c.source_type, str)
+        assert c.source_id is None or isinstance(c.source_id, str)
+        assert c.meta == {} or isinstance(c.meta, dict)
 
     data = json.loads(out.model_dump_json())
     assert data["citations"], "citations missing from JSON output"


### PR DESCRIPTION
## Summary
- add `TextSpan` and `Evidence` models
- extend `Citation` with provenance fields and evidence list
- expose parsed document normalization info and wire new citation fields through legal rules and tests

## Testing
- `pytest contract_review_app/tests/test_citations_block1.py tests/codex/test_citations_doctor.py contract_review_app/tests/legal_rules/test_confidentiality.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b178bbe3b48325a27cd9af43676e2c