### PR TITLE
Implement legal corpus repository with SQLite tests

### DIFF
--- a/contract_review_app/corpus/__init__.py
+++ b/contract_review_app/corpus/__init__.py
@@ -1,0 +1,11 @@
+"""Legal corpus data layer."""
+
+from .db import get_engine, SessionLocal, init_db
+from .repo import CorpusRepository
+
+__all__ = [
+    "get_engine",
+    "SessionLocal",
+    "init_db",
+    "CorpusRepository",
+]

--- a/contract_review_app/corpus/db.py
+++ b/contract_review_app/corpus/db.py
@@ -1,0 +1,35 @@
+"""Database helpers for the legal corpus."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def get_engine(dsn: str | None = None, echo: bool = False) -> Engine:
+    """Return SQLAlchemy engine.
+
+    DSN is read from ``LEGAL_CORPUS_DSN`` environment variable when not
+    provided. Defaults to in-memory SQLite database.
+    """
+
+    if dsn is None:
+        dsn = os.getenv("LEGAL_CORPUS_DSN", "sqlite:///:memory:")
+    return create_engine(dsn, echo=echo, future=True)
+
+
+# Session factory; sessions are normally bound in tests to a specific engine.
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, future=True)
+
+
+from .models import Base  # imported late to avoid circular import
+
+
+def init_db(engine: Engine, create_all: bool = True) -> None:
+    """Initialise the database schema."""
+
+    if create_all:
+        Base.metadata.create_all(engine)

--- a/contract_review_app/corpus/models.py
+++ b/contract_review_app/corpus/models.py
@@ -1,0 +1,48 @@
+"""SQLAlchemy models for the legal corpus."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class CorpusDoc(Base):
+    __tablename__ = "corpus_docs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    source: Mapped[str] = mapped_column(String(64), nullable=False)
+    jurisdiction: Mapped[str] = mapped_column(String(8), nullable=False)
+    act_code: Mapped[str] = mapped_column(String(128), nullable=False)
+    act_title: Mapped[str] = mapped_column(String(256), nullable=False)
+    section_code: Mapped[str] = mapped_column(String(128), nullable=False)
+    section_title: Mapped[str] = mapped_column(String(256), nullable=False)
+    version: Mapped[str] = mapped_column(String(32), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    rights: Mapped[str] = mapped_column(String(128), nullable=False)
+    lang: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    script: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    checksum: Mapped[str] = mapped_column(String(64), nullable=False)
+    latest: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "jurisdiction", "act_code", "section_code", "version", name="uq_doc_version"
+        ),
+        Index("ix_jur_act_sec", "jurisdiction", "act_code", "section_code"),
+        Index("ix_act_title", "act_title"),
+        Index("ix_section_title", "section_title"),
+    )
+

--- a/contract_review_app/corpus/normalizer.py
+++ b/contract_review_app/corpus/normalizer.py
@@ -1,0 +1,48 @@
+"""Utilities for normalising text and timestamps in the corpus."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from hashlib import sha256
+from datetime import datetime, timezone
+from typing import Iterable
+
+
+SPACE_RE = re.compile(r"\s+")
+
+
+def normalize_text(s: str) -> str:
+    """Return a canonical representation of ``s``.
+
+    Performs Unicode NFKC normalisation, replaces non-breaking spaces,
+    collapses whitespace, trims and normalises quotes.
+    """
+
+    if s is None:
+        return ""
+    s = unicodedata.normalize("NFKC", s)
+    s = s.replace("\u00A0", " ")
+    s = s.replace("“", '"').replace("”", '"').replace("’", "'").replace("‘", "'")
+    s = SPACE_RE.sub(" ", s)
+    return s.strip()
+
+
+def utc_iso(dt: str | datetime) -> datetime:
+    """Parse ``dt`` as an aware UTC ``datetime``."""
+
+    if isinstance(dt, str):
+        dt = dt.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(dt)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt
+
+
+def checksum_for(*parts: str) -> str:
+    """Return SHA256 checksum for the concatenated parts."""
+
+    joined = "||".join(parts)
+    return sha256(joined.encode("utf-8")).hexdigest()

--- a/contract_review_app/corpus/repo.py
+++ b/contract_review_app/corpus/repo.py
@@ -1,0 +1,146 @@
+"""Repository layer for the legal corpus."""
+
+from __future__ import annotations
+
+from typing import TypedDict, Optional, Dict, List
+
+from sqlalchemy import select, update, delete, or_, func
+from sqlalchemy.orm import Session
+
+from .models import CorpusDoc
+from .normalizer import normalize_text, utc_iso, checksum_for
+
+
+class CorpusRecord(TypedDict, total=False):
+    source: str
+    jurisdiction: str
+    act_code: str
+    act_title: str
+    section_code: str
+    section_title: str
+    version: str
+    updated_at: str
+    url: Optional[str]
+    rights: str
+    lang: Optional[str]
+    script: Optional[str]
+    text: str
+
+
+class CorpusRepository:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    # upsert operation with normalisation and checksum
+    def upsert(self, dto: CorpusRecord) -> CorpusDoc:
+        normalized_text = normalize_text(dto["text"])
+        updated_at = utc_iso(dto["updated_at"])
+        checksum = checksum_for(
+            dto["jurisdiction"],
+            dto["act_code"],
+            dto["section_code"],
+            dto["version"],
+            normalized_text,
+        )
+
+        stmt = select(CorpusDoc).where(
+            CorpusDoc.jurisdiction == dto["jurisdiction"],
+            CorpusDoc.act_code == dto["act_code"],
+            CorpusDoc.section_code == dto["section_code"],
+            CorpusDoc.version == dto["version"],
+        )
+
+        existing = self.session.execute(stmt).scalar_one_or_none()
+        if existing and existing.checksum == checksum:
+            self.session.commit()
+            return existing
+
+        self.session.execute(
+            update(CorpusDoc)
+            .where(
+                CorpusDoc.jurisdiction == dto["jurisdiction"],
+                CorpusDoc.act_code == dto["act_code"],
+                CorpusDoc.section_code == dto["section_code"],
+                CorpusDoc.latest.is_(True),
+            )
+            .values(latest=False)
+        )
+        doc = CorpusDoc(
+            source=dto["source"],
+            jurisdiction=dto["jurisdiction"],
+            act_code=dto["act_code"],
+            act_title=dto["act_title"],
+            section_code=dto["section_code"],
+            section_title=dto["section_title"],
+            version=dto["version"],
+            updated_at=updated_at,
+            url=dto.get("url"),
+            rights=dto["rights"],
+            lang=dto.get("lang"),
+            script=dto.get("script"),
+            text=normalized_text,
+            checksum=checksum,
+            latest=True,
+        )
+        self.session.add(doc)
+        self.session.commit()
+        self.session.refresh(doc)
+        doc.updated_at = utc_iso(doc.updated_at)
+        return doc
+
+    def get_by_key(
+        self, jurisdiction: str, act_code: str, section_code: str, version: str
+    ) -> Optional[CorpusDoc]:
+        stmt = select(CorpusDoc).where(
+            CorpusDoc.jurisdiction == jurisdiction,
+            CorpusDoc.act_code == act_code,
+            CorpusDoc.section_code == section_code,
+            CorpusDoc.version == version,
+        )
+        result = self.session.execute(stmt).scalar_one_or_none()
+        self.session.commit()
+        return result
+
+    def list_latest(self, filters: Optional[Dict[str, str]] = None) -> List[CorpusDoc]:
+        stmt = select(CorpusDoc).where(CorpusDoc.latest.is_(True))
+        if filters:
+            if source := filters.get("source"):
+                stmt = stmt.where(CorpusDoc.source == source)
+            if jurisdiction := filters.get("jurisdiction"):
+                stmt = stmt.where(CorpusDoc.jurisdiction == jurisdiction)
+            if act_code := filters.get("act_code"):
+                stmt = stmt.where(CorpusDoc.act_code == act_code)
+        res = self.session.execute(stmt).scalars().all()
+        self.session.commit()
+        return res
+
+    def find(
+        self,
+        jurisdiction: Optional[str] = None,
+        act_code: Optional[str] = None,
+        section_code: Optional[str] = None,
+        q: Optional[str] = None,
+    ) -> List[CorpusDoc]:
+        stmt = select(CorpusDoc)
+        if jurisdiction:
+            stmt = stmt.where(CorpusDoc.jurisdiction == jurisdiction)
+        if act_code:
+            stmt = stmt.where(CorpusDoc.act_code == act_code)
+        if section_code:
+            stmt = stmt.where(CorpusDoc.section_code == section_code)
+        if q:
+            like = f"%{q.lower()}%"
+            stmt = stmt.where(
+                or_(
+                    func.lower(CorpusDoc.text).like(like),
+                    func.lower(CorpusDoc.section_title).like(like),
+                    func.lower(CorpusDoc.act_title).like(like),
+                )
+            )
+        res = self.session.execute(stmt).scalars().all()
+        self.session.commit()
+        return res
+
+    def delete_all(self) -> None:
+        with self.session.begin():
+            self.session.execute(delete(CorpusDoc))

--- a/contract_review_app/tests/corpus/test_repo_sqlite.py
+++ b/contract_review_app/tests/corpus/test_repo_sqlite.py
@@ -1,0 +1,82 @@
+import os
+from datetime import timedelta, timezone
+
+import pytest
+
+from contract_review_app.corpus.db import get_engine, init_db, SessionLocal
+from contract_review_app.corpus.repo import CorpusRepository, CorpusRecord
+
+
+@pytest.fixture
+def repo(tmp_path):
+    dsn = f"sqlite:///{tmp_path / 'corpus.db'}"
+    os.environ["LEGAL_CORPUS_DSN"] = dsn
+    engine = get_engine(dsn)
+    init_db(engine)
+    session = SessionLocal(bind=engine)
+    return CorpusRepository(session)
+
+
+def build_dto(version: str, text: str) -> CorpusRecord:
+    return {
+        "source": "gov.uk",
+        "jurisdiction": "UK",
+        "act_code": "UK_GDPR",
+        "act_title": "UK GDPR",
+        "section_code": "Art5",
+        "section_title": "Principles of processing",
+        "version": version,
+        "updated_at": "2024-06-01T00:00:00Z",
+        "rights": "CC-BY",
+        "lang": "en",
+        "script": "Latn",
+        "text": text,
+    }
+
+
+def test_happy_path_and_latest(repo):
+    dto1 = build_dto("2024-06", "Text with\u00A0NBSP and “quotes”.")
+    doc1 = repo.upsert(dto1)
+
+    latest = repo.list_latest()
+    assert len(latest) == 1
+    assert latest[0].latest is True
+
+    dto2 = build_dto("2025-01", "Updated text with different content.")
+    repo.upsert(dto2)
+
+    all_docs = repo.find()
+    assert len(all_docs) == 2
+    old = repo.get_by_key("UK", "UK_GDPR", "Art5", "2024-06")
+    new = repo.get_by_key("UK", "UK_GDPR", "Art5", "2025-01")
+    assert old.latest is False
+    assert new.latest is True
+
+
+def test_idempotent_same_checksum(repo):
+    dto = build_dto("2024-06", "Some text")
+    repo.upsert(dto)
+    repo.upsert(dto)
+    all_docs = repo.find()
+    assert len(all_docs) == 1
+
+
+def test_find_and_titles(repo):
+    dto = build_dto(
+        "2024-06",
+        "Information shall be processed in a transparent manner.",
+    )
+    repo.upsert(dto)
+
+    res = repo.find(jurisdiction="UK", act_code="UK_GDPR", q="transparent")
+    assert len(res) == 1
+
+    res2 = repo.find(jurisdiction="UK", act_code="UK_GDPR", q="Principles")
+    assert len(res2) == 1
+
+
+def test_updated_at_utc(repo):
+    dto = build_dto("2024-06", "Some text")
+    doc = repo.upsert(dto)
+    assert doc.updated_at.tzinfo is not None
+    assert doc.updated_at.utcoffset() == timedelta(0)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ hypothesis>=6.0
 pyyaml>=6.0
 fastapi>=0.110,<1.0
 httpx
+sqlalchemy>=2.0


### PR DESCRIPTION
## Summary
- add SQLAlchemy-based ORM models for legal corpus documents
- implement repository with text normalization, checksum upsert, and query helpers
- add SQLite-backed repository tests and dev dependency on SQLAlchemy

## Testing
- `python -m pytest -q contract_review_app/tests/corpus/test_repo_sqlite.py --maxfail=1`
- `python -m pytest -q -p no:cov --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b35d3057208325a498088cb04bd7ac