### PR TITLE
Improve doctor output handling and corpus DB init

### DIFF
--- a/RUN_DEV.ps1
+++ b/RUN_DEV.ps1
@@ -20,6 +20,8 @@ $ErrorActionPreference = 'Stop'
 if (-not (Test-Path .\.venv\Scripts\Activate.ps1)) { py -3.11 -m venv .venv }
 .\.venv\Scripts\Activate.ps1
 $env:PYTHONPATH = "$PWD"
+if (!(Test-Path .\var)) { New-Item -ItemType Directory -Path .\var | Out-Null }
+if (-not $env:LEGAL_CORPUS_DSN) { $env:LEGAL_CORPUS_DSN = 'sqlite:///var/corpus.db' }
 $env:CONTRACTAI_LLM_API = 'mock'
 $env:CONTRACTAI_DEV_PANEL = '1'
 

--- a/contract_review_app/tests/corpus/test_db_init.py
+++ b/contract_review_app/tests/corpus/test_db_init.py
@@ -1,0 +1,17 @@
+import os, sys, json
+from pathlib import Path
+from sqlalchemy import text
+
+
+def test_corpus_init_sqlite(tmp_path, monkeypatch):
+    db = tmp_path / "corpus.db"
+    monkeypatch.setenv("LEGAL_CORPUS_DSN", f"sqlite:///{db.as_posix()}")
+    from contract_review_app.corpus.db import get_engine
+    from contract_review_app.corpus.db import init_db
+
+    e = get_engine()
+    init_db(e)
+    with e.connect() as c:
+        cnt = c.execute(text("SELECT COUNT(*) FROM legal_corpus")).scalar()
+        assert cnt in (0, int(cnt))
+

--- a/contract_review_app/tests/tools/test_doctor_out_arg.py
+++ b/contract_review_app/tests/tools/test_doctor_out_arg.py
@@ -1,0 +1,36 @@
+import json
+import sys
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def run_doctor(out_arg: str, *flags):
+    cmd = [sys.executable, str(ROOT / "tools" / "doctor.py"), "--out", out_arg, *flags]
+    return subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+
+
+def test_legacy_dir_mode(tmp_path):
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+    cp = run_doctor(str(outdir), "--json")
+    assert cp.returncode == 0, cp.stderr
+    f = outdir / "analysis.json"
+    assert f.is_file()
+    data = json.loads(f.read_text(encoding="utf-8"))
+    assert "blocks" in data and len(data["blocks"]) == 14
+    assert (outdir / "state.log").exists()
+
+
+def test_prefix_mode(tmp_path):
+    prefix = tmp_path / "diag"
+    cp = run_doctor(str(prefix), "--json")
+    assert cp.returncode == 0, cp.stderr
+    f = prefix.with_suffix(".json")
+    assert f.is_file()
+    data = json.loads(f.read_text(encoding="utf-8"))
+    assert "generated_at_utc" in data
+    assert (prefix.parent / "state.log").exists()
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-﻿pytest>=8.0
+pytest>=8.0
 hypothesis>=6.0
 pyyaml>=6.0
 fastapi>=0.110,<1.0
 httpx
-sqlalchemy>=2.0
+SQLAlchemy>=2.0,<3.0
 numpy>=1.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-docx>=0.8.11
 pytest>=8
 pyyaml
 pytest-cov
+SQLAlchemy>=2.0,<3.0


### PR DESCRIPTION
## Summary
- add flexible `--out` handling to doctor with prefix support and block padding
- default legal corpus DSN to local SQLite and provide init routine
- set dev script env vars and defaults for mock API and SQLite corpus

## Testing
- `pip install -r requirements-dev.txt`
- `python -m pytest -q --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b44ec99dd883258c5f285495c3a393