### PR TITLE
feat: add citation resolve API

### DIFF
--- a/contract_review_app/tests/api/test_citation_resolver_api.py
+++ b/contract_review_app/tests/api/test_citation_resolver_api.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_citation_resolve_passthrough():
+    payload = {"citation": {"instrument": "UK GDPR", "section": "Article 28(3)"}}
+    r = client.post("/api/citation/resolve", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["citation"]["instrument"] == "UK GDPR"
+    assert data["citation"]["section"] == "Article 28(3)"
+
+
+def test_citation_resolve_bad_payload():
+    r = client.post("/api/citation/resolve", json={})
+    assert r.status_code == 400
+
+
+def test_citation_resolve_unresolvable():
+    payload = {"finding": {"code": "NO_SUCH_RULE", "message": "irrelevant"}}
+    r = client.post("/api/citation/resolve", json=payload)
+    assert r.status_code == 422


### PR DESCRIPTION
## Summary
- add endpoint to resolve legal citations or pass through existing ones
- cover citation resolver API with tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b473562bf08325a50ca654d7a9744b