### PR TITLE
Add test hook placeholder for draft generation

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -59,6 +59,17 @@ try:
 except Exception:  # pragma: no cover
     rules_loader = None  # type: ignore
 
+
+# --- test hook (будет перезаписан monkeypatch в тестах) ---
+def run_gpt_draft(payload: dict | None = None, *args, **kwargs) -> dict:
+    """Placeholder для тестов: тесты заменяют эту функцию через monkeypatch.
+    Возвращаем минимальную структуру по умолчанию.
+    """
+    return {"text": "", "model": "noop"}
+
+
+# ----------------------------------------------------------
+
 # --------------------------------------------------------------------
 # Config
 # --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add run_gpt_draft hook for tests

## Testing
- `pre-commit run --files contract_review_app/api/app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b1843e19fc8325ad2124285aa6f738