### PR TITLE
harden citation resolver for sanitized in-memory processing

### DIFF
--- a/contract_review_app/core/citation_resolver.py
+++ b/contract_review_app/core/citation_resolver.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from typing import List, Optional
+import logging
 import re
 
 from .schemas import Citation, Finding
+
+logger = logging.getLogger(__name__)
 
 # Predefined citations
 _UK_GDPR_ART_28_3 = Citation(system="UK", instrument="UK GDPR", section="Art. 28(3)")
@@ -17,6 +20,8 @@ _OIL_GAS_RE = re.compile(r"\boil\b|\bgas\b", re.IGNORECASE)
 def resolve_citation(finding: Finding) -> Optional[List[Citation]]:
     """Resolve citations based on rule metadata.
 
+    All processing is performed in-memory and no contract text is logged.
+
     Args:
         finding: Finding object to inspect.
 
@@ -24,13 +29,17 @@ def resolve_citation(finding: Finding) -> Optional[List[Citation]]:
         List of matching citations or ``None`` if no match.
     """
 
-    message = (finding.message or "").lower()
-    code = (finding.code or "").lower()
+    try:
+        message = (finding.message or "").lower()
+        code = (finding.code or "").lower()
 
-    if "personal data" in message or "conf_gdpr" in code:
-        return [_UK_GDPR_ART_28_3]
+        if "personal data" in message or "conf_gdpr" in code:
+            return [_UK_GDPR_ART_28_3]
 
-    if _OIL_GAS_RE.search(message) or "oguk" in message or "oguk" in code:
-        return [_OGUK_MODEL_AGREEMENT]
+        if _OIL_GAS_RE.search(message) or "oguk" in message or "oguk" in code:
+            return [_OGUK_MODEL_AGREEMENT]
 
-    return None
+        return None
+    except Exception as exc:
+        logger.warning("resolve_citation failed: %s", exc)
+        return None

--- a/contract_review_app/llm/citation_resolver.py
+++ b/contract_review_app/llm/citation_resolver.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import Any, Dict, Iterable, List, Optional
 from urllib.parse import urlparse
+
+# This module works entirely in-memory; no data is persisted to disk or external storage.
+
+logger = logging.getLogger(__name__)
 
 _ALLOWED_DOMAINS = {
     "www.legislation.gov.uk",
@@ -31,57 +36,66 @@ def _norm_str(x: Any) -> str:
 
 def _domain_ok(u: str) -> bool:
     try:
-        netloc = urlparse(u).netloc.lower()
+        parsed = urlparse(u)
+        netloc = parsed.netloc.lower()
+        scheme = parsed.scheme.lower()
     except Exception:
         return False
-    return bool(netloc) and (netloc in _ALLOWED_DOMAINS)
+    # Only allow HTTPS requests to whitelisted domains
+    return bool(netloc) and scheme == "https" and (netloc in _ALLOWED_DOMAINS)
 
 
 def normalize_citations(items: Any) -> List[ResolvedCitation]:
     """
     Accepts None|str|dict|list[mixed]; returns unique list of ResolvedCitation with whitelist filtering.
     Dedup key: (system,instrument,section,url or '').
+
+    Evidence text is never logged to avoid PII leakage.
     """
-    if items is None:
-        return []
-    src: Iterable[Any] = items if isinstance(items, list) else [items]
-    out: List[ResolvedCitation] = []
-    seen: set[tuple[str, str, str, str]] = set()
-    idx = 1
-    for it in src:
-        sys = inst = sec = url = title = src_name = ""
-        if isinstance(it, str):
-            inst = _norm_str(it)
-        elif isinstance(it, dict):
-            sys = _norm_str(it.get("system"))
-            inst = _norm_str(it.get("instrument"))
-            sec = _norm_str(it.get("section"))
-            url = _norm_str(it.get("url") or it.get("link"))
-            title = _norm_str(it.get("title"))
-            src_name = _norm_str(it.get("source"))
-        else:
-            inst = _norm_str(it)
-        # URL whitelist (if present)
-        if url and not _domain_ok(url):
-            url = ""
-        key = (sys or "UK", inst, sec, url)
-        if key in seen:
-            continue
-        seen.add(key)
-        cid = f"c{idx}"
-        idx += 1
-        out.append(
-            ResolvedCitation(
-                id=cid,
-                system=sys or "UK",
-                instrument=inst or "unknown",
-                section=sec,
-                url=url or None,
-                source=src_name or None,
-                title=title or None,
+    try:
+        if items is None:
+            return []
+        src: Iterable[Any] = items if isinstance(items, list) else [items]
+        out: List[ResolvedCitation] = []
+        seen: set[tuple[str, str, str, str]] = set()
+        idx = 1
+        for it in src:
+            sys = inst = sec = url = title = src_name = ""
+            if isinstance(it, str):
+                inst = _norm_str(it)
+            elif isinstance(it, dict):
+                sys = _norm_str(it.get("system"))
+                inst = _norm_str(it.get("instrument"))
+                sec = _norm_str(it.get("section"))
+                url = _norm_str(it.get("url") or it.get("link"))
+                title = _norm_str(it.get("title"))
+                src_name = _norm_str(it.get("source"))
+            else:
+                inst = _norm_str(it)
+            # URL whitelist (if present)
+            if url and not _domain_ok(url):
+                url = ""
+            key = (sys or "UK", inst, sec, url)
+            if key in seen:
+                continue
+            seen.add(key)
+            cid = f"c{idx}"
+            idx += 1
+            out.append(
+                ResolvedCitation(
+                    id=cid,
+                    system=sys or "UK",
+                    instrument=inst or "unknown",
+                    section=sec,
+                    url=url or None,
+                    source=src_name or None,
+                    title=title or None,
+                )
             )
-        )
-    return out
+        return out
+    except Exception as exc:
+        logger.warning("normalize_citations failed: %s", exc)
+        return []
 
 
 def make_grounding_pack(
@@ -90,16 +104,27 @@ def make_grounding_pack(
     """
     Build a deterministic grounding package for prompt_builder.
     Evidence items are derived from normalized citations.
+
+    The evidence text is not logged to avoid leaking contract details.
     """
-    norm = normalize_citations(citations)
-    evidence: List[Dict[str, Any]] = []
-    for rc in norm:
-        label = f"{rc.instrument} §{rc.section}".strip()
-        src = rc.url or rc.source or rc.system
-        evidence.append({"id": rc.id, "text": label, "source": src})
-    return {
-        "question": question or "",
-        "context": context_text or "",
-        "citations": [c.__dict__ for c in norm],
-        "evidence": evidence,
-    }
+    try:
+        norm = normalize_citations(citations)
+        evidence: List[Dict[str, Any]] = []
+        for rc in norm:
+            label = f"{rc.instrument} §{rc.section}".strip()
+            src = rc.url or rc.source or rc.system
+            evidence.append({"id": rc.id, "text": label, "source": src})
+        return {
+            "question": question or "",
+            "context": context_text or "",
+            "citations": [c.__dict__ for c in norm],
+            "evidence": evidence,
+        }
+    except Exception as exc:
+        logger.warning("make_grounding_pack failed: %s", exc)
+        return {
+            "question": question or "",
+            "context": context_text or "",
+            "citations": [],
+            "evidence": [],
+        }


### PR DESCRIPTION
## Summary
- enforce HTTPS-only domains and in-memory operation in citation resolver
- add try/except with sanitized logger warnings and no evidence text logging
- guard core resolver with safe error handling

## Testing
- `pre-commit run --files contract_review_app/llm/citation_resolver.py contract_review_app/core/citation_resolver.py`
- `PYTHONPATH=. pytest contract_review_app/tests/test_citation_resolver.py contract_review_app/tests/llm/test_citation_resolver.py`


------
https://chatgpt.com/codex/tasks/task_e_68b343d761d08325ac617f525a2a8bcf