### PR TITLE
Add retrieval evaluation and smoke tests

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -135,3 +135,16 @@ Build vector cache:
 ```bash
 make retrieval-build
 ```
+
+# Block B6-5 — Retrieval evaluation
+
+Run offline evaluation on the demo corpus. Hybrid search should reach at least
+80% recall@5 and MRR above 0.6.
+
+```bash
+python -m contract_review_app.corpus.ingest --dir data/corpus_demo
+python -m contract_review_app.retrieval.indexer
+python -m contract_review_app.retrieval.eval --golden data/retrieval_golden.yaml --method hybrid --k 5
+```
+
+Exit code is zero when the recall threshold is met.

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ corpus-test:
 .PHONY: retrieval-build
 retrieval-build:
 \tpython -m contract_review_app.retrieval.cli build
+
+.PHONY: retrieval-eval
+retrieval-eval:
+	python -m contract_review_app.retrieval.eval --golden data/retrieval_golden.yaml --method hybrid --k 5

--- a/contract_review_app/retrieval/eval.py
+++ b/contract_review_app/retrieval/eval.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Literal, Optional, TypedDict
+
+import yaml
+
+from contract_review_app.corpus.db import SessionLocal, get_engine, init_db
+from contract_review_app.retrieval.config import load_config
+from contract_review_app.retrieval.search import search_corpus
+
+
+class ExpectedItem(TypedDict):
+    jurisdiction: str
+    act_code: str
+    section_code: str
+
+
+@dataclass
+class QueryCase:
+    query: str
+    expected: List[ExpectedItem]
+
+
+class SearchMeta(TypedDict, total=False):
+    jurisdiction: str
+    act_code: str
+    section_code: str
+
+
+class SearchResult(TypedDict, total=False):
+    meta: SearchMeta
+
+
+@dataclass
+class RetrievalConfig:
+    data: dict
+
+    @classmethod
+    def from_env_or_file(cls, path: str | None = None) -> "RetrievalConfig":
+        cfg = load_config(path)
+        return cls(cfg)
+
+
+def load_golden(path: str) -> List[QueryCase]:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or []
+    cases: List[QueryCase] = []
+    for item in data:
+        cases.append(QueryCase(query=item["query"], expected=item.get("expected", [])))
+    return cases
+
+
+def _ensure_session():
+    engine = get_engine()
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+
+
+def run_search(
+    query: str,
+    method: Literal["bm25", "vector", "hybrid"],
+    top_k: int,
+    cfg: RetrievalConfig,
+) -> List[SearchResult]:
+    _ensure_session()
+    with SessionLocal() as session:
+        if method in {"bm25", "vector", "hybrid"}:
+            return search_corpus(session, query=query, mode=method, top=top_k)
+        raise ValueError(f"unknown method {method}")
+
+
+def match(result: SearchResult, expected_item: ExpectedItem) -> bool:
+    meta = result.get("meta", {})
+    return (
+        meta.get("jurisdiction") == expected_item["jurisdiction"]
+        and meta.get("act_code") == expected_item["act_code"]
+        and meta.get("section_code") == expected_item["section_code"]
+    )
+
+
+def evaluate(golden: List[QueryCase], method: str, k: int) -> dict:
+    cfg = RetrievalConfig.from_env_or_file()
+    cases_out = []
+    hits = 0
+    mrr_total = 0.0
+    for case in golden:
+        results = run_search(case.query, method, k, cfg)
+        rank: Optional[int] = None
+        for idx, res in enumerate(results, 1):
+            if any(match(res, exp) for exp in case.expected):
+                rank = idx
+                break
+        cases_out.append({"query": case.query, "found": rank is not None, "rank": rank})
+        if rank is not None:
+            hits += 1
+            mrr_total += 1.0 / rank
+    total = len(golden) if golden else 1
+    recall = hits / total
+    mrr = mrr_total / total
+    return {
+        "method": method,
+        "k": k,
+        "recall_at_k": recall,
+        "mrr_at_k": mrr,
+        "cases": cases_out,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--golden", required=True)
+    p.add_argument("--method", choices=["bm25", "vector", "hybrid"], required=True)
+    p.add_argument("--k", type=int, default=5)
+    p.add_argument("--json", action="store_true", help="reserved; outputs JSON")
+    args = p.parse_args()
+    golden = load_golden(args.golden)
+    res = evaluate(golden, args.method, args.k)
+    print(json.dumps(res))
+    return 0 if res["recall_at_k"] >= 0.8 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/contract_review_app/tests/retrieval/test_eval_smoke.py
+++ b/contract_review_app/tests/retrieval/test_eval_smoke.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from contract_review_app.corpus.db import SessionLocal, get_engine, init_db
+from contract_review_app.corpus.ingest import run_ingest
+from contract_review_app.retrieval.indexer import rebuild_index
+from contract_review_app.retrieval.eval import evaluate, load_golden
+
+GOLDEN_PATH = Path("data/retrieval_golden.yaml")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prepare_demo():
+    import os
+
+    dsn = f"sqlite:///{(Path('.local') / 'corpus.db').resolve()}"
+    os.environ["LEGAL_CORPUS_DSN"] = dsn
+    run_ingest("data/corpus_demo", dsn=dsn)
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    with SessionLocal() as session:
+        rebuild_index(session)
+
+
+@pytest.fixture(autouse=True)
+def fusion_env(monkeypatch):
+    monkeypatch.setenv("RETRIEVAL_FUSION_METHOD", "weighted")
+    monkeypatch.setenv("RETRIEVAL_WEIGHT_VECTOR", "0.4")
+    monkeypatch.setenv("RETRIEVAL_WEIGHT_BM25", "0.6")
+
+
+@pytest.fixture(scope="module")
+def golden() -> list:
+    return load_golden(str(GOLDEN_PATH))
+
+
+def test_hybrid_metrics(golden):
+    res1 = evaluate(golden, "hybrid", 5)
+    res2 = evaluate(golden, "hybrid", 5)
+    assert res1["recall_at_k"] >= 0.8
+    assert res1["mrr_at_k"] > 0.6
+    assert res1 == res2
+
+
+def test_bm25_smoke(golden):
+    res = evaluate(golden, "bm25", 5)
+    assert res["recall_at_k"] >= 0.6
+
+
+def test_vector_smoke(golden):
+    res = evaluate(golden, "vector", 5)
+    assert res["recall_at_k"] >= 0.6

--- a/data/retrieval_golden.yaml
+++ b/data/retrieval_golden.yaml
@@ -1,0 +1,25 @@
+- query: "UK GDPR principles of processing"
+  expected:
+    - jurisdiction: "UK"
+      act_code: "UK_GDPR"
+      section_code: "Art.5"
+- query: "data processing contract requirements"
+  expected:
+    - jurisdiction: "UK"
+      act_code: "UK_GDPR"
+      section_code: "Art.28"
+- query: "UCTA reasonableness test section 2"
+  expected:
+    - jurisdiction: "UK"
+      act_code: "UCTA_1977"
+      section_code: "s.2"
+- query: "DPA 2018 section 28 processors"
+  expected:
+    - jurisdiction: "UK"
+      act_code: "DPA_2018"
+      section_code: "s.28(3)"
+- query: "OGUK model form indemnity"
+  expected:
+    - jurisdiction: "UK"
+      act_code: "OGUK_MODEL"
+      section_code: "Indemnity"


### PR DESCRIPTION
## Summary
- add `contract_review_app.retrieval.eval` for offline recall/MRR evaluation
- include golden query set and Makefile target `retrieval-eval`
- test retrieval metrics for bm25/vector/hybrid search

## Testing
- `python -m contract_review_app.retrieval.eval --golden data/retrieval_golden.yaml --method hybrid --k 5`
- `PYTHONPATH=. pytest -q contract_review_app/tests/retrieval/test_eval_smoke.py --maxfail=1`
- `PYTHONPATH=. pytest -q -p no:cov --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68b427e06f2883258d4b42dea6f39587