### PR TITLE
feat: add problem detail error handling

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -163,3 +163,22 @@ Search responses now expose additional context for each chunk:
 
 These rely on the offset map stored in `corpus_chunks` and help clients
 highlight matches in the original text.
+
+# Block B8-S1 — Unified API error format
+
+## Summary
+
+All endpoints now return a standard ProblemDetail JSON body for 4xx/5xx errors.
+
+* Added `ProblemDetail` schema and global exception handlers.
+* FastAPI default error responses: 400/401/403/404/422/429/500.
+* OpenAPI components include `ProblemDetail`; key routes expose it explicitly.
+
+## How to verify
+
+```bash
+curl -X POST localhost:8000/api/analyze -d '{"text":123}' -H 'Content-Type: application/json'
+curl -X POST localhost:8000/api/gpt/draft -d '{}' -H 'Content-Type: application/json'
+```
+
+Both calls return `{"type":"/errors/general","title":...,"status":422}`.

--- a/contract_review_app/api/error_handlers.py
+++ b/contract_review_app/api/error_handlers.py
@@ -1,0 +1,29 @@
+import logging
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from .models import ProblemDetail
+
+logger = logging.getLogger(__name__)
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    @app.exception_handler(RequestValidationError)
+    async def _handle_validation_error(request: Request, exc: RequestValidationError):
+        problem = ProblemDetail(title="Validation error", status=422)
+        return JSONResponse(problem.model_dump(), status_code=422)
+
+    @app.exception_handler(HTTPException)
+    async def _handle_http_exception(request: Request, exc: HTTPException):
+        if exc.status_code >= 500:
+            logger.exception("HTTPException", exc_info=exc)
+        title = exc.detail if isinstance(exc.detail, str) else "Error"
+        problem = ProblemDetail(title=title, status=exc.status_code)
+        return JSONResponse(problem.model_dump(), status_code=exc.status_code)
+
+    @app.exception_handler(Exception)
+    async def _handle_exception(request: Request, exc: Exception):
+        logger.exception("Unhandled exception", exc_info=exc)
+        problem = ProblemDetail(title="Internal Server Error", status=500)
+        return JSONResponse(problem.model_dump(), status_code=500)

--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from contract_review_app.core.schemas import AppBaseModel
+
+
+class ProblemDetail(AppBaseModel):
+    type: str = "/errors/general"
+    title: str
+    status: int
+    detail: str | None = None
+    instance: str | None = None
+    code: str | None = None
+    extra: dict[str, Any] | None = None

--- a/contract_review_app/gpt/gpt_draft_api.py
+++ b/contract_review_app/gpt/gpt_draft_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Optional, Dict
 
 from fastapi import APIRouter, HTTPException
+from contract_review_app.api.models import ProblemDetail
 from pydantic import BaseModel
 
 # Спробуємо підтягнути типи, але не ламаємося, якщо їх немає
@@ -159,7 +160,11 @@ def api_gpt_draft_analysis_output(payload: Dict[str, Any]) -> Any:
     return _fallback_redraft(analysis)
 
 
-@router.post("/api/gpt/draft", response_model=GPTDraftResponse)
+@router.post(
+    "/api/gpt/draft",
+    response_model=GPTDraftResponse,
+    responses={422: {"model": ProblemDetail}, 500: {"model": ProblemDetail}},
+)
 def api_gpt_draft_gptdto(payload: Dict[str, Any]) -> GPTDraftResponse:
     """
     НОВИЙ контракт для UI-панелі: приймає або {analysis: ...}, або legacy {clause_type,text}

--- a/contract_review_app/tests/api/test_api_errors.py
+++ b/contract_review_app/tests/api/test_api_errors.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+import contract_review_app.api.app as app_module
+from contract_review_app.api.error_handlers import register_error_handlers
+from contract_review_app.api.models import ProblemDetail
+
+client = TestClient(app_module.app, raise_server_exceptions=False)
+
+
+def test_422_validation_error():
+    r = client.post("/api/analyze", json={"text": 123})
+    assert r.status_code == 422
+    ProblemDetail.model_validate(r.json())
+    assert r.json()["status"] == 422
+
+
+def test_http_exception_problem():
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/boom")
+    def _boom():
+        raise HTTPException(status_code=400, detail="bad")
+
+    tmp = TestClient(app)
+    resp = tmp.get("/boom")
+    assert resp.status_code == 400
+    ProblemDetail.model_validate(resp.json())
+    assert resp.json()["status"] == 400
+
+
+def test_generic_exception(monkeypatch):
+    def boom(text: str):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(app_module, "_analyze_document", boom, raising=True)
+    resp = client.post("/api/analyze", json={"text": "hello"})
+    assert resp.status_code == 500
+    ProblemDetail.model_validate(resp.json())
+    assert "boom" not in resp.text

--- a/contract_review_app/tests/api/test_openapi_errors_contract.py
+++ b/contract_review_app/tests/api/test_openapi_errors_contract.py
@@ -1,0 +1,28 @@
+import os
+import importlib
+from fastapi.testclient import TestClient
+
+
+def _build_client() -> TestClient:
+    os.environ["CONTRACTAI_LLM_API"] = "1"
+    import contract_review_app.api.app as app_module
+    importlib.reload(app_module)
+    client = TestClient(app_module.app)
+    os.environ.pop("CONTRACTAI_LLM_API", None)
+    return client
+
+
+def test_problem_detail_component():
+    client = _build_client()
+    schema = client.get("/openapi.json").json()
+    assert "ProblemDetail" in schema["components"]["schemas"]
+
+
+def test_problem_detail_responses():
+    client = _build_client()
+    schema = client.get("/openapi.json").json()
+    for path in ["/api/analyze", "/api/gpt/draft", "/api/citations/resolve"]:
+        post = schema["paths"][path]["post"]
+        for code in ("422", "500"):
+            ref = post["responses"][code]["content"]["application/json"]["schema"]["$ref"]
+            assert ref == "#/components/schemas/ProblemDetail"


### PR DESCRIPTION
## Summary
- return unified ProblemDetail JSON for API errors
- wire global exception handlers and default error responses
- document error schema in OpenAPI and add tests

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_api_errors.py`
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_openapi_errors_contract.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4845060588325b0aff1ed80a2033e