### PR TITLE
feat: add corpus DTOs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,1 @@
+B5-1 introduces DTO only

--- a/contract_review_app/core/corpus_schemas.py
+++ b/contract_review_app/core/corpus_schemas.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal, Optional
+
+try:  # pragma: no cover - environment guards
+    from pydantic import (
+        BaseModel,
+        ConfigDict,
+        HttpUrl,
+        field_validator,
+    )
+except Exception:  # pragma: no cover
+    # minimal fallbacks for type-checking when pydantic v2 is absent
+    BaseModel = object  # type: ignore
+    ConfigDict = dict  # type: ignore
+
+    def field_validator(*args, **kwargs):  # type: ignore
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+
+__all__ = [
+    "LegalSource",
+    "JurisdictionCode",
+    "CorpusDocMeta",
+    "CorpusDocument",
+    "OGL_V3",
+]
+
+# =============================================================================
+# Literals / Enums
+# =============================================================================
+LegalSource = Literal["legislation", "case_law", "regulation", "other"]
+JurisdictionCode = Literal["UK", "UA", "EU"]
+
+OGL_V3: str = "OGL-v3"
+
+
+# =============================================================================
+# DTOs
+# =============================================================================
+class CorpusDocMeta(BaseModel):
+    source: LegalSource
+    jurisdiction: JurisdictionCode
+    act: str
+    section: str
+    version: str
+    updated_at: datetime
+    url: HttpUrl
+    rights: str
+    lang: Optional[str] = None
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    @field_validator(
+        "source", "jurisdiction", "act", "section", "version", "rights"
+    )
+    @classmethod
+    def _trim_non_empty(cls, v: str) -> str:
+        if not isinstance(v, str):
+            raise TypeError("must be a string")
+        v = v.strip()
+        if not v:
+            raise ValueError("must be a non-empty string")
+        return v
+
+    @field_validator("lang")
+    @classmethod
+    def _trim_optional(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        v = v.strip()
+        return v or None
+
+    @field_validator("updated_at", mode="before")
+    @classmethod
+    def _ensure_datetime(cls, v: datetime | str) -> datetime:
+        if isinstance(v, str):
+            v = datetime.fromisoformat(v)
+        if not isinstance(v, datetime):
+            raise TypeError("updated_at must be datetime")
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=timezone.utc)
+        else:
+            v = v.astimezone(timezone.utc)
+        return v
+
+
+class CorpusDocument(BaseModel):
+    meta: CorpusDocMeta
+    content: str
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    @field_validator("content")
+    @classmethod
+    def _trim_content(cls, v: str) -> str:
+        if not isinstance(v, str):
+            raise TypeError("content must be a string")
+        v = v.strip()
+        if not v:
+            raise ValueError("content must be a non-empty string")
+        return v

--- a/contract_review_app/tests/corpus/test_corpus_schemas.py
+++ b/contract_review_app/tests/corpus/test_corpus_schemas.py
@@ -1,0 +1,66 @@
+import pytest
+from datetime import datetime, timezone
+from pydantic import ValidationError
+
+from contract_review_app.core.corpus_schemas import (
+    CorpusDocMeta,
+    CorpusDocument,
+    OGL_V3,
+)
+
+
+def _meta(**kwargs):
+    data = {
+        "source": "legislation",
+        "jurisdiction": "UK",
+        "act": "Some Act",
+        "section": "10",
+        "version": "1",
+        "updated_at": "2023-01-01T00:00:00",
+        "url": "https://example.com",
+        "rights": OGL_V3,
+    }
+    data.update(kwargs)
+    return CorpusDocMeta(**data)
+
+
+def test_happy_path():
+    meta = _meta(lang="en")
+    doc = CorpusDocument(meta=meta, content="  lorem ipsum  ")
+    assert doc.meta == meta
+    assert doc.content == "lorem ipsum"
+
+
+def test_empty_fields_raise():
+    with pytest.raises(ValidationError):
+        _meta(source=" ")
+    with pytest.raises(ValidationError):
+        CorpusDocument(meta=_meta(), content="  ")
+
+
+def test_updated_at_utc():
+    meta = _meta(updated_at=datetime(2023, 1, 1, 12, 0, 0))
+    assert meta.updated_at.tzinfo == timezone.utc
+
+
+def test_round_trip():
+    meta = _meta(lang=None)
+    dumped = meta.model_dump(exclude_none=True)
+    meta2 = CorpusDocMeta.model_validate(dumped)
+    assert meta2 == meta
+    doc = CorpusDocument(meta=meta, content="text")
+    doc_dump = doc.model_dump(exclude_none=True)
+    doc2 = CorpusDocument.model_validate(doc_dump)
+    assert doc2 == doc
+
+
+def test_hashability():
+    m1 = _meta()
+    m2 = _meta()
+    assert m1 == m2
+    s = {m1, m2}
+    assert len(s) == 1
+    d1 = CorpusDocument(meta=m1, content="abc")
+    d2 = CorpusDocument(meta=m2, content="abc")
+    assert d1 == d2
+    assert len({d1, d2}) == 1


### PR DESCRIPTION
## Summary
- add strict Pydantic v2 DTOs for corpus metadata and documents
- validate fields, normalize timestamps to UTC, and expose OGL-v3 rights preset
- cover DTO behavior with unit tests and document migration note

## Testing
- `PYTHONPATH=$PWD pytest -q contract_review_app/tests/corpus/test_corpus_schemas.py --maxfail=1`
- `PYTHONPATH=$PWD pytest -q -p no:cov --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68b34c0b79f88325afa1b06ef0b443c1