### PR TITLE
feat: add snippet highlighting and spans to corpus search

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -153,3 +153,13 @@ are met (0.8/0.6 for hybrid, 0.6/0.5 for bm25/vector).
 # Testing
 
 tests reset analyze idempotency cache per test via conftest.py
+
+# Block B6-6 — Highlight snippets and offsets
+
+Search responses now expose additional context for each chunk:
+
+* `snippet` – a short window around the first query token match,
+* `span` – exact `start`/`end` offsets in the source document.
+
+These rely on the offset map stored in `corpus_chunks` and help clients
+highlight matches in the original text.

--- a/contract_review_app/retrieval/highlight.py
+++ b/contract_review_app/retrieval/highlight.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import re
+
+
+def make_snippet(text: str, query: str, window: int = 80) -> str:
+    """Return a short snippet around the first match of query tokens.
+
+    The algorithm is deterministic:
+    * tokenize ``query`` into lowercase words;
+    * find the earliest occurrence of any token in ``text`` (case-insensitive);
+    * return ``window`` characters of context on both sides;
+    * trim to string bounds and prepend/append "…" if cut off;
+    * if no token is found, return the head of ``text`` of length ``2*window``.
+    """
+    tokens = re.findall(r"\w+", query.lower())
+    text_len = len(text)
+    text_lower = text.lower()
+    match_pos: int | None = None
+    match_len = 0
+    for tok in tokens:
+        idx = text_lower.find(tok)
+        if idx != -1 and (match_pos is None or idx < match_pos):
+            match_pos = idx
+            match_len = len(tok)
+    if match_pos is not None:
+        start = max(match_pos - window, 0)
+        end = min(match_pos + match_len + window, text_len)
+        snippet = text[start:end]
+        if start > 0:
+            snippet = "…" + snippet
+        if end < text_len:
+            snippet += "…"
+        return snippet
+    # Fallback: head of the text
+    end = min(2 * window, text_len)
+    snippet = text[:end]
+    if end < text_len:
+        snippet += "…"
+    return snippet

--- a/contract_review_app/tests/api/test_corpus_search_highlight.py
+++ b/contract_review_app/tests/api/test_corpus_search_highlight.py
@@ -1,0 +1,71 @@
+import yaml
+import yaml
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from contract_review_app.corpus.db import SessionLocal, get_engine, init_db
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.retrieval.cache import ensure_vector_cache
+from contract_review_app.retrieval.config import load_config
+from contract_review_app.retrieval.embedder import HashingEmbedder
+from contract_review_app.retrieval.indexer import rebuild_index
+from contract_review_app.api.corpus_search import router
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    dsn = f"sqlite:///{tmp_path/'api.db'}"
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    sess = SessionLocal()
+    repo = Repo(sess)
+    demo_dir = Path('data/corpus_demo')
+    for p in demo_dir.glob('*.yaml'):
+        with open(p, 'r', encoding='utf-8') as fh:
+            data = yaml.safe_load(fh)
+            for item in data['items']:
+                repo.upsert(item)
+    rebuild_index(sess)
+    cache_dir = tmp_path / 'cache'
+    monkeypatch.setenv('RETRIEVAL_CACHE_DIR', str(cache_dir))
+    cfg = load_config()
+    embedder = HashingEmbedder(cfg['vector']['embedding_dim'])
+    ensure_vector_cache(
+        sess,
+        embedder=embedder,
+        cache_dir=cfg['vector']['cache_dir'],
+        emb_ver=cfg['vector']['embedding_version'],
+    )
+    app = FastAPI()
+    app.include_router(router)
+    yield TestClient(app)
+    sess.close()
+
+
+def test_search_returns_snippet_and_span(client):
+    r = client.get(
+        "/api/corpus/search",
+        params={"q": "principles processing", "mode": "hybrid", "top": 5},
+    )
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert results
+    def stem(w: str) -> str:
+        for suf in ("ing", "ed", "es", "s"):
+            if w.endswith(suf) and len(w) - len(suf) >= 3:
+                return w[: -len(suf)]
+        return w
+    stems = {stem(w) for w in {"principles", "processing"}}
+    for item in results:
+        assert isinstance(item.get("snippet"), str) and len(item["snippet"]) > 0
+        span = item["span"]
+        start, end = span.get("start"), span.get("end")
+        assert 0 <= start < end <= len(item["text"])
+        snippet_lower = item["snippet"].lower()
+        text_lower = item["text"].lower()
+        if any(s in text_lower for s in stems):
+            assert any(s in snippet_lower for s in stems)

--- a/contract_review_app/tests/retrieval/test_highlight.py
+++ b/contract_review_app/tests/retrieval/test_highlight.py
@@ -1,0 +1,18 @@
+import pytest
+from contract_review_app.retrieval.highlight import make_snippet
+
+
+def test_make_snippet_includes_keyword_and_ellipsis():
+    text = "A" * 100 + "principles" + "B" * 100
+    query = "principles processing"
+    snippet = make_snippet(text, query, window=10)
+    assert "principles" in snippet.lower()
+    assert snippet.startswith("…") and snippet.endswith("…")
+
+
+def test_make_snippet_deterministic():
+    text = "Data processing principles are important."
+    query = "processing"
+    s1 = make_snippet(text, query)
+    s2 = make_snippet(text, query)
+    assert s1 == s2


### PR DESCRIPTION
## Summary
- add deterministic `make_snippet` helper for extracting context windows
- include snippet and span offsets in retrieval results and API responses
- document new fields in MIGRATION notes

## Testing
- `python -m contract_review_app.corpus.ingest --dir data/corpus_demo`
- `python -m contract_review_app.retrieval.indexer`
- `python -m contract_review_app.retrieval.cli build`
- `python -m pytest -q contract_review_app/tests/retrieval/test_highlight.py --maxfail=1`
- `python -m pytest -q contract_review_app/tests/api/test_corpus_search_highlight.py --maxfail=1`
- `python -m pytest -q -p no:cov --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68b458524b908325952f2747b89cdad6