### PR TITLE
Add corpus tooling, CI workflow, and migration docs

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -1,0 +1,28 @@
+name: Corpus
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    paths:
+      - "contract_review_app/corpus/**"
+      - "data/corpus_demo/**"
+      - "contract_review_app/tests/corpus/**"
+
+jobs:
+  corpus:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m pip install -U pip
+      - run: pip install -r requirements-dev.txt
+      - run: pytest -q contract_review_app/tests/corpus --maxfail=1 --disable-warnings -p no:cov
+      - run: python -m contract_review_app.corpus.ingest --dir data/corpus_demo > corpus_demo_report.txt
+      - name: Upload demo corpus report
+        uses: actions/upload-artifact@v4
+        with:
+          name: corpus_demo_report
+          path: corpus_demo_report.txt

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,1 +1,50 @@
-B5-1 introduces DTO only
+# Block B5 — Legal Corpus & Metadata
+
+## Schema
+
+```sql
+CREATE TABLE legal_corpus (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    jurisdiction TEXT NOT NULL,
+    act_code TEXT NOT NULL,
+    act_title TEXT NOT NULL,
+    section_code TEXT NOT NULL,
+    section_title TEXT NOT NULL,
+    version TEXT NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    url TEXT,
+    rights TEXT NOT NULL,
+    lang TEXT,
+    script TEXT,
+    text TEXT NOT NULL,
+    checksum TEXT NOT NULL,
+    latest BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX uq_doc_version
+ON legal_corpus (jurisdiction, act_code, section_code, version);
+
+CREATE UNIQUE INDEX ux_latest_unique
+ON legal_corpus (jurisdiction, act_code, section_code)
+WHERE latest = TRUE;
+```
+
+## Usage
+
+Dev/CI: SQLite (sqlite:///.local/corpus.db)
+
+Prod: PostgreSQL (postgresql+psycopg://...)
+
+Run demo ingest:
+
+```bash
+make corpus-demo
+```
+
+Run tests:
+
+```bash
+make corpus-test
+```

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,23 @@
-﻿.PHONY: lint fix test regen-snapshots test-cov
+.PHONY: lint fix test regen-snapshots test-cov corpus-demo corpus-test
+
 lint:
-\truff check . && isort --check-only . && black --check .
+	ruff check . && isort --check-only . && black --check .
+
 fix:
-\truff check . --fix && isort . && black .
+	ruff check . --fix && isort . && black .
+
 test:
-\tPYTHONPATH=. pytest contract_review_app/tests -q
+	PYTHONPATH=. pytest contract_review_app/tests -q
+
 regen-snapshots:
-\tPYTHONPATH=. pytest contract_review_app/tests/report/test_renderer_matrix_snapshots.py::test_renderer_snapshots -q -p no:cov --force-regen
+	PYTHONPATH=. pytest contract_review_app/tests/report/test_renderer_matrix_snapshots.py::test_renderer_snapshots -q -p no:cov --force-regen
+
 test-cov:
-\tPYTHONPATH=. pytest contract_review_app/tests -q --cov=contract_review_app/report --cov-branch --cov-report=term-missing
+	PYTHONPATH=. pytest contract_review_app/tests -q --cov=contract_review_app/report --cov-branch --cov-report=term-missing
+
+corpus-demo:
+	@echo "Running corpus ingest on demo data..."
+	python -m contract_review_app.corpus.ingest --dir data/corpus_demo
+
+corpus-test:
+	pytest -q contract_review_app/tests/corpus --maxfail=1

--- a/contract_review_app/corpus/report.py
+++ b/contract_review_app/corpus/report.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from .db import get_engine, init_db, SessionLocal
+
+
+def corpus_summary(session) -> dict:
+    from sqlalchemy import func
+    from .models import CorpusDoc
+
+    rows = (
+        session.query(
+            CorpusDoc.jurisdiction,
+            CorpusDoc.act_code,
+            func.count().label("sections"),
+        )
+        .filter(CorpusDoc.latest == True)
+        .group_by(CorpusDoc.jurisdiction, CorpusDoc.act_code)
+        .all()
+    )
+    return {f"{j}/{a}": s for j, a, s in rows}
+
+
+def main() -> dict:
+    dsn = os.getenv("LEGAL_CORPUS_DSN")
+    if dsn is None:
+        local = Path(".local")
+        local.mkdir(exist_ok=True)
+        dsn = f"sqlite:///{(local / 'corpus.db').resolve()}"
+
+    engine = get_engine(dsn)
+    init_db(engine, create_all=False)
+    session = SessionLocal(bind=engine)
+    summary = corpus_summary(session)
+    session.close()
+
+    text = json.dumps(summary, indent=2, sort_keys=True)
+    print(text)
+    Path("corpus_demo_report.json").write_text(text, encoding="utf-8")
+    return summary
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/scripts/corpus.ps1
+++ b/scripts/corpus.ps1
@@ -1,0 +1,9 @@
+param([switch]$Test, [switch]$Demo)
+
+if ($Demo) {
+    Write-Host "Running corpus ingest on demo data..."
+    python -m contract_review_app.corpus.ingest --dir data/corpus_demo
+}
+elseif ($Test) {
+    pytest -q contract_review_app/tests/corpus --maxfail=1
+}


### PR DESCRIPTION
## Summary
- Add Make targets and Windows script for demo ingest and corpus tests
- Introduce corpus GitHub Actions workflow and report generator
- Document legal corpus schema and usage in MIGRATION.md

## Testing
- `python -m pytest contract_review_app/tests/corpus --maxfail=1`
- `python -m contract_review_app.corpus.ingest --dir data/corpus_demo`
- `python -m contract_review_app.corpus.report`


------
https://chatgpt.com/codex/tasks/task_e_68b36976ff848325998abdd5ddacbdd0