### PR TITLE
Gate LLM routes behind env flag and update tests

### DIFF
--- a/contract_review_app/tests/api/test_api_smoke.py
+++ b/contract_review_app/tests/api/test_api_smoke.py
@@ -21,35 +21,3 @@ def test_api_analyze_smoke(monkeypatch):
     assert data["summary"]["len"] == 5
 
 
-def test_api_gpt_draft_new_request(monkeypatch):
-    def _fake_draft(inp):
-        return {"text": "DRAFT", "model": "mock"}
-
-    import contract_review_app.api.app as app_mod
-    monkeypatch.setattr(app_mod, "run_gpt_draft", _fake_draft, raising=True)
-    monkeypatch.setenv("OPENAI_API_KEY", "x")
-
-    new_req = {"analysis": {"status": "OK"}, "model": "gpt-4"}
-    resp = client.post("/api/gpt/draft", json=new_req)
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["draft_text"] == "DRAFT"
-    assert data["status"] == "ok"
-    assert data["meta"]["model"] == "mock"
-
-
-def test_api_gpt_draft_legacy_request(monkeypatch):
-    def _fake_draft(inp):
-        return {"text": "[AI-DRAFT] Text", "model": "mock"}
-
-    import contract_review_app.api.app as app_mod
-    monkeypatch.setattr(app_mod, "run_gpt_draft", _fake_draft, raising=True)
-    monkeypatch.setenv("OPENAI_API_KEY", "x")
-
-    legacy_req = {"clause_type": "termination", "text": "Text", "language": "en"}
-    resp = client.post("/api/gpt/draft", json=legacy_req)
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["draft_text"].startswith("[AI-DRAFT]")
-    assert data["status"] == "ok"
-    assert data["meta"]["model"] == "mock"

--- a/contract_review_app/tests/api/test_app_contract.py
+++ b/contract_review_app/tests/api/test_app_contract.py
@@ -71,28 +71,6 @@ def test_suggest_edits_normalization_and_bounds():
         assert isinstance(s.get("message", ""), str)
 
 
-def test_gpt_draft_shape_and_headers():
-    r = client.post("/api/gpt/draft", json={"text": "Some clause text", "mode": "friendly"})
-    assert r.status_code == 200
-    body = r.json()
-    assert body["status"] == "ok"
-    assert "draft_text" in body
-    assert isinstance(body.get("meta", {}), dict)
-    # std headers
-    assert r.headers.get("x-schema-version") == SCHEMA_VERSION
-    assert _is_int(r.headers.get("x-latency-ms", "0"))
-
-
-def test_gpt_draft_stub_without_llm_keys(monkeypatch):
-    for k in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "LLM_API_KEY"):
-        monkeypatch.delenv(k, raising=False)
-    r = client.post("/api/gpt/draft", json={"text": "Law"})
-    assert r.status_code == 200
-    data = r.json()
-    assert isinstance(data.get("draft_text"), str) and data["draft_text"].strip()
-    assert data.get("meta", {}).get("model") == "rulebased"
-
-
 def test_qa_recheck_fallback_payload_and_deltas():
     text = "Payment shall be made within 30 days."
     # apply a trivial patch (replace '30' -> '60')

--- a/contract_review_app/tests/test_api_integration.py
+++ b/contract_review_app/tests/test_api_integration.py
@@ -23,12 +23,6 @@ def test_analyze_envelope_and_keys():
     for k in ("analysis", "results", "clauses", "document"):
         assert k in j
 
-def test_draft_endpoint_minimal_text():
-    r = client.post("/api/gpt/draft", data=json.dumps({"text": "Draft me a friendlier clause."}))
-    assert r.status_code == 200
-    j = r.json()
-    assert j["status"] == "ok"
-    assert "draft_text" in j and isinstance(j["draft_text"], str)
 
 def test_suggest_edits_smoke():
     r = client.post("/api/suggest_edits", data=json.dumps({

--- a/contract_review_app/tests/test_api_schemas_compat.py
+++ b/contract_review_app/tests/test_api_schemas_compat.py
@@ -1,7 +1,7 @@
 import json
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
-from contract_review_app.core.schemas import AnalyzeOut, DraftOut, SuggestOut, QARecheckOut
+from contract_review_app.core.schemas import AnalyzeOut, SuggestOut, QARecheckOut
 
 client = TestClient(app)
 
@@ -20,20 +20,6 @@ def test_analyze_response_is_compatible_with_AnalyzeOut():
     }
     # Will raise if incompatible:
     _ = AnalyzeOut(**payload)
-
-def test_draft_response_is_compatible_with_DraftOut():
-    r = client.post("/api/gpt/draft", data=json.dumps({"text": "Make this clause polite."}))
-    assert r.status_code == 200
-    j = r.json()
-    assert j["status"] == "ok"
-    payload = {k: j[k] for k in ("draft_text",) if k in j}
-    payload["alternatives"] = j.get("alternatives", [])
-    payload["rationale"] = j.get("rationale")
-    payload["citations_hint"] = j.get("citations_hint", [])
-    payload["model"] = j.get("model", "rule-based")
-    payload["elapsed_ms"] = j.get("elapsed_ms")
-    payload["metadata"] = j.get("metadata", {})
-    _ = DraftOut(**payload)
 
 def test_suggest_response_is_compatible_with_SuggestOut():
     r = client.post("/api/suggest_edits", data=json.dumps({

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -146,8 +146,7 @@ def test_gpt_draft_endpoint():
     r = client.post(
         "/api/gpt/draft", json={"text": "sample", "clause_type": "clause"}
     )
-    assert r.status_code == 200
-    assert r.json().get("draft_text")
+    assert r.status_code == 404
 
 
 def test_suggest_edits_endpoint():


### PR DESCRIPTION
## Summary
- Only mount `/api/gpt/*` routes when `CONTRACTAI_LLM_API` is set to a truthy value
- Drop legacy gpt draft stubs and clean up tests to align with disabled-by-default LLM endpoints
- Keep analyze and suggest-edits APIs consistent with schema

## Testing
- `PYTHONPATH=. pytest -q contract_review_app/tests/api/test_llm_api_routes.py::test_routes_absent_by_default --maxfail=1`
- `PYTHONPATH=. pytest -q contract_review_app/tests/rules/test_msa_v1.py::test_analyze_endpoint_returns_findings --maxfail=1`
- `PYTHONPATH=. pytest -q --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b32a416478832593b70b62adeeaecc