### PR TITLE
test: reset analyze cache between tests

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -149,3 +149,7 @@ python -m contract_review_app.retrieval.eval --golden data/retrieval_golden.yaml
 
 Exit code is zero when both recall and MRR thresholds for the selected method
 are met (0.8/0.6 for hybrid, 0.6/0.5 for bm25/vector).
+
+# Testing
+
+tests reset analyze idempotency cache per test via conftest.py

--- a/contract_review_app/api/cache.py
+++ b/contract_review_app/api/cache.py
@@ -21,3 +21,11 @@ class IdempotencyCache:
 
 
 IDEMPOTENCY_CACHE = IdempotencyCache()
+
+
+def clear_cache() -> None:
+    """Public API to clear the idempotency cache.
+
+    Tests call this to avoid cross-test cache interference.
+    """
+    IDEMPOTENCY_CACHE.clear()

--- a/contract_review_app/tests/conftest.py
+++ b/contract_review_app/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_analyze_idempotency_cache():
+    try:
+        from contract_review_app.api.cache import clear_cache
+        clear_cache()
+    except Exception:
+        # silently ignore if module or function is not available yet
+        pass


### PR DESCRIPTION
## Summary
- expose `clear_cache` helper on idempotency cache
- reset `/api/analyze` cache before every test via `conftest`
- document cache reset in MIGRATION.md

## Testing
- `PYTHONPATH=$PWD python -m pytest -q contract_review_app/tests/test_api_contract_ssot.py::test_analyze_cache_idempotency_headers --maxfail=1`
- `PYTHONPATH=$PWD python -m pytest -q -p no:cov --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b44fd046e0832599a3daa7e3916fb6