### PR TITLE
feat: add vector retrieval cache and CLI

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -91,3 +91,37 @@ API smoke:
 ```bash
 uvicorn contract_review_app.api.corpus_search:router
 ```
+
+# Block B6-3 — Retrieval config & vector cache
+
+Configuration lives in `config/retrieval.yaml`:
+
+```yaml
+vector:
+  backend: inmemory
+  embedding_dim: 128
+  embedding_version: emb-dev-1
+  cache_dir: .cache/retrieval
+fusion:
+  method: rrf
+  rrf_k: 60
+bm25:
+  top: 10
+```
+
+Environment overrides:
+
+```
+RETRIEVAL_CONFIG            # path to YAML
+RETRIEVAL_EMBEDDING_DIM     # int
+RETRIEVAL_EMBEDDING_VERSION # string
+RETRIEVAL_CACHE_DIR         # cache location
+RETRIEVAL_RRF_K             # int
+RETRIEVAL_BM25_TOP          # int
+```
+
+Build vector cache:
+
+```bash
+make retrieval-build
+```

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,8 @@ corpus-demo:
 	python -m contract_review_app.corpus.ingest --dir data/corpus_demo
 
 corpus-test:
-	pytest -q contract_review_app/tests/corpus --maxfail=1
+\tpytest -q contract_review_app/tests/corpus --maxfail=1
+
+.PHONY: retrieval-build
+retrieval-build:
+\tpython -m contract_review_app.retrieval.cli build

--- a/config/retrieval.yaml
+++ b/config/retrieval.yaml
@@ -1,0 +1,10 @@
+vector:
+  backend: "inmemory"
+  embedding_dim: 128
+  embedding_version: "emb-dev-1"
+  cache_dir: ".cache/retrieval"
+fusion:
+  method: "rrf"
+  rrf_k: 60
+bm25:
+  top: 10

--- a/contract_review_app/api/corpus_search.py
+++ b/contract_review_app/api/corpus_search.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from typing import Generator
 
 from contract_review_app.corpus.db import SessionLocal
-from contract_review_app.retrieval.search import BM25Search
+from contract_review_app.retrieval.search import search_corpus
 
 
 router = APIRouter(prefix="/api/corpus")
@@ -27,32 +27,17 @@ def corpus_search(
     act_code: str | None = None,
     section_code: str | None = None,
     top: int = 10,
+    mode: str = "bm25",
     session: Session = Depends(get_session),
 ):
-    searcher = BM25Search(session)
-    rows = searcher.search(
+    rows = search_corpus(
+        session,
         q,
+        mode=mode,
         jurisdiction=jurisdiction,
         source=source,
         act_code=act_code,
         section_code=section_code,
         top=top,
     )
-    results = [
-        {
-            "id": r["id"],
-            "meta": {
-                "corpus_id": r["corpus_id"],
-                "jurisdiction": r["jurisdiction"],
-                "source": r["source"],
-                "act_code": r["act_code"],
-                "section_code": r["section_code"],
-                "version": r["version"],
-            },
-            "span": {"start": r["start"], "end": r["end"], "lang": r["lang"]},
-            "text": r["text"],
-            "score": r["score"],
-        }
-        for r in rows
-    ]
-    return {"results": results}
+    return {"results": rows}

--- a/contract_review_app/retrieval/cache.py
+++ b/contract_review_app/retrieval/cache.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import os
+import hashlib
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from contract_review_app.corpus.models import CorpusDoc
+from .models import CorpusChunk
+
+
+def corpus_fingerprint(session: Session) -> str:
+    """Return deterministic fingerprint of the latest corpus chunks."""
+    q = (
+        select(
+            CorpusChunk.corpus_id,
+            CorpusChunk.jurisdiction,
+            CorpusChunk.act_code,
+            CorpusChunk.section_code,
+            CorpusChunk.version,
+            CorpusChunk.checksum,
+        )
+        .join(CorpusDoc, CorpusDoc.id == CorpusChunk.corpus_id)
+        .where(CorpusDoc.latest.is_(True))
+        .order_by(CorpusChunk.id)
+    )
+    h = hashlib.blake2b()
+    for row in session.execute(q):
+        for col in row:
+            h.update(str(col).encode("utf-8"))
+            h.update(b"|")
+    return h.hexdigest()
+
+
+def cache_paths(cache_dir: str, fp: str, emb_ver: str) -> Tuple[str, str]:
+    base = Path(cache_dir)
+    npz_path = base / f"vecs_{fp}_{emb_ver}.npz"
+    meta_path = base / f"vecs_{fp}_{emb_ver}.json"
+    return str(npz_path), str(meta_path)
+
+
+def ensure_vector_cache(
+    session: Session,
+    *,
+    embedder,
+    cache_dir: str,
+    emb_ver: str,
+) -> Tuple[np.ndarray, np.ndarray, List[dict], bool]:
+    """Ensure vector cache exists and return vectors and metadata.
+
+    Returns ``(vecs, ids, metas, from_cache)`` where ``from_cache`` indicates
+    whether data was loaded from an existing cache.
+    """
+
+    fp = corpus_fingerprint(session)
+    npz_path, meta_path = cache_paths(cache_dir, fp, emb_ver)
+    os.makedirs(cache_dir, exist_ok=True)
+    if os.path.exists(npz_path) and os.path.exists(meta_path):
+        with open(meta_path, "r", encoding="utf-8") as fh:
+            meta = json.load(fh)
+        if (
+            meta.get("fingerprint") == fp
+            and meta.get("embedding_version") == emb_ver
+            and meta.get("dim") == embedder.dim
+        ):
+            data = np.load(npz_path)
+            vecs = data["vecs"].astype(np.float32)
+            ids = data["ids"].astype(np.int64)
+            metas = meta.get("metas", [])
+            return vecs, ids, metas, True
+    # rebuild
+    q = (
+        select(
+            CorpusChunk.id,
+            CorpusChunk.corpus_id,
+            CorpusChunk.jurisdiction,
+            CorpusChunk.source,
+            CorpusChunk.act_code,
+            CorpusChunk.section_code,
+            CorpusChunk.version,
+            CorpusChunk.start,
+            CorpusChunk.end,
+            CorpusChunk.lang,
+            CorpusChunk.text,
+        )
+        .join(CorpusDoc, CorpusDoc.id == CorpusChunk.corpus_id)
+        .where(CorpusDoc.latest.is_(True))
+        .order_by(CorpusChunk.id)
+    )
+    rows = session.execute(q).all()
+    texts = [r.text for r in rows]
+    vecs = embedder.embed(texts).astype(np.float32)
+    ids = np.array([r.id for r in rows], dtype=np.int64)
+    metas = [
+        {
+            "id": r.id,
+            "corpus_id": r.corpus_id,
+            "jurisdiction": r.jurisdiction,
+            "source": r.source,
+            "act_code": r.act_code,
+            "section_code": r.section_code,
+            "version": r.version,
+            "start": r.start,
+            "end": r.end,
+            "lang": r.lang,
+            "text": r.text,
+        }
+        for r in rows
+    ]
+    np.savez(npz_path, vecs=vecs, ids=ids)
+    with open(meta_path, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "fingerprint": fp,
+                "embedding_version": emb_ver,
+                "dim": int(vecs.shape[1]),
+                "metas": metas,
+            },
+            fh,
+        )
+    return vecs, ids, metas, False

--- a/contract_review_app/retrieval/cli.py
+++ b/contract_review_app/retrieval/cli.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from contract_review_app.corpus.db import SessionLocal, get_engine, init_db
+from .config import load_config
+from .cache import ensure_vector_cache
+from .embedder import HashingEmbedder
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("command", choices=["build"])
+    args = p.parse_args()
+    if args.command == "build":
+        cfg = load_config()
+        engine = get_engine()
+        init_db(engine)
+        SessionLocal.configure(bind=engine)
+        with SessionLocal() as session:
+            embedder = HashingEmbedder(cfg["vector"]["embedding_dim"])
+            vecs, ids, _, from_cache = ensure_vector_cache(
+                session,
+                embedder=embedder,
+                cache_dir=cfg["vector"]["cache_dir"],
+                emb_ver=cfg["vector"]["embedding_version"],
+            )
+        out = {"built": not from_cache, "from_cache": from_cache, "count": int(len(ids))}
+        print(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/contract_review_app/retrieval/config.py
+++ b/contract_review_app/retrieval/config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "retrieval.yaml"
+
+
+def _env_override(data: Dict[str, Any]) -> None:
+    mapping = {
+        "RETRIEVAL_EMBEDDING_DIM": ("vector", "embedding_dim", int),
+        "RETRIEVAL_EMBEDDING_VERSION": ("vector", "embedding_version", str),
+        "RETRIEVAL_CACHE_DIR": ("vector", "cache_dir", str),
+        "RETRIEVAL_RRF_K": ("fusion", "rrf_k", int),
+        "RETRIEVAL_BM25_TOP": ("bm25", "top", int),
+    }
+    for env, (section, key, cast) in mapping.items():
+        val = os.getenv(env)
+        if val is not None:
+            data.setdefault(section, {})[key] = cast(val)
+
+
+def load_config(path: str | None = None) -> Dict[str, Any]:
+    """Load retrieval configuration.
+
+    ``path`` overrides default lookup which checks ``RETRIEVAL_CONFIG``
+    environment variable and finally ``config/retrieval.yaml``.
+    Selected values can be overridden via specific environment variables.
+    """
+
+    cfg_path = path or os.getenv("RETRIEVAL_CONFIG") or DEFAULT_CONFIG_PATH
+    with open(cfg_path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    _env_override(data)
+    vec = data.get("vector", {})
+    fusion = data.get("fusion", {})
+    bm25 = data.get("bm25", {})
+    vec["embedding_dim"] = int(vec.get("embedding_dim", 128))
+    vec["embedding_version"] = str(vec.get("embedding_version", ""))
+    vec["cache_dir"] = str(vec.get("cache_dir", ".cache/retrieval"))
+    vec["backend"] = str(vec.get("backend", "inmemory"))
+    fusion["method"] = str(fusion.get("method", "rrf"))
+    if "rrf_k" in fusion:
+        fusion["rrf_k"] = int(fusion["rrf_k"])
+    bm25["top"] = int(bm25.get("top", 10))
+    return {"vector": vec, "fusion": fusion, "bm25": bm25}

--- a/contract_review_app/retrieval/embedder.py
+++ b/contract_review_app/retrieval/embedder.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable, List
+
+import numpy as np
+
+
+class HashingEmbedder:
+    """Simple deterministic embedding based on token hashing.
+
+    Each token is hashed with blake2b and mapped into embedding space.
+    The resulting vector is a bag-of-words with counts per dimension.
+    """
+
+    def __init__(self, dim: int) -> None:
+        self.dim = dim
+
+    def embed(self, texts: Iterable[str]) -> np.ndarray:
+        seq: List[str] = list(texts)
+        vecs = np.zeros((len(seq), self.dim), dtype=np.float32)
+        for i, text in enumerate(seq):
+            for token in text.split():
+                h = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+                idx = int.from_bytes(h, "little") % self.dim
+                vecs[i, idx] += 1.0
+        return vecs

--- a/contract_review_app/retrieval/search.py
+++ b/contract_review_app/retrieval/search.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import re
+from typing import List
 
+import numpy as np
 from sqlalchemy.orm import Session
+
+from .cache import ensure_vector_cache
+from .config import load_config
+from .embedder import HashingEmbedder
 
 
 class BM25Search:
@@ -53,3 +59,116 @@ class BM25Search:
         conn = self.session.connection()
         res = conn.exec_driver_sql(sql, params)
         return [dict(r) for r in res.mappings()]
+
+
+def _format_rows(rows: List[dict]) -> List[dict]:
+    return [
+        {
+            "id": r["id"],
+            "meta": {
+                "corpus_id": r["corpus_id"],
+                "jurisdiction": r["jurisdiction"],
+                "source": r["source"],
+                "act_code": r["act_code"],
+                "section_code": r["section_code"],
+                "version": r["version"],
+            },
+            "span": {"start": r["start"], "end": r["end"], "lang": r["lang"]},
+            "text": r["text"],
+            "score": float(r["score"]),
+        }
+        for r in rows
+    ]
+
+
+def _cosine_search(vecs: np.ndarray, metas: List[dict], ids: np.ndarray, query_vec: np.ndarray, top: int) -> List[dict]:
+    norms = np.linalg.norm(vecs, axis=1)
+    q_norm = np.linalg.norm(query_vec)
+    denom = norms * (q_norm if q_norm != 0 else 1)
+    denom[denom == 0] = 1.0
+    sims = (vecs @ query_vec) / denom
+    order = np.argsort(-sims)[:top]
+    results: List[dict] = []
+    for idx in order:
+        m = metas[idx]
+        results.append(
+            {
+                "id": int(ids[idx]),
+                "meta": {
+                    "corpus_id": m["corpus_id"],
+                    "jurisdiction": m["jurisdiction"],
+                    "source": m["source"],
+                    "act_code": m["act_code"],
+                    "section_code": m["section_code"],
+                    "version": m["version"],
+                },
+                "span": {"start": m["start"], "end": m["end"], "lang": m["lang"]},
+                "text": m["text"],
+                "score": float(sims[idx]),
+            }
+        )
+    return results
+
+
+def _rrf_merge(lists: List[List[dict]], k: int, top: int) -> List[dict]:
+    scores: dict[int, float] = {}
+    items: dict[int, dict] = {}
+    for lst in lists:
+        for rank, item in enumerate(lst, 1):
+            i = int(item["id"])
+            items.setdefault(i, item)
+            scores[i] = scores.get(i, 0.0) + 1.0 / (k + rank)
+    merged = []
+    for i, item in items.items():
+        item = item.copy()
+        item["score"] = scores[i]
+        merged.append(item)
+    merged.sort(key=lambda x: x["score"], reverse=True)
+    return merged[:top]
+
+
+def search_corpus(
+    session: Session,
+    query: str,
+    *,
+    mode: str = "bm25",
+    jurisdiction: str | None = None,
+    source: str | None = None,
+    act_code: str | None = None,
+    section_code: str | None = None,
+    top: int = 10,
+) -> List[dict]:
+    if mode == "bm25":
+        rows = BM25Search(session).search(
+            query,
+            jurisdiction=jurisdiction,
+            source=source,
+            act_code=act_code,
+            section_code=section_code,
+            top=top,
+        )
+        return _format_rows(rows)
+
+    cfg = load_config()
+    vec_cfg = cfg["vector"]
+    embedder = HashingEmbedder(vec_cfg["embedding_dim"])
+    vecs, ids, metas, _ = ensure_vector_cache(
+        session,
+        embedder=embedder,
+        cache_dir=vec_cfg["cache_dir"],
+        emb_ver=vec_cfg["embedding_version"],
+    )
+    q_vec = embedder.embed([query]).astype(np.float32)[0]
+    vec_results = _cosine_search(vecs, metas, ids, q_vec, top)
+    if mode == "vector":
+        return vec_results
+    bm25_rows = BM25Search(session).search(
+        query,
+        jurisdiction=jurisdiction,
+        source=source,
+        act_code=act_code,
+        section_code=section_code,
+        top=cfg["bm25"]["top"],
+    )
+    bm25_results = _format_rows(bm25_rows)
+    return _rrf_merge([vec_results, bm25_results], cfg["fusion"].get("rrf_k", 60), top)

--- a/contract_review_app/tests/api/test_corpus_search_modes.py
+++ b/contract_review_app/tests/api/test_corpus_search_modes.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from contract_review_app.corpus.db import SessionLocal, get_engine, init_db
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.retrieval.cache import ensure_vector_cache
+from contract_review_app.retrieval.config import load_config
+from contract_review_app.retrieval.embedder import HashingEmbedder
+from contract_review_app.retrieval.indexer import rebuild_index
+from contract_review_app.api.corpus_search import router
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch):
+    dsn = f"sqlite:///{tmp_path/'api.db'}"
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    sess = SessionLocal()
+    repo = Repo(sess)
+    demo_dir = Path('data/corpus_demo')
+    for p in demo_dir.glob('*.yaml'):
+        with open(p, 'r', encoding='utf-8') as fh:
+            data = yaml.safe_load(fh)
+            for item in data['items']:
+                repo.upsert(item)
+    rebuild_index(sess)
+    cache_dir = tmp_path / 'cache'
+    monkeypatch.setenv('RETRIEVAL_CACHE_DIR', str(cache_dir))
+    cfg = load_config()
+    embedder = HashingEmbedder(cfg['vector']['embedding_dim'])
+    ensure_vector_cache(
+        sess,
+        embedder=embedder,
+        cache_dir=cfg['vector']['cache_dir'],
+        emb_ver=cfg['vector']['embedding_version'],
+    )
+    yield sess
+    sess.close()
+
+
+def test_vector_and_hybrid_modes(session, monkeypatch):
+    from contract_review_app.retrieval import search as rsearch
+
+    calls = []
+    orig = rsearch.ensure_vector_cache
+
+    def wrapper(*args, **kwargs):
+        vecs, ids, metas, from_cache = orig(*args, **kwargs)
+        calls.append(from_cache)
+        return vecs, ids, metas, from_cache
+
+    monkeypatch.setattr(rsearch, 'ensure_vector_cache', wrapper)
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    r = client.get('/api/corpus/search', params={'q': 'data', 'mode': 'vector'})
+    assert r.status_code == 200
+    assert r.json()['results']
+    r2 = client.get('/api/corpus/search', params={'q': 'data', 'mode': 'hybrid'})
+    assert r2.status_code == 200
+    assert r2.json()['results']
+    assert calls == [True, True]

--- a/contract_review_app/tests/retrieval/test_config_and_cache.py
+++ b/contract_review_app/tests/retrieval/test_config_and_cache.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+from contract_review_app.corpus.db import SessionLocal, get_engine, init_db
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.retrieval.cache import ensure_vector_cache
+from contract_review_app.retrieval.config import load_config
+from contract_review_app.retrieval.embedder import HashingEmbedder
+from contract_review_app.retrieval.indexer import rebuild_index
+
+
+@pytest.fixture
+def session(tmp_path):
+    dsn = f"sqlite:///{tmp_path/'retr.db'}"
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    session = SessionLocal()
+    repo = Repo(session)
+    demo_dir = Path('data/corpus_demo')
+    for p in demo_dir.glob('*.yaml'):
+        with open(p, 'r', encoding='utf-8') as fh:
+            data = yaml.safe_load(fh)
+            for item in data['items']:
+                repo.upsert(item)
+    rebuild_index(session)
+    yield session
+    session.close()
+
+
+def test_load_config_env_override(tmp_path, monkeypatch):
+    cfg_path = tmp_path / 'retrieval.yaml'
+    cfg_path.write_text(
+        "vector:\n  embedding_dim: 128\n  embedding_version: v1\n  cache_dir: cache\n", encoding='utf-8'
+    )
+    monkeypatch.setenv('RETRIEVAL_CONFIG', str(cfg_path))
+    monkeypatch.setenv('RETRIEVAL_EMBEDDING_DIM', '64')
+    cfg = load_config()
+    assert cfg['vector']['embedding_dim'] == 64
+    assert cfg['vector']['embedding_version'] == 'v1'
+
+
+def test_vector_cache_build_and_reuse(session, tmp_path):
+    cache_dir = tmp_path / 'cache'
+    embedder = HashingEmbedder(128)
+    vecs, ids, metas, from_cache = ensure_vector_cache(
+        session,
+        embedder=embedder,
+        cache_dir=str(cache_dir),
+        emb_ver='emb-dev-1',
+    )
+    assert not from_cache
+    assert len(ids) > 0
+    vecs2, ids2, metas2, from_cache2 = ensure_vector_cache(
+        session,
+        embedder=embedder,
+        cache_dir=str(cache_dir),
+        emb_ver='emb-dev-1',
+    )
+    assert from_cache2
+    assert vecs.shape == vecs2.shape
+    assert np.allclose(vecs, vecs2)
+    assert np.array_equal(ids, ids2)
+    assert metas == metas2
+
+
+def test_vector_cache_invalidation_on_version(session, tmp_path):
+    cache_dir = tmp_path / 'cache'
+    embedder = HashingEmbedder(128)
+    vecs, ids, metas, from_cache = ensure_vector_cache(
+        session,
+        embedder=embedder,
+        cache_dir=str(cache_dir),
+        emb_ver='v1',
+    )
+    assert not from_cache
+    vecs2, ids2, metas2, from_cache2 = ensure_vector_cache(
+        session,
+        embedder=embedder,
+        cache_dir=str(cache_dir),
+        emb_ver='v2',
+    )
+    assert not from_cache2
+    assert vecs2.shape == vecs.shape
+    files = list(cache_dir.glob('*.npz'))
+    assert len(files) == 2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pyyaml>=6.0
 fastapi>=0.110,<1.0
 httpx
 sqlalchemy>=2.0
+numpy>=1.26


### PR DESCRIPTION
## Summary
- add retrieval.yaml config with environment overrides
- implement deterministic vector cache with invalidation by embedding version and corpus fingerprint
- support vector and hybrid search modes with RRF fusion and build CLI

## Testing
- `python -m pytest -q contract_review_app/tests/retrieval/test_config_and_cache.py --maxfail=1`
- `python -m pytest -q contract_review_app/tests/api/test_corpus_search_modes.py --maxfail=1`
- `python -m pytest -q -p no:cov --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b41548b9d48325962f87e3e6cdc2a9