### PR TITLE
Normalize severity synonyms in findings

### DIFF
--- a/contract_review_app/tests/test_finding_severity_normalization.py
+++ b/contract_review_app/tests/test_finding_severity_normalization.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from contract_review_app.core.schemas import Finding
+
+
+def test_severity_level_synonyms():
+    cases = [
+        ("information", "info"),
+        ("Low", "minor"),
+        ("MED", "major"),
+        ("moderate", "major"),
+        ("High", "critical"),
+        ("severe", "critical"),
+        ("unexpected", "major"),
+    ]
+    for given, expected in cases:
+        f = Finding(code="X", message="m", severity=given)
+        assert f.severity_level == expected
+
+
+def test_severity_level_none():
+    f = Finding(code="X", message="m")
+    assert f.severity_level is None


### PR DESCRIPTION
## Summary
- normalize severity_level to accept common synonyms and fall back to `major`
- test normalization of severity synonyms

## Testing
- `pre-commit run --files contract_review_app/core/schemas.py contract_review_app/tests/test_finding_severity_normalization.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest contract_review_app/tests/test_finding_severity_normalization.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1a5eaac9c83259ff19fcbddb8ea9c