### PR TITLE
feat: add sqlite bm25 retrieval baseline

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,3 +48,46 @@ Run tests:
 ```bash
 make corpus-test
 ```
+
+# Block B6-1 — Retrieval baseline (FTS5)
+
+## Schema
+
+```sql
+CREATE TABLE corpus_chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    corpus_id INTEGER NOT NULL,
+    jurisdiction TEXT NOT NULL,
+    source TEXT NOT NULL,
+    act_code TEXT NOT NULL,
+    section_code TEXT NOT NULL,
+    version TEXT NOT NULL,
+    start INTEGER NOT NULL,
+    end INTEGER NOT NULL,
+    lang TEXT,
+    text TEXT NOT NULL,
+    token_count INTEGER NOT NULL,
+    checksum TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE VIRTUAL TABLE corpus_chunks_fts USING fts5(
+    text, jurisdiction, source, act_code, section_code, version,
+    content='corpus_chunks', content_rowid='id'
+);
+```
+
+## How to run
+
+Rebuild local index and run BM25 search:
+
+```bash
+python -m contract_review_app.retrieval.indexer
+python -m contract_review_app.retrieval.search # library usage
+```
+
+API smoke:
+
+```bash
+uvicorn contract_review_app.api.corpus_search:router
+```

--- a/contract_review_app/api/corpus_search.py
+++ b/contract_review_app/api/corpus_search.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+from typing import Generator
+
+from contract_review_app.corpus.db import SessionLocal
+from contract_review_app.retrieval.search import BM25Search
+
+
+router = APIRouter(prefix="/api/corpus")
+
+
+def get_session() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/search")
+def corpus_search(
+    q: str = Query(..., min_length=1),
+    jurisdiction: str | None = None,
+    source: str | None = None,
+    act_code: str | None = None,
+    section_code: str | None = None,
+    top: int = 10,
+    session: Session = Depends(get_session),
+):
+    searcher = BM25Search(session)
+    rows = searcher.search(
+        q,
+        jurisdiction=jurisdiction,
+        source=source,
+        act_code=act_code,
+        section_code=section_code,
+        top=top,
+    )
+    results = [
+        {
+            "id": r["id"],
+            "meta": {
+                "corpus_id": r["corpus_id"],
+                "jurisdiction": r["jurisdiction"],
+                "source": r["source"],
+                "act_code": r["act_code"],
+                "section_code": r["section_code"],
+                "version": r["version"],
+            },
+            "span": {"start": r["start"], "end": r["end"], "lang": r["lang"]},
+            "text": r["text"],
+            "score": r["score"],
+        }
+        for r in rows
+    ]
+    return {"results": results}

--- a/contract_review_app/retrieval/chunker.py
+++ b/contract_review_app/retrieval/chunker.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from hashlib import sha1
+from typing import List, Optional
+
+
+@dataclass
+class ChunkDTO:
+    text: str
+    start: int
+    end: int
+    lang: Optional[str] = None
+    token_count: int = 0
+    checksum: str = ""
+
+
+def _normalise_text(s: str) -> str:
+    lines = [line.strip() for line in s.splitlines()]
+    return "\n".join(lines).strip()
+
+
+def _token_count(s: str) -> int:
+    return len(re.findall(r"\w+", s))
+
+
+def chunk_text(
+    text: str,
+    *,
+    lang: str | None = None,
+    max_chars: int = 800,
+    overlap: int = 120,
+    stride: int | None = None,
+) -> List[ChunkDTO]:
+    """Deterministically chunk ``text`` into overlapping pieces."""
+
+    if stride is None:
+        stride = max_chars - overlap
+    chunks: List[ChunkDTO] = []
+
+    # split by paragraphs (blank lines)
+    parts = []
+    pos = 0
+    for m in re.finditer(r"\n\s*\n+", text):
+        parts.append((pos, m.start()))
+        pos = m.end()
+    parts.append((pos, len(text)))
+
+    for p_start, p_end in parts:
+        block = text[p_start:p_end]
+        if not block:
+            continue
+        start = 0
+        while start < len(block):
+            end = min(start + max_chars, len(block))
+            if end < len(block):
+                # try to cut at sentence or newline boundary
+                boundary = max(
+                    block.rfind(".", start, end),
+                    block.rfind("!", start, end),
+                    block.rfind("?", start, end),
+                    block.rfind("\n", start, end),
+                )
+                if boundary > start:
+                    end = boundary + 1
+            piece = block[start:end]
+            abs_start = p_start + start
+            abs_end = p_start + end
+            norm = _normalise_text(piece)
+            checksum = sha1(norm.encode("utf-8")).hexdigest()
+            tokens = _token_count(piece)
+            chunks.append(
+                ChunkDTO(
+                    text=piece,
+                    start=abs_start,
+                    end=abs_end,
+                    lang=lang,
+                    token_count=tokens,
+                    checksum=checksum,
+                )
+            )
+            if end == len(block):
+                break
+            start = end - overlap
+    return chunks

--- a/contract_review_app/retrieval/indexer.py
+++ b/contract_review_app/retrieval/indexer.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.corpus.db import get_engine, init_db, SessionLocal
+from .chunker import chunk_text
+from .models import CorpusChunk
+
+
+def rebuild_index(session: Session, *, where_latest: bool = True, limit: int | None = None) -> int:
+    repo = Repo(session)
+    docs = repo.list_latest() if where_latest else repo.find()
+    if limit is not None:
+        docs = docs[:limit]
+    count = 0
+    with session.begin():
+        session.execute(delete(CorpusChunk))
+        for doc in docs:
+            chunks = chunk_text(doc.text, lang=doc.lang)
+            for ch in chunks:
+                session.add(
+                    CorpusChunk(
+                        corpus_id=doc.id,
+                        jurisdiction=doc.jurisdiction,
+                        source=doc.source,
+                        act_code=doc.act_code,
+                        section_code=doc.section_code,
+                        version=doc.version,
+                        start=ch.start,
+                        end=ch.end,
+                        lang=ch.lang,
+                        text=ch.text,
+                        token_count=ch.token_count,
+                        checksum=ch.checksum,
+                    )
+                )
+                count += 1
+    session.commit()
+    return count
+
+
+def _cli() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--limit", type=int, default=None)
+    args = p.parse_args()
+    engine = get_engine()
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    with SessionLocal() as session:
+        n = rebuild_index(session, limit=args.limit)
+        print(n)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/contract_review_app/retrieval/models.py
+++ b/contract_review_app/retrieval/models.py
@@ -1,0 +1,39 @@
+"""SQLAlchemy models for retrieval chunks."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from contract_review_app.corpus.models import Base, utcnow
+
+
+class CorpusChunk(Base):
+    __tablename__ = "corpus_chunks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    corpus_id: Mapped[int] = mapped_column(ForeignKey("corpus_docs.id"), nullable=False)
+    jurisdiction: Mapped[str] = mapped_column(String(8), nullable=False)
+    source: Mapped[str] = mapped_column(String(64), nullable=False)
+    act_code: Mapped[str] = mapped_column(String(128), nullable=False)
+    section_code: Mapped[str] = mapped_column(String(128), nullable=False)
+    version: Mapped[str] = mapped_column(String(32), nullable=False)
+    start: Mapped[int] = mapped_column(Integer, nullable=False)
+    end: Mapped[int] = mapped_column(Integer, nullable=False)
+    lang: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    token_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    checksum: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+    __table_args__ = (
+        Index(
+            "ix_chunks_meta",
+            "jurisdiction",
+            "source",
+            "act_code",
+            "section_code",
+            "version",
+        ),
+    )

--- a/contract_review_app/retrieval/search.py
+++ b/contract_review_app/retrieval/search.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.orm import Session
+
+
+class BM25Search:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def search(
+        self,
+        query: str,
+        *,
+        jurisdiction: str | None = None,
+        source: str | None = None,
+        act_code: str | None = None,
+        section_code: str | None = None,
+        top: int = 10,
+    ):
+        terms = re.findall(r"\w+", query.lower())
+        if not terms:
+            return []
+
+        def _prefix(t: str) -> str:
+            for suf in ("ing", "ed", "es", "s"):
+                if t.endswith(suf) and len(t) - len(suf) >= 3:
+                    t = t[: -len(suf)]
+                    break
+            return f"{t}*"
+
+        q = " OR ".join(_prefix(t) for t in terms)
+        sql = (
+            "SELECT c.id, c.corpus_id, c.start, c.end, c.jurisdiction, c.source, c.act_code, c.section_code, c.version, c.lang, c.text, bm25(corpus_chunks_fts) AS score "
+            "FROM corpus_chunks_fts JOIN corpus_chunks c ON c.id = corpus_chunks_fts.rowid "
+            "WHERE corpus_chunks_fts MATCH :q"
+        )
+        params: dict[str, object] = {"q": q, "top": top}
+        if jurisdiction:
+            sql += " AND c.jurisdiction = :jurisdiction"
+            params["jurisdiction"] = jurisdiction
+        if source:
+            sql += " AND c.source = :source"
+            params["source"] = source
+        if act_code:
+            sql += " AND c.act_code = :act_code"
+            params["act_code"] = act_code
+        if section_code:
+            sql += " AND c.section_code = :section_code"
+            params["section_code"] = section_code
+        sql += " ORDER BY score LIMIT :top"
+        conn = self.session.connection()
+        res = conn.exec_driver_sql(sql, params)
+        return [dict(r) for r in res.mappings()]

--- a/contract_review_app/tests/api/test_corpus_search_api.py
+++ b/contract_review_app/tests/api/test_corpus_search_api.py
@@ -1,0 +1,39 @@
+import yaml
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from contract_review_app.corpus.db import get_engine, init_db, SessionLocal
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.retrieval.indexer import rebuild_index
+from contract_review_app.api.corpus_search import router
+
+
+def _setup_demo(session):
+    repo = Repo(session)
+    for p in Path('data/corpus_demo').glob('*.yaml'):
+        with open(p, 'r', encoding='utf-8') as fh:
+            data = yaml.safe_load(fh)
+            for item in data['items']:
+                repo.upsert(item)
+
+
+def test_corpus_search_api(tmp_path):
+    dsn = f"sqlite:///{tmp_path/'api.db'}"
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    with SessionLocal() as session:
+        _setup_demo(session)
+        rebuild_index(session)
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    r = client.get("/api/corpus/search", params={"q": "processing", "jurisdiction": "UK", "top": 3})
+    assert r.status_code == 200
+    data = r.json()
+    assert isinstance(data.get("results"), list)
+    assert data["results"]
+    item = data["results"][0]
+    assert {"id", "meta", "span", "text", "score"}.issubset(item.keys())

--- a/contract_review_app/tests/retrieval/test_bm25_sqlite_search.py
+++ b/contract_review_app/tests/retrieval/test_bm25_sqlite_search.py
@@ -1,0 +1,61 @@
+import yaml
+from pathlib import Path
+
+import yaml
+from pathlib import Path
+
+import pytest
+
+from contract_review_app.corpus.db import get_engine, init_db, SessionLocal
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.retrieval.indexer import rebuild_index
+from contract_review_app.retrieval.search import BM25Search
+from contract_review_app.corpus.models import CorpusDoc
+
+
+@pytest.fixture
+def session(tmp_path):
+    dsn = f"sqlite:///{tmp_path/'corpus.db'}"
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    session = SessionLocal()
+    repo = Repo(session)
+    demo_dir = Path('data/corpus_demo')
+    for p in demo_dir.glob('*.yaml'):
+        with open(p, 'r', encoding='utf-8') as fh:
+            data = yaml.safe_load(fh)
+            for item in data['items']:
+                repo.upsert(item)
+    rebuild_index(session)
+    yield session
+    session.close()
+
+
+def test_search_gdpr_article5(session):
+    searcher = BM25Search(session)
+    res = searcher.search("transparent processing", jurisdiction="UK")
+    assert any(r['act_code'] == 'UK_GDPR' and r['section_code'] == 'Art.5' for r in res)
+
+
+def test_filters_work(session):
+    searcher = BM25Search(session)
+    res = searcher.search("pollution")
+    assert any(r['act_code'] == 'OGUK_MODEL' for r in res)
+    res2 = searcher.search("pollution", source="legislation.gov.uk")
+    assert all(r['act_code'] != 'OGUK_MODEL' for r in res2)
+
+
+def test_deterministic_ordering(session):
+    searcher = BM25Search(session)
+    r1 = searcher.search("data")
+    r2 = searcher.search("data")
+    assert [x['id'] for x in r1] == [x['id'] for x in r2]
+
+
+def test_span_bounds(session):
+    searcher = BM25Search(session)
+    res = searcher.search("data", jurisdiction="UK")
+    for r in res:
+        doc = session.get(CorpusDoc, r['corpus_id'])
+        assert 0 <= r['start'] < r['end'] <= len(doc.text)

--- a/contract_review_app/tests/retrieval/test_chunker.py
+++ b/contract_review_app/tests/retrieval/test_chunker.py
@@ -1,0 +1,22 @@
+from contract_review_app.retrieval.chunker import chunk_text
+
+
+def test_overlap_and_offsets_are_consistent():
+    text = ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * 40)
+    chunks = chunk_text(text, max_chars=200, overlap=40)
+    assert len(chunks) > 1
+    for i, ch in enumerate(chunks[:-1]):
+        nxt = chunks[i + 1]
+        overlap = ch.end - nxt.start
+        assert overlap >= 35  # allow small tolerance
+        assert text[ch.start:ch.end] == ch.text
+        assert ch.start < ch.end <= len(text)
+
+
+def test_checksum_and_determinism():
+    text = "Sentence one. Sentence two. Sentence three." * 5
+    c1 = chunk_text(text)
+    c2 = chunk_text(text)
+    sig1 = [(c.start, c.end, c.checksum) for c in c1]
+    sig2 = [(c.start, c.end, c.checksum) for c in c2]
+    assert sig1 == sig2


### PR DESCRIPTION
## Summary
- chunk legal texts deterministically with checksum and overlap
- index corpus chunks into SQLite FTS5 for BM25 search and add API endpoint
- document retrieval setup and add tests for chunker, search and API

## Testing
- `python -m pytest -q contract_review_app/tests/retrieval/test_chunker.py --maxfail=1`
- `python -m pytest -q contract_review_app/tests/retrieval/test_bm25_sqlite_search.py --maxfail=1`
- `python -m pytest -q contract_review_app/tests/api/test_corpus_search_api.py --maxfail=1`
- `python -m pytest -q -p no:cov --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b36c66e76483259587e1b0572a3320