### PR TITLE
Add citation metadata and expand citation resolver tests

### DIFF
--- a/contract_review_app/core/citation_resolver.py
+++ b/contract_review_app/core/citation_resolver.py
@@ -5,10 +5,24 @@ import re
 
 from .schemas import Citation, Finding
 
-# Predefined citations
-_UK_GDPR_ART_28_3 = Citation(system="UK", instrument="UK GDPR", section="Art. 28(3)")
+# Predefined citations with rich metadata for tests
+_UK_GDPR_ART_28_3 = Citation(
+    system="UK",
+    instrument="UK GDPR",
+    section="Art. 28(3)",
+    title="UK GDPR Article 28(3)",
+    source="legislation.gov.uk",
+    score=1.0,
+    evidence_text="Processors must act only on documented instructions.",
+)
 _OGUK_MODEL_AGREEMENT = Citation(
-    system="UK", instrument="OGUK Model Agreement", section="General reference"
+    system="UK",
+    instrument="OGUK Model Agreement",
+    section="General reference",
+    title="OGUK Model Agreement for Offshore Operations",
+    source="oguk.org.uk",
+    score=1.0,
+    evidence_text="OGUK standards for oil and gas exploration.",
 )
 
 _OIL_GAS_RE = re.compile(r"\boil\b|\bgas\b", re.IGNORECASE)

--- a/contract_review_app/tests/test_citation_resolver.py
+++ b/contract_review_app/tests/test_citation_resolver.py
@@ -8,22 +8,45 @@ def test_resolve_citation_personal_data_message():
     )
     result = resolve_citation(finding)
     assert result is not None
-    assert result[0].instrument == "UK GDPR"
-    assert result[0].section == "Art. 28(3)"
+    citation = result[0]
+    assert citation.instrument == "UK GDPR"
+    assert citation.section == "Art. 28(3)"
+    assert citation.title
+    assert citation.source
+    assert citation.score is not None
+    assert citation.evidence_text
 
 
 def test_resolve_citation_conf_gdpr_code():
     finding = Finding(code="conf_gdpr_check", message="No personal terms")
     result = resolve_citation(finding)
     assert result is not None
-    assert result[0].instrument == "UK GDPR"
+    citation = result[0]
+    assert citation.instrument == "UK GDPR"
+    assert citation.section == "Art. 28(3)"
+    assert citation.title
+    assert citation.source
+    assert citation.score is not None
+    assert citation.evidence_text
 
 
 def test_resolve_citation_oguk_keyword():
     finding = Finding(code="rule2", message="OGUK standards for oil exploration apply.")
     result = resolve_citation(finding)
     assert result is not None
-    assert result[0].instrument == "OGUK Model Agreement"
+    citation = result[0]
+    assert citation.instrument == "OGUK Model Agreement"
+    assert citation.section == "General reference"
+    assert citation.title == "OGUK Model Agreement for Offshore Operations"
+    assert citation.source == "oguk.org.uk"
+    assert citation.score == 1.0
+    assert citation.evidence_text
+
+
+def test_resolve_citation_unmatched_rule_code():
+    """An unmatched rule code should yield no citation."""
+    finding = Finding(code="conf_gdp_check", message="No personal terms")
+    assert resolve_citation(finding) is None
 
 
 def test_resolve_citation_no_match():


### PR DESCRIPTION
## Summary
- enrich built-in citations with source, title, score and evidence fields
- extend citation resolver tests to check populated metadata and add unmatched-rule coverage
- verify OGUK citation returns full metadata and score of 1.0

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/test_citation_resolver.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b343d3aa74832581ebd3f2eff5db4e