### PR TITLE
Ensure analyze endpoint always returns a finding

### DIFF
--- a/contract_review_app/analysis/extract_summary.py
+++ b/contract_review_app/analysis/extract_summary.py
@@ -205,7 +205,7 @@ def extract_document_snapshot(text: str) -> DocumentSnapshot:
     subject = _extract_subject(text)
     subject_raw = subject.get("raw") if subject else None
 
-    slug, confidence, evidence, _ = guess_doc_type(text, subject_raw)
+    slug, confidence, evidence, score_map = guess_doc_type(text, subject_raw)
     doc_type = slug_to_display(slug)
     if confidence < 0.1:
         doc_type = "unknown"
@@ -252,4 +252,14 @@ def extract_document_snapshot(text: str) -> DocumentSnapshot:
             object.__setattr__(snapshot, "subject", subject)
         except Exception:
             pass
+    # Expose top document type candidates for debugging/clients
+    try:
+        debug_top = [
+            {"type": slug_to_display(s), "score": round(v, 3)}
+            for s, v in sorted(score_map.items(), key=lambda kv: kv[1], reverse=True)[:5]
+        ]
+        if debug_top:
+            object.__setattr__(snapshot, "debug", {"doctype_top": debug_top})
+    except Exception:
+        pass
     return snapshot


### PR DESCRIPTION
## Summary
- Guarantee `/api/analyze` always returns at least one finding by filtering empty clause types and injecting a synthetic `Unknown` finding when no rules match
- Surface document type candidate scores in analysis summaries
- Relax `/api/suggest_edits` to accept JSON requests with only text while keeping legacy validation for non-JSON posts

## Testing
- `PYTHONPATH=. pytest -q contract_review_app/tests/rules/test_msa_v1.py::test_analyze_endpoint_returns_findings -vv`
- `PYTHONPATH=. pytest -q --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b326ccdd9c832581edbc98f9c84c7b