### PR TITLE
feat: enforce corpus invariants with DB guard and property tests

### DIFF
--- a/contract_review_app/corpus/__init__.py
+++ b/contract_review_app/corpus/__init__.py
@@ -1,0 +1,14 @@
+from .db import Base, LegalCorpus, SessionLocal, get_engine, init_db
+from .repo import Repo, CorpusDTO, normalize_text, compute_checksum
+
+__all__ = [
+    "Base",
+    "LegalCorpus",
+    "SessionLocal",
+    "get_engine",
+    "init_db",
+    "Repo",
+    "CorpusDTO",
+    "normalize_text",
+    "compute_checksum",
+]

--- a/contract_review_app/corpus/db.py
+++ b/contract_review_app/corpus/db.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+)
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+Base = declarative_base()
+
+
+class LegalCorpus(Base):
+    __tablename__ = "legal_corpus"
+
+    id = Column(Integer, primary_key=True)
+    jurisdiction = Column(String, nullable=False)
+    act_code = Column(String, nullable=False)
+    section_code = Column(String, nullable=False)
+    version = Column(String, nullable=False)
+    text = Column(Text, nullable=False)
+    checksum = Column(String, nullable=False)
+    latest = Column(Boolean, default=True, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "jurisdiction",
+            "act_code",
+            "section_code",
+            "version",
+            name="uq_doc_version",
+        ),
+    )
+
+
+SessionLocal = sessionmaker()
+
+
+def get_engine(dsn: str):
+    return create_engine(dsn, future=True)
+
+
+def _exec_ddl(engine, sql: str) -> None:
+    with engine.connect() as conn:
+        conn.exec_driver_sql(sql)
+
+
+def init_db(engine, create_all: bool = True) -> None:
+    if create_all:
+        Base.metadata.create_all(engine)
+    dialect = engine.dialect.name
+    if dialect == "sqlite":
+        ddl = """CREATE UNIQUE INDEX IF NOT EXISTS ux_latest_unique
+ON legal_corpus (jurisdiction, act_code, section_code)
+WHERE latest = 1"""
+        _exec_ddl(engine, ddl)
+    elif dialect == "postgresql":
+        ddl = """CREATE UNIQUE INDEX IF NOT EXISTS ux_latest_unique
+ON legal_corpus (jurisdiction, act_code, section_code)
+WHERE latest = TRUE"""
+        _exec_ddl(engine, ddl)

--- a/contract_review_app/corpus/repo.py
+++ b/contract_review_app/corpus/repo.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from sqlalchemy import select, update, func
+
+from .db import LegalCorpus
+
+
+_TRANSLATION = str.maketrans(
+    {
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u00a0": " ",
+    }
+)
+
+
+def normalize_text(text: str) -> str:
+    text = text.translate(_TRANSLATION)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def compute_checksum(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class CorpusDTO:
+    jurisdiction: str
+    act_code: str
+    section_code: str
+    version: str
+    text: str
+
+
+class Repo:
+    def __init__(self, Session):
+        self.Session = Session
+
+    def upsert(self, dto: CorpusDTO) -> LegalCorpus:
+        with self.Session() as session:
+            with session.begin():
+                norm = normalize_text(dto.text)
+                ch = compute_checksum(norm)
+                stmt = select(LegalCorpus).where(
+                    LegalCorpus.jurisdiction == dto.jurisdiction,
+                    LegalCorpus.act_code == dto.act_code,
+                    LegalCorpus.section_code == dto.section_code,
+                    LegalCorpus.version == dto.version,
+                )
+                existing = session.execute(stmt).scalar_one_or_none()
+                if existing:
+                    if existing.checksum != ch:
+                        existing.text = dto.text
+                        existing.checksum = ch
+                else:
+                    existing = LegalCorpus(
+                        jurisdiction=dto.jurisdiction,
+                        act_code=dto.act_code,
+                        section_code=dto.section_code,
+                        version=dto.version,
+                        text=dto.text,
+                        checksum=ch,
+                        latest=False,
+                    )
+                    session.add(existing)
+
+                session.execute(
+                    update(LegalCorpus)
+                    .where(
+                        LegalCorpus.jurisdiction == dto.jurisdiction,
+                        LegalCorpus.act_code == dto.act_code,
+                        LegalCorpus.section_code == dto.section_code,
+                    )
+                    .values(latest=False)
+                )
+                max_row = session.execute(
+                    select(LegalCorpus)
+                    .where(
+                        LegalCorpus.jurisdiction == dto.jurisdiction,
+                        LegalCorpus.act_code == dto.act_code,
+                        LegalCorpus.section_code == dto.section_code,
+                    )
+                    .order_by(LegalCorpus.version.desc())
+                    .limit(1)
+                ).scalar_one()
+                max_row.latest = True
+                session.flush()
+                session.expunge(existing)
+                return existing
+
+    def group_latest_count(
+        self, jurisdiction: str, act_code: str, section_code: str
+    ) -> int:
+        with self.Session() as session:
+            return session.scalar(
+                select(func.count()).where(
+                    LegalCorpus.jurisdiction == jurisdiction,
+                    LegalCorpus.act_code == act_code,
+                    LegalCorpus.section_code == section_code,
+                    LegalCorpus.latest.is_(True),
+                )
+            )
+
+    def list_latest(self, filters: Optional[dict] = None) -> Iterable[LegalCorpus]:
+        filters = filters or {}
+        with self.Session() as session:
+            stmt = select(LegalCorpus).where(LegalCorpus.latest.is_(True))
+            if "jurisdiction" in filters:
+                stmt = stmt.where(LegalCorpus.jurisdiction == filters["jurisdiction"])
+            if "act_code" in filters:
+                stmt = stmt.where(LegalCorpus.act_code == filters["act_code"])
+            if "section_code" in filters:
+                stmt = stmt.where(LegalCorpus.section_code == filters["section_code"])
+            return session.execute(stmt).scalars().all()

--- a/contract_review_app/tests/corpus/test_b5_properties.py
+++ b/contract_review_app/tests/corpus/test_b5_properties.py
@@ -1,0 +1,123 @@
+"""Property tests for legal corpus invariants."""
+
+# ruff: noqa: E402
+
+import os
+import re
+
+import pytest
+from sqlalchemy import select, func
+
+from contract_review_app.corpus import (
+    CorpusDTO,
+    Repo,
+    SessionLocal,
+    get_engine,
+    init_db,
+    LegalCorpus,
+)
+
+hypothesis = pytest.importorskip(
+    "hypothesis", reason="property tests require hypothesis"
+)
+from hypothesis import (
+    HealthCheck,
+    given,
+    settings,
+    strategies as st,
+)  # noqa: E402
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    dsn = f"sqlite:///{tmp_path/'corpus_prop.db'}"
+    os.environ["LEGAL_CORPUS_DSN"] = dsn
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    return Repo(SessionLocal)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    st.permutations(["2024-01", "2024-02", "2024-03", "2024-04"]),
+    st.lists(st.text(min_size=1), min_size=4, max_size=4),
+)
+def test_latest_singleton_property(repo, versions, noises):
+    j, a, s = "UK", "UK_GDPR", "Art.5"
+    for v, noise in zip(versions, noises):
+        text = f"Article text {v} {noise}"
+        repo.upsert(
+            CorpusDTO(jurisdiction=j, act_code=a, section_code=s, version=v, text=text)
+        )
+        assert repo.group_latest_count(j, a, s) == 1
+
+    latest = repo.list_latest({"jurisdiction": j, "act_code": a})
+    assert latest and latest[0].version == max(versions)
+
+
+_base_text = " \"Hello\" world and \n\n\t'quotes' "
+
+
+def _variant(base, nbsp, curly, multispace):
+    text = base
+    if nbsp:
+        text = text.replace(" ", "\u00a0")
+    if curly:
+        text = text.replace('"', "\u201c").replace("'", "\u2019")
+    if multispace:
+        text = re.sub(" ", "  ", text)
+    return text
+
+
+variant_strategy = st.builds(
+    _variant,
+    st.just(_base_text),
+    st.booleans(),
+    st.booleans(),
+    st.booleans(),
+)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.lists(variant_strategy, min_size=1, max_size=5))
+def test_checksum_normalization_property(repo, variants):
+    j, a, s, v = "UK", "UK_GDPR", "Art.5", "2024-01"
+    checksums = set()
+    for text in variants:
+        row = repo.upsert(CorpusDTO(j, a, s, v, text))
+        checksums.add(row.checksum)
+    assert len(checksums) == 1
+
+    with repo.Session() as session:
+        count = session.scalar(
+            select(func.count()).where(
+                LegalCorpus.jurisdiction == j,
+                LegalCorpus.act_code == a,
+                LegalCorpus.section_code == s,
+                LegalCorpus.version == v,
+            )
+        )
+    assert count == 1
+
+
+def test_unique_version_invariant(repo):
+    j, a, s, v = "UK", "UK_GDPR", "Art.5", "2024-02"
+    repo.upsert(CorpusDTO(j, a, s, v, "first"))
+    repo.upsert(CorpusDTO(j, a, s, v, "second"))
+
+    with repo.Session() as session:
+        rows = (
+            session.execute(
+                select(LegalCorpus).where(
+                    LegalCorpus.jurisdiction == j,
+                    LegalCorpus.act_code == a,
+                    LegalCorpus.section_code == s,
+                    LegalCorpus.version == v,
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    assert rows[0].text == "second"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-docx>=0.8.11
 pytest>=8
 pyyaml
 pytest-cov
+sqlalchemy>=2.0


### PR DESCRIPTION
## Summary
- ensure one latest corpus entry per group via partial unique index
- normalize text for deterministic checksums and transactional upsert
- add Hypothesis property tests for latest singleton, checksum normalization, and version uniqueness

## Testing
- `HYPOTHESIS_MAX_EXAMPLES=100 python -m pytest -q contract_review_app/tests/corpus/test_b5_properties.py --maxfail=1`
- `HYPOTHESIS_MAX_EXAMPLES=100 python -m pytest -q -p no:cov --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68b35e0e9f80832590be226d5fe4843d