### PR TITLE
feat: centralize idempotency cache for analyze endpoint

### DIFF
--- a/contract_review_app/api/__init__.py
+++ b/contract_review_app/api/__init__.py
@@ -1,0 +1,3 @@
+from .cache import IDEMPOTENCY_CACHE
+
+__all__ = ["IDEMPOTENCY_CACHE"]

--- a/contract_review_app/api/cache.py
+++ b/contract_review_app/api/cache.py
@@ -1,0 +1,23 @@
+from threading import RLock
+from typing import Optional, Dict, Any
+
+
+class IdempotencyCache:
+    def __init__(self) -> None:
+        self._data: Dict[str, Any] = {}
+        self._lock = RLock()
+
+    def get(self, key: str) -> Optional[Any]:
+        with self._lock:
+            return self._data.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._data[key] = value
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+
+IDEMPOTENCY_CACHE = IdempotencyCache()


### PR DESCRIPTION
## Summary
- add thread-safe IdempotencyCache shared across API modules
- clear idempotency cache at app startup and on manual app instantiation
- return deterministic x-cache headers for /api/analyze responses

## Testing
- `python -m pytest -q contract_review_app/tests/test_api_contract_ssot.py::test_analyze_cache_idempotency_headers --maxfail=1`
- `python -m pytest -q -p no:cov --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b4113acce08325957d695f59311cf3