### PR TITLE
COD-117: fix build_prompt return type for compatibility

### DIFF
--- a/contract_review_app/gpt/gpt_dto.py
+++ b/contract_review_app/gpt/gpt_dto.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 from typing import Optional, Any
 from pydantic import BaseModel
+from contract_review_app.core.schemas import (
+    GPTDraftResponse as CoreGPTDraftResponse,
+)
 
 # ⚠️ Не імпортуємо AnalysisOutput як тип, щоб уникати циклічних імпортів під час runtime.
 # Приймаємо dict-подібний об'єкт.
 
-class GPTDraftResponse(BaseModel):
+
+class GPTDraftResponse(CoreGPTDraftResponse):
+    """Розширений варіант :class:`core.schemas.GPTDraftResponse`.
+
+    Додає кілька полів, корисних для фронтенду/Word, але зберігає сумісність
+    з базовим класом, що використовується у тестах.
     """
-    Уніфікований DTO-відповідь для фронтенду/Word.
-    """
+
     clause_type: Optional[str] = None
     original_text: Optional[str] = None
-    draft_text: str
-    explanation: str
-    score: int
     status: str = "ok"  # ok | warn | fail
     title: Optional[str] = None
 


### PR DESCRIPTION
## Summary
- Restore `build_prompt` to return a single legacy string prompt while offering new `build_prompt_parts` for structured access
- Align GPTDraftResponse DTO with core schema to keep type checks working

## Testing
- `PYTHONPATH=. pytest -q contract_review_app/tests/gpt/test_gpt_prompt_builder.py contract_review_app/tests/gpt/test_gpt_draft_engine.py contract_review_app/tests/gpt/test_gpt_drafting_pipeline.py contract_review_app/tests/gpt/test_gpt_pipeline.py::test_end_to_end_gpt_pipeline`

------
https://chatgpt.com/codex/tasks/task_e_68b1ae2929c483259bf66d91d8c6e23e