### PR TITLE
feat: add legal corpus ingest and demo data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ ruff_cache/
 pytest_cache/
 .mypy_cache/
 .cache/
+.hypothesis/
+.local/
 
 # Reports and logs
 reports/

--- a/contract_review_app/corpus/ingest.py
+++ b/contract_review_app/corpus/ingest.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Dict, Any
+
+import yaml
+
+from .normalizer import normalize_text, utc_iso, checksum_for
+from .db import get_engine, init_db, SessionLocal
+from .repo import Repo
+
+REQUIRED_FIELDS = {
+    "source",
+    "jurisdiction",
+    "act_code",
+    "act_title",
+    "section_code",
+    "section_title",
+    "version",
+    "updated_at",
+    "text",
+    "rights",
+}
+
+
+def load_dir(dir_path: str) -> List[Dict[str, Any]]:
+    """Load all YAML items from ``dir_path``.
+
+    Each ``*.yaml`` file may contain a single object or ``{"items": [...]}``.
+    Returns a list of item dictionaries after validating required fields.
+    """
+
+    path = Path(dir_path)
+    items: List[Dict[str, Any]] = []
+    for file in sorted(path.glob("*.yaml")):
+        with open(file, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        if isinstance(data, dict) and "items" in data:
+            objs = data.get("items", []) or []
+        else:
+            objs = [data]
+        for obj in objs:
+            missing = [f for f in REQUIRED_FIELDS if f not in obj]
+            if missing:
+                raise ValueError(f"Missing fields {missing} in {file}")
+            items.append(obj)
+    return items
+
+
+def to_repo_dto(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise fields and compute checksum for repository ingestion."""
+
+    text = normalize_text(item["text"])
+    updated_at = utc_iso(item["updated_at"])
+    checksum = checksum_for(
+        item["jurisdiction"],
+        item["act_code"],
+        item["section_code"],
+        item["version"],
+        text,
+    )
+    dto = dict(item)
+    dto["text"] = text
+    dto["updated_at"] = updated_at
+    dto["checksum"] = checksum
+    return dto
+
+
+def run_ingest(dir_path: str, *, dsn: str | None = None) -> int:
+    """Ingest YAML files from ``dir_path`` into the corpus database."""
+
+    if dsn is None:
+        dsn = os.getenv("LEGAL_CORPUS_DSN")
+    if dsn is None:
+        local = Path(".local")
+        local.mkdir(exist_ok=True)
+        dsn = f"sqlite:///{(local / 'corpus.db').resolve()}"
+
+    engine = get_engine(dsn)
+    init_db(engine)
+
+    session = SessionLocal(bind=engine)
+    repo = Repo(session)
+
+    records = load_dir(dir_path)
+    for item in records:
+        repo.upsert(to_repo_dto(item))
+
+    session.close()
+    return len(records)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--dir", required=True)
+    p.add_argument("--dsn", default=os.getenv("LEGAL_CORPUS_DSN"))
+    args = p.parse_args()
+    n = run_ingest(args.dir, dsn=args.dsn)
+    print(f"Ingested records: {n}")

--- a/contract_review_app/corpus/repo.py
+++ b/contract_review_app/corpus/repo.py
@@ -144,3 +144,7 @@ class CorpusRepository:
     def delete_all(self) -> None:
         with self.session.begin():
             self.session.execute(delete(CorpusDoc))
+
+
+# Backwards-compatible alias
+Repo = CorpusRepository

--- a/contract_review_app/tests/corpus/test_b5_ingest.py
+++ b/contract_review_app/tests/corpus/test_b5_ingest.py
@@ -1,0 +1,138 @@
+import os
+from pathlib import Path
+
+import yaml
+
+from contract_review_app.corpus.db import get_engine, init_db, SessionLocal
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.corpus.ingest import run_ingest, to_repo_dto
+
+
+def setup_sqlite(tmp_path):
+    dsn = f"sqlite:///{tmp_path / 'corpus.db'}"
+    os.environ["LEGAL_CORPUS_DSN"] = dsn
+    engine = get_engine(dsn)
+    init_db(engine)
+    return dsn
+
+
+ITEM_ART5 = {
+    "source": "legislation.gov.uk",
+    "jurisdiction": "UK",
+    "act_code": "UK_GDPR",
+    "act_title": "UK GDPR",
+    "section_code": "Art.5",
+    "section_title": "Principles relating to processing of personal data",
+    "version": "2024-06",
+    "updated_at": "2024-06-01T00:00:00Z",
+    "url": "https://www.legislation.gov.uk/eur/2016/679/article/5",
+    "rights": "Open Government Licence v3.0",
+    "lang": "en",
+    "script": "Latn",
+    "text": "Personal data shall be processed lawfully, fairly and in a transparent manner…",
+}
+
+ITEM_ART28 = {
+    "source": "legislation.gov.uk",
+    "jurisdiction": "UK",
+    "act_code": "UK_GDPR",
+    "act_title": "UK GDPR",
+    "section_code": "Art.28",
+    "section_title": "Processor",
+    "version": "2024-06",
+    "updated_at": "2024-06-01T00:00:00Z",
+    "url": "https://www.legislation.gov.uk/eur/2016/679/article/28",
+    "rights": "Open Government Licence v3.0",
+    "lang": "en",
+    "script": "Latn",
+    "text": "The processor shall not engage another processor without prior authorisation of the controller.",
+}
+
+ITEM_UCTA = {
+    "source": "legislation.gov.uk",
+    "jurisdiction": "UK",
+    "act_code": "UCTA_1977",
+    "act_title": "Unfair Contract Terms Act 1977",
+    "section_code": "s.2",
+    "section_title": "Negligence liability",
+    "version": "2020-01",
+    "updated_at": "2020-01-01T00:00:00Z",
+    "url": "https://www.legislation.gov.uk/ukpga/1977/50/section/2",
+    "rights": "Open Government Licence v3.0",
+    "lang": "en",
+    "script": "Latn",
+    "text": "A person cannot exclude or restrict liability for negligence resulting in death or personal injury.",
+}
+
+
+def _write_items(dir_path: Path, items):
+    with open(dir_path / "demo.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump({"items": items}, fh, sort_keys=False, allow_unicode=True)
+
+
+def test_ingest_demo_dir_idempotent(tmp_path):
+    dsn = setup_sqlite(tmp_path)
+    demo_dir = tmp_path / "dir"
+    demo_dir.mkdir()
+    _write_items(demo_dir, [ITEM_ART5, ITEM_ART28, ITEM_UCTA])
+
+    n1 = run_ingest(str(demo_dir), dsn=dsn)
+    assert n1 == 3
+    n2 = run_ingest(str(demo_dir), dsn=dsn)
+    assert n2 == 3
+
+    session = SessionLocal(bind=get_engine(dsn))
+    repo = Repo(session)
+    latest_docs = repo.list_latest()
+    assert len(latest_docs) == 3
+    assert all(doc.latest for doc in latest_docs)
+    keys = {(d.jurisdiction, d.act_code, d.section_code) for d in latest_docs}
+    assert len(keys) == 3
+    all_docs = repo.find()
+    assert len(all_docs) == 3
+
+
+def test_find_query_and_titles(tmp_path):
+    dsn = setup_sqlite(tmp_path)
+    demo_dir = tmp_path / "dir"
+    demo_dir.mkdir()
+    _write_items(demo_dir, [ITEM_ART5])
+    run_ingest(str(demo_dir), dsn=dsn)
+
+    session = SessionLocal(bind=get_engine(dsn))
+    repo = Repo(session)
+    res = repo.find(jurisdiction="UK", act_code="UK_GDPR", q="transparent")
+    assert len(res) == 1
+    res2 = repo.find(jurisdiction="UK", act_code="UK_GDPR", q="Principles")
+    assert len(res2) == 1
+
+
+def test_checksum_normalization(tmp_path):
+    dsn = setup_sqlite(tmp_path)
+    engine = get_engine(dsn)
+    session = SessionLocal(bind=engine)
+    repo = Repo(session)
+
+    item = {
+        "source": "legislation.gov.uk",
+        "jurisdiction": "UK",
+        "act_code": "UK_GDPR",
+        "act_title": "UK GDPR",
+        "section_code": "Art.5",
+        "section_title": "Principles",
+        "version": "2024-06",
+        "updated_at": "2024-06-01T00:00:00Z",
+        "rights": "Open Government Licence v3.0",
+        "text": "Data must be processed lawfully\u00A0and “fairly”.",
+    }
+    dto1 = to_repo_dto(item)
+    repo.upsert(dto1)
+
+    item2 = dict(item)
+    item2["text"] = "Data must be processed lawfully and \"fairly\"."
+    dto2 = to_repo_dto(item2)
+    assert dto1["checksum"] == dto2["checksum"]
+    repo.upsert(dto2)
+
+    all_docs = repo.find()
+    assert len(all_docs) == 1

--- a/data/corpus_demo/dpa_2018_s28.yaml
+++ b/data/corpus_demo/dpa_2018_s28.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "DPA_2018"
+    act_title: "Data Protection Act 2018"
+    section_code: "s.28(3)"
+    section_title: "National security and defence"
+    version: "2023-12"
+    updated_at: "2023-12-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/2018/12/section/28"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      This Act does not apply to personal data processed for the purposes of safeguarding national security.

--- a/data/corpus_demo/oguk_sample_indemnity.yaml
+++ b/data/corpus_demo/oguk_sample_indemnity.yaml
@@ -1,0 +1,14 @@
+items:
+  - source: "OGUK"
+    jurisdiction: "UK"
+    act_code: "OGUK_MODEL"
+    act_title: "OGUK Model Form"
+    section_code: "Indemnity"
+    section_title: "Indemnity clause"
+    version: "2024-01"
+    updated_at: "2024-01-01T00:00:00Z"
+    rights: "OGUK sample rights"
+    lang: "en"
+    script: "Latn"
+    text: |
+      Contractor shall indemnify the Company against all claims arising from pollution.

--- a/data/corpus_demo/ucta_1977_s2.yaml
+++ b/data/corpus_demo/ucta_1977_s2.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "UCTA_1977"
+    act_title: "Unfair Contract Terms Act 1977"
+    section_code: "s.2"
+    section_title: "Negligence liability"
+    version: "2020-01"
+    updated_at: "2020-01-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/1977/50/section/2"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      A person cannot exclude or restrict liability for negligence resulting in death or personal injury.

--- a/data/corpus_demo/uk_gdpr_art28.yaml
+++ b/data/corpus_demo/uk_gdpr_art28.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "UK_GDPR"
+    act_title: "UK GDPR"
+    section_code: "Art.28"
+    section_title: "Processor"
+    version: "2024-06"
+    updated_at: "2024-06-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/eur/2016/679/article/28"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      The processor shall not engage another processor without prior authorisation of the controller.

--- a/data/corpus_demo/uk_gdpr_art5.yaml
+++ b/data/corpus_demo/uk_gdpr_art5.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "UK_GDPR"
+    act_title: "UK GDPR"
+    section_code: "Art.5"
+    section_title: "Principles relating to processing of personal data"
+    version: "2024-06"
+    updated_at: "2024-06-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/eur/2016/679/article/5"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      Personal data shall be processed lawfully, fairly and in a transparent manner…


### PR DESCRIPTION
## Summary
- implement deterministic corpus ingest utilities
- include demo UK corpus YAML files
- test ingestion idempotence and search functionality

## Testing
- `python -m pytest -q contract_review_app/tests/corpus/test_b5_ingest.py::test_ingest_demo_dir_idempotent --maxfail=1`
- `python -m pytest -q contract_review_app/tests/corpus/test_b5_ingest.py::test_find_query_and_titles --maxfail=1`
- `python -m pytest -q contract_review_app/tests/corpus/test_b5_ingest.py::test_checksum_normalization --maxfail=1`
- `python -m pytest -q -p no:cov`
- `python -m contract_review_app.corpus.ingest --dir data/corpus_demo`


------
https://chatgpt.com/codex/tasks/task_e_68b360219eac83259fe00012d559e0f9