### PR TITLE
feat: add weighted hybrid fusion

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -104,10 +104,17 @@ vector:
   cache_dir: .cache/retrieval
 fusion:
   method: rrf
+  weights:
+    vector: 0.6
+    bm25: 0.4
   rrf_k: 60
 bm25:
   top: 10
 ```
+
+`fusion.method` controls how BM25 and vector results are combined: "rrf" for
+reciprocal rank fusion (default) or "weighted" for weighted hybrid using the
+specified `weights`.
 
 Environment overrides:
 
@@ -117,6 +124,9 @@ RETRIEVAL_EMBEDDING_DIM     # int
 RETRIEVAL_EMBEDDING_VERSION # string
 RETRIEVAL_CACHE_DIR         # cache location
 RETRIEVAL_RRF_K             # int
+RETRIEVAL_FUSION_METHOD     # rrf|weighted
+RETRIEVAL_WEIGHT_VECTOR     # float
+RETRIEVAL_WEIGHT_BM25       # float
 RETRIEVAL_BM25_TOP          # int
 ```
 

--- a/config/retrieval.yaml
+++ b/config/retrieval.yaml
@@ -5,6 +5,9 @@ vector:
   cache_dir: ".cache/retrieval"
 fusion:
   method: "rrf"
+  weights:
+    vector: 0.6
+    bm25: 0.4
   rrf_k: 60
 bm25:
   top: 10

--- a/contract_review_app/retrieval/fusion.py
+++ b/contract_review_app/retrieval/fusion.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def rrf(bm25_ids: List[int], vec_ids: List[int], k: int = 60) -> List[int]:
+    """Reciprocal rank fusion of id lists."""
+    scores: Dict[int, float] = {}
+    for rank, i in enumerate(bm25_ids, 1):
+        scores[i] = scores.get(i, 0.0) + 1.0 / (k + rank)
+    for rank, i in enumerate(vec_ids, 1):
+        scores[i] = scores.get(i, 0.0) + 1.0 / (k + rank)
+    return sorted(scores, key=lambda x: (-scores[x], x))
+
+
+def weighted_fusion(
+    bm25_ids: List[int],
+    vec_ids: List[int],
+    w_bm25: float,
+    w_vec: float,
+    k: int = 60,
+) -> List[int]:
+    """Weighted hybrid fusion of id lists."""
+    scores: Dict[int, float] = {}
+    for rank, i in enumerate(bm25_ids, 1):
+        scores[i] = scores.get(i, 0.0) + w_bm25 / (k + rank)
+    for rank, i in enumerate(vec_ids, 1):
+        scores[i] = scores.get(i, 0.0) + w_vec / (k + rank)
+    return sorted(scores, key=lambda x: (-scores[x], x))

--- a/contract_review_app/retrieval/search.py
+++ b/contract_review_app/retrieval/search.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from .cache import ensure_vector_cache
 from .config import load_config
 from .embedder import HashingEmbedder
+from .fusion import rrf, weighted_fusion
 
 
 class BM25Search:
@@ -62,8 +63,9 @@ class BM25Search:
 
 
 def _format_rows(rows: List[dict]) -> List[dict]:
-    return [
-        {
+    formatted = []
+    for r in rows:
+        item = {
             "id": r["id"],
             "meta": {
                 "corpus_id": r["corpus_id"],
@@ -75,10 +77,13 @@ def _format_rows(rows: List[dict]) -> List[dict]:
             },
             "span": {"start": r["start"], "end": r["end"], "lang": r["lang"]},
             "text": r["text"],
-            "score": float(r["score"]),
+            "bm25_score": float(r["score"]),
+            "cosine_sim": None,
+            "rank_fusion": None,
         }
-        for r in rows
-    ]
+        item["score"] = item["bm25_score"]
+        formatted.append(item)
+    return formatted
 
 
 def _cosine_search(vecs: np.ndarray, metas: List[dict], ids: np.ndarray, query_vec: np.ndarray, top: int) -> List[dict]:
@@ -91,40 +96,27 @@ def _cosine_search(vecs: np.ndarray, metas: List[dict], ids: np.ndarray, query_v
     results: List[dict] = []
     for idx in order:
         m = metas[idx]
-        results.append(
-            {
-                "id": int(ids[idx]),
-                "meta": {
-                    "corpus_id": m["corpus_id"],
-                    "jurisdiction": m["jurisdiction"],
-                    "source": m["source"],
-                    "act_code": m["act_code"],
-                    "section_code": m["section_code"],
-                    "version": m["version"],
-                },
-                "span": {"start": m["start"], "end": m["end"], "lang": m["lang"]},
-                "text": m["text"],
-                "score": float(sims[idx]),
-            }
-        )
+        item = {
+            "id": int(ids[idx]),
+            "meta": {
+                "corpus_id": m["corpus_id"],
+                "jurisdiction": m["jurisdiction"],
+                "source": m["source"],
+                "act_code": m["act_code"],
+                "section_code": m["section_code"],
+                "version": m["version"],
+            },
+            "span": {"start": m["start"], "end": m["end"], "lang": m["lang"]},
+            "text": m["text"],
+            "bm25_score": None,
+            "cosine_sim": float(sims[idx]),
+            "rank_fusion": None,
+        }
+        item["score"] = item["cosine_sim"]
+        results.append(item)
     return results
 
 
-def _rrf_merge(lists: List[List[dict]], k: int, top: int) -> List[dict]:
-    scores: dict[int, float] = {}
-    items: dict[int, dict] = {}
-    for lst in lists:
-        for rank, item in enumerate(lst, 1):
-            i = int(item["id"])
-            items.setdefault(i, item)
-            scores[i] = scores.get(i, 0.0) + 1.0 / (k + rank)
-    merged = []
-    for i, item in items.items():
-        item = item.copy()
-        item["score"] = scores[i]
-        merged.append(item)
-    merged.sort(key=lambda x: x["score"], reverse=True)
-    return merged[:top]
 
 
 def search_corpus(
@@ -171,4 +163,50 @@ def search_corpus(
         top=cfg["bm25"]["top"],
     )
     bm25_results = _format_rows(bm25_rows)
-    return _rrf_merge([vec_results, bm25_results], cfg["fusion"].get("rrf_k", 60), top)
+
+    bm25_ids = [r["id"] for r in bm25_results]
+    vec_ids = [r["id"] for r in vec_results]
+    k = cfg["fusion"].get("rrf_k", 60)
+    if cfg["fusion"].get("method") == "weighted":
+        order = weighted_fusion(
+            bm25_ids,
+            vec_ids,
+            cfg["fusion"]["weights"]["bm25"],
+            cfg["fusion"]["weights"]["vector"],
+            k,
+        )
+        scores: dict[int, float] = {}
+        for rank, i in enumerate(bm25_ids, 1):
+            scores[i] = scores.get(i, 0.0) + cfg["fusion"]["weights"]["bm25"] / (k + rank)
+        for rank, i in enumerate(vec_ids, 1):
+            scores[i] = scores.get(i, 0.0) + cfg["fusion"]["weights"]["vector"] / (k + rank)
+    else:
+        order = rrf(bm25_ids, vec_ids, k)
+        scores = {}
+        for rank, i in enumerate(bm25_ids, 1):
+            scores[i] = scores.get(i, 0.0) + 1.0 / (k + rank)
+        for rank, i in enumerate(vec_ids, 1):
+            scores[i] = scores.get(i, 0.0) + 1.0 / (k + rank)
+
+    bm25_map = {r["id"]: r for r in bm25_results}
+    vec_map = {r["id"]: r for r in vec_results}
+    merged: List[dict] = []
+    for i in order:
+        if scores.get(i, 0.0) <= 0:
+            continue
+        base = vec_map.get(i, bm25_map.get(i))
+        item = {
+            "id": i,
+            "meta": base["meta"],
+            "span": base["span"],
+            "text": base["text"],
+            "bm25_score": bm25_map.get(i, {}).get("bm25_score"),
+            "cosine_sim": vec_map.get(i, {}).get("cosine_sim"),
+            "rank_fusion": len(merged) + 1,
+        }
+        item["score"] = scores.get(i, 0.0)
+        merged.append(item)
+        if len(merged) >= top:
+            break
+
+    return merged

--- a/contract_review_app/tests/retrieval/test_config_and_cache.py
+++ b/contract_review_app/tests/retrieval/test_config_and_cache.py
@@ -35,13 +35,21 @@ def session(tmp_path):
 def test_load_config_env_override(tmp_path, monkeypatch):
     cfg_path = tmp_path / 'retrieval.yaml'
     cfg_path.write_text(
-        "vector:\n  embedding_dim: 128\n  embedding_version: v1\n  cache_dir: cache\n", encoding='utf-8'
+        "vector:\n  embedding_dim: 128\n  embedding_version: v1\n  cache_dir: cache\n"
+        "fusion:\n  method: rrf\n  weights:\n    vector: 0.1\n    bm25: 0.9\n",
+        encoding='utf-8',
     )
     monkeypatch.setenv('RETRIEVAL_CONFIG', str(cfg_path))
     monkeypatch.setenv('RETRIEVAL_EMBEDDING_DIM', '64')
+    monkeypatch.setenv('RETRIEVAL_FUSION_METHOD', 'weighted')
+    monkeypatch.setenv('RETRIEVAL_WEIGHT_VECTOR', '0.7')
+    monkeypatch.setenv('RETRIEVAL_WEIGHT_BM25', '0.3')
     cfg = load_config()
     assert cfg['vector']['embedding_dim'] == 64
     assert cfg['vector']['embedding_version'] == 'v1'
+    assert cfg['fusion']['method'] == 'weighted'
+    assert cfg['fusion']['weights']['vector'] == 0.7
+    assert cfg['fusion']['weights']['bm25'] == 0.3
 
 
 def test_vector_cache_build_and_reuse(session, tmp_path):

--- a/contract_review_app/tests/retrieval/test_weighted_fusion.py
+++ b/contract_review_app/tests/retrieval/test_weighted_fusion.py
@@ -1,0 +1,58 @@
+import pytest
+import yaml
+from pathlib import Path
+
+from contract_review_app.corpus.db import SessionLocal, get_engine, init_db
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.retrieval.config import load_config
+from contract_review_app.retrieval.embedder import HashingEmbedder
+from contract_review_app.retrieval.cache import ensure_vector_cache
+from contract_review_app.retrieval.indexer import rebuild_index
+from contract_review_app.retrieval.search import search_corpus
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch):
+    dsn = f"sqlite:///{tmp_path/'wf.db'}"
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    sess = SessionLocal()
+    repo = Repo(sess)
+    demo_dir = Path('data/corpus_demo')
+    for p in demo_dir.glob('*.yaml'):
+        with open(p, 'r', encoding='utf-8') as fh:
+            data = yaml.safe_load(fh)
+            for item in data['items']:
+                repo.upsert(item)
+    rebuild_index(sess)
+    cache_dir = tmp_path / 'cache'
+    monkeypatch.setenv('RETRIEVAL_CACHE_DIR', str(cache_dir))
+    cfg = load_config()
+    embedder = HashingEmbedder(cfg['vector']['embedding_dim'])
+    ensure_vector_cache(
+        sess,
+        embedder=embedder,
+        cache_dir=cfg['vector']['cache_dir'],
+        emb_ver=cfg['vector']['embedding_version'],
+    )
+    yield sess
+    sess.close()
+
+
+def test_weighted_equals_vector_when_vector_weight_1(session, monkeypatch):
+    monkeypatch.setenv('RETRIEVAL_FUSION_METHOD', 'weighted')
+    monkeypatch.setenv('RETRIEVAL_WEIGHT_VECTOR', '1.0')
+    monkeypatch.setenv('RETRIEVAL_WEIGHT_BM25', '0.0')
+    vec = search_corpus(session, 'processing', mode='vector', top=5)
+    hybrid = search_corpus(session, 'processing', mode='hybrid', top=5)
+    assert [r['id'] for r in hybrid] == [r['id'] for r in vec]
+
+
+def test_weighted_equals_bm25_when_bm25_weight_1(session, monkeypatch):
+    monkeypatch.setenv('RETRIEVAL_FUSION_METHOD', 'weighted')
+    monkeypatch.setenv('RETRIEVAL_WEIGHT_VECTOR', '0.0')
+    monkeypatch.setenv('RETRIEVAL_WEIGHT_BM25', '1.0')
+    bm = search_corpus(session, 'processing', mode='bm25', top=5)
+    hybrid = search_corpus(session, 'processing', mode='hybrid', top=5)
+    assert [r['id'] for r in hybrid] == [r['id'] for r in bm]


### PR DESCRIPTION
## Summary
- support weighted BM25/vector fusion with env overrides
- expose fusion fields in search results
- test and document retrieval fusion weights

## Testing
- `pip install -r requirements-dev.txt`
- `python -m contract_review_app.corpus.ingest --dir data/corpus_demo`
- `python -m contract_review_app.retrieval.indexer`
- `RETRIEVAL_FUSION_METHOD='weighted' RETRIEVAL_WEIGHT_VECTOR='1.0' RETRIEVAL_WEIGHT_BM25='0.0' python -m pytest -q contract_review_app/tests/retrieval/test_weighted_fusion.py::test_weighted_equals_vector_when_vector_weight_1 --maxfail=1`
- `RETRIEVAL_FUSION_METHOD='weighted' RETRIEVAL_WEIGHT_VECTOR='0.0' RETRIEVAL_WEIGHT_BM25='1.0' python -m pytest -q contract_review_app/tests/retrieval/test_weighted_fusion.py::test_weighted_equals_bm25_when_bm25_weight_1 --maxfail=1`
- `RETRIEVAL_FUSION_METHOD='weighted' RETRIEVAL_WEIGHT_VECTOR='0.6' RETRIEVAL_WEIGHT_BM25='0.4' python -m pytest -q contract_review_app/tests/api/test_corpus_search_modes.py --maxfail=1`
- `python -m pytest -q -p no:cov --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b41f13ed9c832582c692d0192df4cd