### PR TITLE
feat: add citation resolver

### DIFF
--- a/contract_review_app/core/citation_resolver.py
+++ b/contract_review_app/core/citation_resolver.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import List, Optional
+import re
+
+from .schemas import Citation, Finding
+
+# Predefined citations
+_UK_GDPR_ART_28_3 = Citation(system="UK", instrument="UK GDPR", section="Art. 28(3)")
+_OGUK_MODEL_AGREEMENT = Citation(
+    system="UK", instrument="OGUK Model Agreement", section="General reference"
+)
+
+_OIL_GAS_RE = re.compile(r"\boil\b|\bgas\b", re.IGNORECASE)
+
+
+def resolve_citation(finding: Finding) -> Optional[List[Citation]]:
+    """Resolve citations based on rule metadata.
+
+    Args:
+        finding: Finding object to inspect.
+
+    Returns:
+        List of matching citations or ``None`` if no match.
+    """
+
+    message = (finding.message or "").lower()
+    code = (finding.code or "").lower()
+
+    if "personal data" in message or "conf_gdpr" in code:
+        return [_UK_GDPR_ART_28_3]
+
+    if _OIL_GAS_RE.search(message) or "oguk" in message or "oguk" in code:
+        return [_OGUK_MODEL_AGREEMENT]
+
+    return None

--- a/contract_review_app/tests/test_citation_resolver.py
+++ b/contract_review_app/tests/test_citation_resolver.py
@@ -1,0 +1,31 @@
+from contract_review_app.core.citation_resolver import resolve_citation
+from contract_review_app.core.schemas import Finding
+
+
+def test_resolve_citation_personal_data_message():
+    finding = Finding(
+        code="rule1", message="This clause mentions personal data processing."
+    )
+    result = resolve_citation(finding)
+    assert result is not None
+    assert result[0].instrument == "UK GDPR"
+    assert result[0].section == "Art. 28(3)"
+
+
+def test_resolve_citation_conf_gdpr_code():
+    finding = Finding(code="conf_gdpr_check", message="No personal terms")
+    result = resolve_citation(finding)
+    assert result is not None
+    assert result[0].instrument == "UK GDPR"
+
+
+def test_resolve_citation_oguk_keyword():
+    finding = Finding(code="rule2", message="OGUK standards for oil exploration apply.")
+    result = resolve_citation(finding)
+    assert result is not None
+    assert result[0].instrument == "OGUK Model Agreement"
+
+
+def test_resolve_citation_no_match():
+    finding = Finding(code="rule3", message="No special terms here.")
+    assert resolve_citation(finding) is None


### PR DESCRIPTION
## Summary
- add citation resolver for UK GDPR and OGUK Model Agreement
- test citation resolver for matching and non-matching findings

## Testing
- `pre-commit run --files contract_review_app/core/citation_resolver.py contract_review_app/tests/test_citation_resolver.py`
- `PYTHONPATH=. pytest contract_review_app/tests/test_citation_resolver.py`


------
https://chatgpt.com/codex/tasks/task_e_68b178c12ad08325817175f9eec0624f