### PR TITLE
Implement deterministic corpus ingest with UK demo data

### DIFF
--- a/contract_review_app/corpus/__init__.py
+++ b/contract_review_app/corpus/__init__.py
@@ -1,0 +1,3 @@
+"""Corpus package for legal corpus storage and search."""
+
+from . import db, models, repo, normalizer, ingest  # noqa: F401

--- a/contract_review_app/corpus/db.py
+++ b/contract_review_app/corpus/db.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .models import Base
+
+
+SessionLocal = sessionmaker()
+
+
+def get_engine(dsn: str | None = None):
+    dsn = dsn or os.getenv("LEGAL_CORPUS_DSN") or "sqlite:///./.local/corpus.db"
+    if dsn.startswith("sqlite:///"):
+        path = dsn.replace("sqlite:///", "", 1)
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+    return create_engine(dsn, future=True)
+
+
+def init_db(engine) -> None:
+    Base.metadata.create_all(engine)
+    SessionLocal.configure(bind=engine)

--- a/contract_review_app/corpus/ingest.py
+++ b/contract_review_app/corpus/ingest.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+from .normalizer import normalize_text, utc_iso, checksum_for
+from .db import get_engine, init_db, SessionLocal
+from .repo import Repo
+
+REQUIRED_FIELDS = {
+    "source",
+    "jurisdiction",
+    "act_code",
+    "act_title",
+    "section_code",
+    "section_title",
+    "version",
+    "updated_at",
+    "text",
+    "rights",
+}
+
+
+def load_dir(dir_path: str) -> List[Dict]:
+    items: List[Dict] = []
+    for path in sorted(Path(dir_path).glob("*.yaml")):
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        if isinstance(data, dict) and "items" in data:
+            docs = data["items"]
+        else:
+            docs = [data]
+        for item in docs:
+            if not REQUIRED_FIELDS.issubset(item.keys()):
+                missing = REQUIRED_FIELDS - set(item.keys())
+                raise ValueError(f"{path}: missing fields {missing}")
+            items.append(item)
+    return items
+
+
+def to_repo_dto(item: Dict) -> Dict:
+    text = normalize_text(item["text"])
+    updated_at = utc_iso(item["updated_at"])
+    checksum = checksum_for(
+        item["jurisdiction"],
+        item["act_code"],
+        item["section_code"],
+        item["version"],
+        text,
+    )
+    dto = dict(item)
+    dto.update({"text": text, "updated_at": updated_at, "checksum": checksum})
+    return dto
+
+
+def run_ingest(dir_path: str, *, dsn: str | None = None) -> int:
+    engine = get_engine(dsn)
+    init_db(engine)
+    session = SessionLocal()
+    repo = Repo(session)
+    items = load_dir(dir_path)
+    for it in items:
+        dto = to_repo_dto(it)
+        repo.upsert(dto)
+    session.close()
+    return len(items)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--dir", required=True)
+    p.add_argument("--dsn", default=os.getenv("LEGAL_CORPUS_DSN"))
+    args = p.parse_args()
+    n = run_ingest(args.dir, dsn=args.dsn)
+    print(f"Ingested records: {n}")

--- a/contract_review_app/corpus/models.py
+++ b/contract_review_app/corpus/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
+from sqlalchemy.orm import declarative_base
+
+
+Base = declarative_base()
+
+
+class LegalCorpus(Base):
+    __tablename__ = "legal_corpus"
+
+    id = Column(Integer, primary_key=True)
+    source = Column(String, nullable=False)
+    jurisdiction = Column(String, nullable=False)
+    act_code = Column(String, nullable=False)
+    act_title = Column(String, nullable=False)
+    section_code = Column(String, nullable=False)
+    section_title = Column(String, nullable=False)
+    version = Column(String, nullable=False)
+    updated_at = Column(String, nullable=False)
+    url = Column(String)
+    rights = Column(String, nullable=False)
+    lang = Column(String)
+    script = Column(String)
+    text = Column(Text, nullable=False)
+    checksum = Column(String, nullable=False)
+    latest = Column(Boolean, nullable=False, default=True)
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc)
+    )

--- a/contract_review_app/corpus/normalizer.py
+++ b/contract_review_app/corpus/normalizer.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import re
+from typing import Any
+
+
+_RE_WS = re.compile(r"\s+")
+
+_REPLACEMENTS = {
+    "\u00A0": " ",
+    "\u201C": '"',
+    "\u201D": '"',
+    "\u2018": "'",
+    "\u2019": "'",
+}
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text for storage and checksum calculation."""
+    for src, dst in _REPLACEMENTS.items():
+        text = text.replace(src, dst)
+    text = _RE_WS.sub(" ", text)
+    return text.strip()
+
+
+def utc_iso(value: Any) -> str:
+    """Return ISO 8601 UTC string for given datetime or string."""
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if not isinstance(value, datetime):
+        raise TypeError("expected datetime or ISO string")
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def checksum_for(*parts: str) -> str:
+    """Compute checksum for given string parts."""
+    h = hashlib.sha256()
+    for part in parts:
+        h.update((part or "").encode("utf-8"))
+        h.update(b"\x1f")
+    return h.hexdigest()

--- a/contract_review_app/corpus/repo.py
+++ b/contract_review_app/corpus/repo.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+from sqlalchemy import or_, func
+
+from .models import LegalCorpus
+
+
+class Repo:
+    def __init__(self, session):
+        self.session = session
+
+    def upsert(self, dto: dict) -> LegalCorpus:
+        key_filter = {
+            "jurisdiction": dto["jurisdiction"],
+            "act_code": dto["act_code"],
+            "section_code": dto["section_code"],
+            "version": dto["version"],
+            "checksum": dto["checksum"],
+        }
+        existing = (
+            self.session.query(LegalCorpus)
+            .filter_by(**key_filter)
+            .one_or_none()
+        )
+        if existing:
+            return existing
+
+        # mark previous latest as false
+        self.session.query(LegalCorpus).filter_by(
+            jurisdiction=dto["jurisdiction"],
+            act_code=dto["act_code"],
+            section_code=dto["section_code"],
+            latest=True,
+        ).update({"latest": False})
+
+        obj = LegalCorpus(**dto, latest=True)
+        self.session.add(obj)
+        self.session.commit()
+        return obj
+
+    def list_latest(self) -> List[LegalCorpus]:
+        return (
+            self.session.query(LegalCorpus)
+            .filter_by(latest=True)
+            .all()
+        )
+
+    def find(
+        self,
+        *,
+        jurisdiction: str | None = None,
+        act_code: str | None = None,
+        q: str | None = None,
+    ) -> List[LegalCorpus]:
+        query = self.session.query(LegalCorpus).filter_by(latest=True)
+        if jurisdiction:
+            query = query.filter(LegalCorpus.jurisdiction == jurisdiction)
+        if act_code:
+            query = query.filter(LegalCorpus.act_code == act_code)
+        if q:
+            pattern = f"%{q.lower()}%"
+            query = query.filter(
+                or_(
+                    func.lower(LegalCorpus.text).like(pattern),
+                    func.lower(LegalCorpus.act_title).like(pattern),
+                    func.lower(LegalCorpus.section_title).like(pattern),
+                )
+            )
+        return query.all()

--- a/contract_review_app/tests/corpus/test_b5_ingest.py
+++ b/contract_review_app/tests/corpus/test_b5_ingest.py
@@ -1,0 +1,135 @@
+import os
+from pathlib import Path
+
+import yaml
+
+from contract_review_app.corpus.db import get_engine, init_db, SessionLocal
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.corpus.ingest import run_ingest, to_repo_dto
+
+
+
+def setup_sqlite(tmp_path):
+    dsn = f"sqlite:///{tmp_path/'corpus.db'}"
+    os.environ["LEGAL_CORPUS_DSN"] = dsn
+    engine = get_engine(dsn)
+    init_db(engine)
+    return dsn
+
+
+def _demo_items():
+    return [
+        {
+            "source": "legislation.gov.uk",
+            "jurisdiction": "UK",
+            "act_code": "UK_GDPR",
+            "act_title": "UK GDPR",
+            "section_code": "Art.5",
+            "section_title": "Principles relating to processing of personal data",
+            "version": "2024-06",
+            "updated_at": "2024-06-01T00:00:00Z",
+            "url": "https://www.legislation.gov.uk/eur/2016/679/article/5",
+            "rights": "Open Government Licence v3.0",
+            "lang": "en",
+            "script": "Latn",
+            "text": "Personal data shall be processed lawfully, fairly and in a transparent manner",
+        },
+        {
+            "source": "legislation.gov.uk",
+            "jurisdiction": "UK",
+            "act_code": "UCTA_1977",
+            "act_title": "Unfair Contract Terms Act 1977",
+            "section_code": "s.2",
+            "section_title": "Negligence liability",
+            "version": "2024-06",
+            "updated_at": "2024-06-01T00:00:00Z",
+            "url": "https://www.legislation.gov.uk/ukpga/1977/50/section/2",
+            "rights": "Open Government Licence v3.0",
+            "lang": "en",
+            "script": "Latn",
+            "text": "A person cannot by reference to any contract term restrict his liability",
+        },
+        {
+            "source": "OGUK",
+            "jurisdiction": "UK",
+            "act_code": "OGUK_MODEL",
+            "act_title": "OGUK Model Form",
+            "section_code": "Indemnity",
+            "section_title": "Sample mutual indemnity clause",
+            "version": "2024-06",
+            "updated_at": "2024-06-01T00:00:00Z",
+            "rights": "OGUK Licence",
+            "lang": "en",
+            "script": "Latn",
+            "text": "Each party shall indemnify the other against all claims and losses",
+        },
+    ]
+
+
+def test_ingest_demo_dir_idempotent(tmp_path):
+    dsn = setup_sqlite(tmp_path)
+    demo_dir = tmp_path / "dir"
+    demo_dir.mkdir()
+    data = {"items": _demo_items()}
+    with open(demo_dir / "demo.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, allow_unicode=True)
+
+    n1 = run_ingest(str(demo_dir), dsn=dsn)
+    assert n1 == len(data["items"])
+    n2 = run_ingest(str(demo_dir), dsn=dsn)
+    assert n2 == len(data["items"])
+
+    session = SessionLocal()
+    repo = Repo(session)
+    docs = repo.list_latest()
+    assert len(docs) == len(data["items"])
+    combos = {(d.jurisdiction, d.act_code, d.section_code) for d in docs}
+    assert len(combos) == len(data["items"])
+    for d in docs:
+        assert d.latest is True
+    session.close()
+
+
+def test_find_query_and_titles(tmp_path):
+    dsn = setup_sqlite(tmp_path)
+    demo_dir = tmp_path / "dir"
+    demo_dir.mkdir()
+    items = _demo_items()
+    with open(demo_dir / "demo.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump({"items": items}, fh, allow_unicode=True)
+    run_ingest(str(demo_dir), dsn=dsn)
+    session = SessionLocal()
+    repo = Repo(session)
+    res1 = repo.find(jurisdiction="UK", act_code="UK_GDPR", q="transparent")
+    assert res1
+    res2 = repo.find(jurisdiction="UK", act_code="UK_GDPR", q="Principles")
+    assert res2
+    session.close()
+
+
+def test_checksum_normalization(tmp_path):
+    dsn = setup_sqlite(tmp_path)
+    session = SessionLocal()
+    repo = Repo(session)
+    item = {
+        "source": "legislation.gov.uk",
+        "jurisdiction": "UK",
+        "act_code": "UK_GDPR",
+        "act_title": "UK GDPR",
+        "section_code": "Art.99",
+        "section_title": "Special provision",
+        "version": "2024-06",
+        "updated_at": "2024-06-01T00:00:00Z",
+        "rights": "Open Government Licence v3.0",
+        "lang": "en",
+        "script": "Latn",
+        "text": "Quotes\u00A0and “spaces”",
+    }
+    dto1 = to_repo_dto(item)
+    repo.upsert(dto1)
+    item["text"] = 'Quotes and "spaces"'
+    dto2 = to_repo_dto(item)
+    repo.upsert(dto2)
+    docs = repo.list_latest()
+    assert len(docs) == 1
+    session.close()

--- a/data/corpus_demo/dpa_2018_s28.yaml
+++ b/data/corpus_demo/dpa_2018_s28.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "DPA_2018"
+    act_title: "Data Protection Act 2018"
+    section_code: "s.28(3)"
+    section_title: "National security certificates"
+    version: "2024-06"
+    updated_at: "2024-06-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/2018/12/section/28"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      A certificate issued by a Minister of the Crown certifying that exemption is required for the purpose of safeguarding national security…

--- a/data/corpus_demo/oguk_sample_indemnity.yaml
+++ b/data/corpus_demo/oguk_sample_indemnity.yaml
@@ -1,0 +1,14 @@
+items:
+  - source: "OGUK"
+    jurisdiction: "UK"
+    act_code: "OGUK_MODEL"
+    act_title: "OGUK Model Form"
+    section_code: "Indemnity"
+    section_title: "Sample mutual indemnity clause"
+    version: "2024-06"
+    updated_at: "2024-06-01T00:00:00Z"
+    rights: "OGUK Licence"
+    lang: "en"
+    script: "Latn"
+    text: |
+      Each party shall indemnify the other against all claims and losses arising from the indemnifying party's operations…

--- a/data/corpus_demo/ucta_1977_s2.yaml
+++ b/data/corpus_demo/ucta_1977_s2.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "UCTA_1977"
+    act_title: "Unfair Contract Terms Act 1977"
+    section_code: "s.2"
+    section_title: "Negligence liability"
+    version: "2024-06"
+    updated_at: "2024-06-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/1977/50/section/2"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      A person cannot by reference to any contract term restrict his liability for death or personal injury resulting from negligence…

--- a/data/corpus_demo/uk_gdpr_art28.yaml
+++ b/data/corpus_demo/uk_gdpr_art28.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "UK_GDPR"
+    act_title: "UK GDPR"
+    section_code: "Art.28"
+    section_title: "Processor"
+    version: "2024-06"
+    updated_at: "2024-06-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/eur/2016/679/article/28"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      The processor shall not engage another processor without prior specific or general written authorisation…

--- a/data/corpus_demo/uk_gdpr_art5.yaml
+++ b/data/corpus_demo/uk_gdpr_art5.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "UK_GDPR"
+    act_title: "UK GDPR"
+    section_code: "Art.5"
+    section_title: "Principles relating to processing of personal data"
+    version: "2024-06"
+    updated_at: "2024-06-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/eur/2016/679/article/5"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      Personal data shall be processed lawfully, fairly and in a transparent manner…


### PR DESCRIPTION
## Summary
- add corpus package with SQLAlchemy models, repository and normalization utilities
- implement deterministic ETL ingest with checksum-based upsert and CLI
- include demo UK corpus YAML files and regression tests

## Testing
- `python -m pytest -q contract_review_app/tests/corpus/test_b5_ingest.py::test_ingest_demo_dir_idempotent --maxfail=1`
- `python -m pytest -q contract_review_app/tests/corpus/test_b5_ingest.py::test_find_query_and_titles --maxfail=1`
- `python -m pytest -q contract_review_app/tests/corpus/test_b5_ingest.py::test_checksum_normalization --maxfail=1`
- `python -m pytest -q -p no:cov` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `python -m contract_review_app.corpus.ingest --dir data/corpus_demo`


------
https://chatgpt.com/codex/tasks/task_e_68b35dcebb94832580f47664c1313c30