### PR TITLE
Align panel self-test with taskpane backend logic

### DIFF
--- a/contract_review_app/tests/panel/__init__.py
+++ b/contract_review_app/tests/panel/__init__.py
@@ -1,0 +1,1 @@
+# Panel tests package

--- a/contract_review_app/tests/panel/test_dev_env.py
+++ b/contract_review_app/tests/panel/test_dev_env.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_run_dev_sets_llm_mock(tmp_path):
+    # Проверим, что команда содержит CONTRACTAI_LLM_API=mock (по тексту файла)
+    ps = Path("RUN_DEV.ps1")
+    assert ps.exists()
+    text = ps.read_text(encoding="utf-8").lower()
+    assert "contractai_llm_api" in text and "mock" in text

--- a/contract_review_app/tests/panel/test_panel_urls.py
+++ b/contract_review_app/tests/panel/test_panel_urls.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SELFTEST = ROOT / "word_addin_dev" / "panel_selftest.html"
+
+
+def test_panel_selftest_default_backend_is_https9443():
+    html = SELFTEST.read_text(encoding="utf-8")
+    assert "https://127.0.0.1:9443" in html
+
+
+def test_panel_selftest_uses_unified_ls_key():
+    html = SELFTEST.read_text(encoding="utf-8").lower()
+    assert "panel:backendurl".lower() in html
+
+
+def test_normbase_forces_https_for_9443():
+    html = SELFTEST.read_text(encoding="utf-8")
+    # must contain the http->https replace for localhost:9443 like taskpane
+    assert (
+        "replace(/^http:\/\/(127\\.0\\.0\\.1|localhost)(:9443)" in html
+    ), "normBase must force https for :9443"

--- a/word_addin_dev/START_DEV.bat
+++ b/word_addin_dev/START_DEV.bat
@@ -1,4 +1,4 @@
 @echo off
 setlocal
 REM Запуск PowerShell-скрипта з правильного каталогу та без політик
-powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0RUN_DEV.ps1"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0RUN_DEV.ps1"

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -47,7 +47,7 @@
 
   <div class="row">
     <label for="backendInput">Backend URL:</label>
-    <input id="backendInput" type="text" value="http://127.0.0.1:9000" class="mono" />
+    <input id="backendInput" type="text" value="https://127.0.0.1:9443" class="mono" />
     <button id="saveBtn">Save</button>
     <button id="runAllBtn">Run All</button>
     <span class="small">Saved in localStorage</span>
@@ -126,7 +126,7 @@
 
   <script>
     // ---------------------- helpers ----------------------
-    const LS_KEY = "doctor:backendUrl";
+    const LS_KEY = "panel:backendUrl";
     let clientCid = genCid();
     let lastCid = ""; // from response headers
 
@@ -163,18 +163,19 @@
 
     function genCid(){ return "cid-" + Math.random().toString(16).slice(2) + "-" + Date.now().toString(16); }
 
-    function normBase(v){
-      v = (v || "").trim();
-      if (!v) return "";
-      if (!/^https?:\/\//i.test(v)) v = "http://" + v;
-      v = v.replace(/\/+$/,"");
-      return v;
+    function normBase(u){
+      if (!u) return "";
+      let s = String(u).trim();
+      if (s.startsWith("//")) s = "https:" + s;
+      if (!/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(s)) s = "https://" + s;
+      s = s.replace(/^http:\/\/(127\.0\.0\.1|localhost)(:9443)(\/|$)/, "https://$1$2$3");
+      return s.replace(/\/+$/, "");
     }
     function saveBase(){ try{ localStorage.setItem(LS_KEY, document.getElementById("backendInput").value.trim()); }catch{} }
     function loadBase(){
-      let v = localStorage.getItem(LS_KEY) || document.getElementById("backendInput").value || "http://127.0.0.1:9000";
+      let v = localStorage.getItem(LS_KEY) || document.getElementById("backendInput").value || "https://127.0.0.1:9443";
       v = normBase(v);
-      document.getElementById("backendInput").value = v || "http://127.0.0.1:9000";
+      document.getElementById("backendInput").value = v || "https://127.0.0.1:9443";
       return v;
     }
     function setCidLabels(){


### PR DESCRIPTION
## Summary
- unify panel self-test backend defaults and localStorage key
- enable LLM mock in RUN_DEV script and auto-venv setup
- add smoke tests for panel self-test and dev env

@codex: fix comments

## Testing
- `pre-commit run --files RUN_DEV.ps1 word_addin_dev/START_DEV.bat word_addin_dev/panel_selftest.html contract_review_app/tests/panel/__init__.py contract_review_app/tests/panel/test_panel_urls.py contract_review_app/tests/panel/test_dev_env.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4299c079c8325bd00443bed88cd08