### PR TITLE
feat: add doctor v2 maturity matrix

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,1 +1,31 @@
-B5-1 introduces DTO only
+# Doctor v2 Migration
+
+The doctor collects diagnostics and a 14-block maturity matrix.
+
+## Running
+
+```bash
+python tools/doctor.py --out reports/latest/analysis --json --html
+```
+
+This writes `reports/latest/analysis.json`, `reports/latest/analysis.html` and a `state.log` in the same folder.
+
+## Reading the report
+
+- `generated_at_utc` – UTC ISO8601 timestamp.
+- `overall_score` – average of all block scores.
+- `blocks` – 14 items (`B0`..`B13`) with `status` (`OK`, `WARN`, `MISSING`), `score`, `metrics` and `notes`.
+
+## CLI help
+
+```
+$ python tools/doctor.py --help
+usage: doctor.py --out OUT [--json] [--html]
+
+Collect project diagnostics
+
+optional arguments:
+  --out OUT   Output file prefix for the report
+  --json      Write JSON report
+  --html      Write HTML report
+```

--- a/tests/codex/test_app_analyze_hook.py
+++ b/tests/codex/test_app_analyze_hook.py
@@ -1,15 +1,17 @@
-import json, subprocess, sys
+import json
+import subprocess
+import sys
 
 
 def _run_doctor(tmp_path, monkeypatch):
-    out_dir = tmp_path / "diag"
-    out_dir.mkdir()
+    prefix = tmp_path / "diag" / "analysis"
+    prefix.parent.mkdir()
     monkeypatch.setenv("LLM_PROVIDER", "mock")
     monkeypatch.setenv("LLM_MODEL", "mock")
     monkeypatch.setenv("LLM_TIMEOUT", "5")
-    cmd = [sys.executable, "tools/doctor.py", "--out", str(out_dir), "--json"]
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(prefix), "--json"]
     assert subprocess.call(cmd) == 0
-    return json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+    return json.loads(prefix.with_suffix(".json").read_text(encoding="utf-8"))
 
 
 def test_app_has_analyze_hook(monkeypatch):

--- a/tests/codex/test_doctor_addin.py
+++ b/tests/codex/test_doctor_addin.py
@@ -4,12 +4,12 @@ import sys
 
 
 def test_doctor_addin_section(tmp_path):
-    out_dir = tmp_path / "diag"
-    out_dir.mkdir()
-    cmd = [sys.executable, "tools/doctor.py", "--out", str(out_dir), "--json"]
+    prefix = tmp_path / "diag" / "analysis"
+    prefix.parent.mkdir()
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(prefix), "--json"]
     rc = subprocess.call(cmd)
     assert rc == 0
-    data = json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+    data = json.loads(prefix.with_suffix(".json").read_text(encoding="utf-8"))
     addin = data.get("addin", {})
     assert "manifest" in addin and "bundle" in addin
 

--- a/tests/codex/test_doctor_repo_hygiene.py
+++ b/tests/codex/test_doctor_repo_hygiene.py
@@ -4,15 +4,15 @@ import sys
 
 
 def test_doctor_repo_hygiene(tmp_path, monkeypatch):
-    out_dir = tmp_path / "diag"
-    out_dir.mkdir()
+    prefix = tmp_path / "diag" / "analysis"
+    prefix.parent.mkdir()
     monkeypatch.setenv("LLM_PROVIDER", "mock")
     monkeypatch.setenv("LLM_MODEL", "mock")
     monkeypatch.setenv("LLM_TIMEOUT", "5")
-    cmd = [sys.executable, "tools/doctor.py", "--out", str(out_dir), "--json"]
+    cmd = [sys.executable, "tools/doctor.py", "--out", str(prefix), "--json"]
     rc = subprocess.call(cmd)
     assert rc == 0
-    data = json.loads((out_dir / "analysis.json").read_text(encoding="utf-8"))
+    data = json.loads(prefix.with_suffix(".json").read_text(encoding="utf-8"))
     assert "repo" in data
     repo = data["repo"]
     assert "tracked_pyc" in repo

--- a/tests/tools/test_doctor_blocks.py
+++ b/tests/tools/test_doctor_blocks.py
@@ -1,0 +1,98 @@
+import json
+
+from tools import doctor
+
+
+ALLOWED_STATUSES = {"OK", "WARN", "MISSING"}
+
+
+def _stub_gatherers(monkeypatch):
+    monkeypatch.setattr(doctor, "gather_env", lambda: {"env": {"NO_RETENTION": "1"}})
+    monkeypatch.setattr(doctor, "gather_git", lambda: {})
+    monkeypatch.setattr(doctor, "gather_precommit", lambda: {"config_exists": True})
+    monkeypatch.setattr(
+        doctor,
+        "gather_backend",
+        lambda: {
+            "endpoints": [
+                {"path": "/api/analyze", "method": "POST"},
+                {"path": "/api/gpt/draft", "method": "POST"},
+                {"path": "/api/learning/item", "method": "GET"},
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        doctor,
+        "gather_llm",
+        lambda backend: {
+            "providers_detected": ["mock"],
+            "node_is_mock": True,
+            "has_draft_endpoint": True,
+        },
+    )
+    monkeypatch.setattr(doctor, "gather_service", lambda: {"exports": {"LLMService": True}})
+    monkeypatch.setattr(doctor, "gather_api", lambda: {})
+    monkeypatch.setattr(
+        doctor,
+        "gather_rules",
+        lambda: {"python": {"count": 1, "samples": []}, "yaml": {"count": 0, "samples": []}},
+    )
+    monkeypatch.setattr(
+        doctor,
+        "gather_addin",
+        lambda: {"manifest": {"exists": False}, "bundle": {"exists": False}},
+    )
+    monkeypatch.setattr(doctor, "gather_runtime", lambda: {})
+    monkeypatch.setattr(doctor, "gather_inventory", lambda: {})
+    monkeypatch.setattr(doctor, "gather_repo", lambda: {})
+    monkeypatch.setattr(
+        doctor,
+        "gather_quality",
+        lambda: {"ruff": {"status": "ok", "issues_total": 0}, "mypy": {"status": "ok", "errors_total": 0}},
+    )
+    monkeypatch.setattr(doctor, "gather_smoke", lambda: {})
+
+
+def test_blocks_present_and_ids_unique():
+    ids = [b["id"] for b in doctor.BLOCKS]
+    assert len(ids) == 14
+    assert ids == [f"B{i}" for i in range(14)]
+    assert len(set(ids)) == 14
+
+
+def test_json_structure_and_status_values(monkeypatch, tmp_path):
+    _stub_gatherers(monkeypatch)
+    prefix = tmp_path / "analysis"
+    doctor.main(["--out", str(prefix), "--json", "--html"])
+    data = json.loads(prefix.with_suffix(".json").read_text("utf-8"))
+    assert "generated_at_utc" in data
+    assert "overall_score" in data
+    assert len(data["blocks"]) == 14
+    scores = [b["score"] for b in data["blocks"]]
+    assert data["overall_score"] == int(round(sum(scores) / len(scores)))
+    for block in data["blocks"]:
+        assert block["status"] in ALLOWED_STATUSES
+        assert 0 <= block["score"] <= 100
+
+
+def test_html_contains_all_block_names(monkeypatch, tmp_path):
+    _stub_gatherers(monkeypatch)
+    prefix = tmp_path / "analysis"
+    doctor.main(["--out", str(prefix), "--json", "--html"])
+    html = prefix.with_suffix(".html").read_text("utf-8")
+    for block in doctor.BLOCKS:
+        assert block["name"] in html
+
+
+def test_scoring_determinism(monkeypatch, tmp_path):
+    _stub_gatherers(monkeypatch)
+    prefix = tmp_path / "analysis"
+    doctor.main(["--out", str(prefix), "--json"])
+    data = json.loads(prefix.with_suffix(".json").read_text("utf-8"))
+    statuses = {b["id"]: b["status"] for b in data["blocks"]}
+    assert statuses["B0"] == "OK"
+    assert statuses["B3"] == "WARN"
+    assert statuses["B9"] == "MISSING"
+    scores = {b["id"]: b["score"] for b in data["blocks"]}
+    expected = int(round(sum(scores.values()) / len(scores)))
+    assert data["overall_score"] == expected


### PR DESCRIPTION
## Summary
- add 14-block maturity matrix with deterministic scoring to doctor
- generate JSON and HTML reports with UTC timestamps
- document new CLI usage and reporting

## Testing
- `python -m ruff check tools/doctor.py tests/tools/test_doctor_blocks.py tests/codex/test_app_analyze_hook.py tests/codex/test_doctor_addin.py tests/codex/test_doctor_autosmoke_and_env.py tests/codex/test_doctor_repo_hygiene.py`
- `python -m pytest tests/tools/test_doctor_blocks.py tests/codex/test_app_analyze_hook.py tests/codex/test_doctor_addin.py tests/codex/test_doctor_autosmoke_and_env.py tests/codex/test_doctor_repo_hygiene.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b36805b38883259467662258995fed