### PR TITLE
feat(api): add strict DTO models for public API

### DIFF
--- a/contract_review_app/api/corpus_search.py
+++ b/contract_review_app/api/corpus_search.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from typing import Generator
+from typing import Generator, List
 
 from contract_review_app.corpus.db import SessionLocal
 from contract_review_app.retrieval.search import search_corpus
+
+from .models import CorpusSearchRequest, CorpusSearchResponse, SearchHit, Span
 
 
 router = APIRouter(prefix="/api/corpus")
@@ -19,25 +21,31 @@ def get_session() -> Generator[Session, None, None]:
         db.close()
 
 
-@router.get("/search")
-def corpus_search(
-    q: str = Query(..., min_length=1),
-    jurisdiction: str | None = None,
-    source: str | None = None,
-    act_code: str | None = None,
-    section_code: str | None = None,
-    top: int = 10,
-    mode: str = "bm25",
-    session: Session = Depends(get_session),
-):
+@router.post("/search", response_model=CorpusSearchResponse)
+def corpus_search(body: CorpusSearchRequest, session: Session = Depends(get_session)):
     rows = search_corpus(
         session,
-        q,
-        mode=mode,
-        jurisdiction=jurisdiction,
-        source=source,
-        act_code=act_code,
-        section_code=section_code,
-        top=top,
+        body.q,
+        mode=body.method,
+        jurisdiction=body.jurisdiction,
+        source=body.source,
+        act_code=body.act_code,
+        section_code=body.section_code,
+        top=body.k,
     )
-    return {"results": rows}
+    hits: List[dict] = []
+    for r in rows:
+        hit = SearchHit(
+            doc_id=str(r.get("id")),
+            score=float(r.get("score", 0.0)),
+            span=Span(**r.get("span", {})),
+            snippet=r.get("snippet"),
+            title=(r.get("meta") or {}).get("title"),
+            text=r.get("text"),
+            meta=r.get("meta"),
+            bm25_score=r.get("bm25_score"),
+            cosine_sim=r.get("cosine_sim"),
+            rank_fusion=r.get("rank_fusion"),
+        ).model_dump()
+        hits.append(hit)
+    return CorpusSearchResponse(hits=hits)

--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -1,6 +1,12 @@
-from typing import Any
+from typing import Any, Dict, List, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from contract_review_app.core.schemas import AppBaseModel
+
+
+class _DTOBase(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
 
 class ProblemDetail(AppBaseModel):
@@ -11,3 +17,100 @@ class ProblemDetail(AppBaseModel):
     instance: str | None = None
     code: str | None = None
     extra: dict[str, Any] | None = None
+
+
+class AnalyzeRequest(_DTOBase):
+    text: str
+
+
+class Span(_DTOBase):
+    start: int = Field(ge=0)
+    end: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _check_order(self):  # type: ignore[override]
+        if self.start >= self.end:
+            raise ValueError("start must be < end")
+        return self
+
+
+class Finding(_DTOBase):
+    span: Span
+    text: str
+    lang: Literal["latin", "cyrillic"]
+
+    @property
+    def message(self) -> str:
+        return self.text
+
+    @property
+    def code(self) -> str:
+        return ""
+
+
+class Segment(_DTOBase):
+    span: Span
+    lang: Literal["latin", "cyrillic"]
+
+
+class AnalyzeResult(_DTOBase):
+    findings: List[Finding]
+    segments: List[Segment] | None = None
+
+
+class _AnalyzeResults(_DTOBase):
+    analysis: AnalyzeResult
+
+
+class AnalyzeResponse(_DTOBase):
+    results: _AnalyzeResults
+    analysis: AnalyzeResult | None = None
+    status: str | None = None
+    clauses: List[Any] | None = None
+    document: Dict[str, Any] | None = None
+    summary: Dict[str, Any] | None = None
+    schema_version: str | None = None
+
+
+class Citation(_DTOBase):
+    instrument: str
+    section: str
+
+
+class CitationResolveRequest(_DTOBase):
+    findings: List[Finding] | None = None
+    citations: List[Citation] | None = None
+
+
+class CitationResolveResponse(_DTOBase):
+    citations: List[Citation]
+
+
+SearchMethod = Literal["hybrid", "bm25", "vector"]
+
+
+class CorpusSearchRequest(_DTOBase):
+    q: str
+    k: int = 10
+    method: SearchMethod = "hybrid"
+    jurisdiction: str | None = None
+    source: str | None = None
+    act_code: str | None = None
+    section_code: str | None = None
+
+
+class SearchHit(_DTOBase):
+    doc_id: str
+    score: float
+    span: Span
+    snippet: str | None = None
+    title: str | None = None
+    text: str | None = None
+    meta: Dict[str, Any] | None = None
+    bm25_score: float | None = None
+    cosine_sim: float | None = None
+    rank_fusion: int | None = None
+
+
+class CorpusSearchResponse(_DTOBase):
+    hits: List[SearchHit]

--- a/contract_review_app/tests/api/test_citation_resolver_api.py
+++ b/contract_review_app/tests/api/test_citation_resolver_api.py
@@ -5,12 +5,16 @@ client = TestClient(app)
 
 
 def test_citation_resolve_passthrough():
-    payload = {"citation": {"instrument": "UK GDPR", "section": "Article 28(3)"}}
+    payload = {
+        "citations": [
+            {"instrument": "UK GDPR", "section": "Article 28(3)"}
+        ]
+    }
     r = client.post("/api/citation/resolve", json=payload)
     assert r.status_code == 200
     data = r.json()
-    assert data["citation"]["instrument"] == "UK GDPR"
-    assert data["citation"]["section"] == "Article 28(3)"
+    assert data["citations"][0]["instrument"] == "UK GDPR"
+    assert data["citations"][0]["section"] == "Article 28(3)"
 
 
 def test_citation_resolve_bad_payload():
@@ -19,6 +23,10 @@ def test_citation_resolve_bad_payload():
 
 
 def test_citation_resolve_unresolvable():
-    payload = {"finding": {"code": "NO_SUCH_RULE", "message": "irrelevant"}}
+    payload = {
+        "findings": [
+            {"span": {"start": 0, "end": 1}, "text": "irrelevant", "lang": "latin"}
+        ]
+    }
     r = client.post("/api/citation/resolve", json=payload)
     assert r.status_code == 422

--- a/contract_review_app/tests/api/test_corpus_search_api.py
+++ b/contract_review_app/tests/api/test_corpus_search_api.py
@@ -30,10 +30,13 @@ def test_corpus_search_api(tmp_path):
     app = FastAPI()
     app.include_router(router)
     client = TestClient(app)
-    r = client.get("/api/corpus/search", params={"q": "processing", "jurisdiction": "UK", "top": 3})
+    r = client.post(
+        "/api/corpus/search",
+        json={"q": "processing", "jurisdiction": "UK", "k": 3, "method": "bm25"},
+    )
     assert r.status_code == 200
     data = r.json()
-    assert isinstance(data.get("results"), list)
-    assert data["results"]
-    item = data["results"][0]
-    assert {"id", "meta", "span", "text", "score"}.issubset(item.keys())
+    assert isinstance(data.get("hits"), list)
+    assert data["hits"]
+    item = data["hits"][0]
+    assert {"doc_id", "span", "score"}.issubset(item.keys())

--- a/contract_review_app/tests/api/test_corpus_search_highlight.py
+++ b/contract_review_app/tests/api/test_corpus_search_highlight.py
@@ -47,12 +47,12 @@ def client(tmp_path, monkeypatch):
 
 
 def test_search_returns_snippet_and_span(client):
-    r = client.get(
+    r = client.post(
         "/api/corpus/search",
-        params={"q": "principles processing", "mode": "hybrid", "top": 5},
+        json={"q": "principles processing", "method": "hybrid", "k": 5},
     )
     assert r.status_code == 200
-    results = r.json()["results"]
+    results = r.json()["hits"]
     assert results
     def stem(w: str) -> str:
         for suf in ("ing", "ed", "es", "s"):

--- a/contract_review_app/tests/api/test_corpus_search_modes.py
+++ b/contract_review_app/tests/api/test_corpus_search_modes.py
@@ -58,12 +58,12 @@ def test_vector_and_hybrid_modes(session, monkeypatch):
     app = FastAPI()
     app.include_router(router)
     client = TestClient(app)
-    r = client.get('/api/corpus/search', params={'q': 'data', 'mode': 'vector'})
+    r = client.post('/api/corpus/search', json={'q': 'data', 'method': 'vector'})
     assert r.status_code == 200
-    assert r.json()['results']
-    r2 = client.get('/api/corpus/search', params={'q': 'data', 'mode': 'hybrid'})
+    assert r.json()['hits']
+    r2 = client.post('/api/corpus/search', json={'q': 'data', 'method': 'hybrid'})
     assert r2.status_code == 200
-    assert r2.json()['results']
+    assert r2.json()['hits']
     assert calls == [True, True]
 
 
@@ -74,9 +74,9 @@ def test_hybrid_weighted_has_rank_fusion(session, monkeypatch):
     app = FastAPI()
     app.include_router(router)
     client = TestClient(app)
-    r = client.get('/api/corpus/search', params={'q': 'data', 'mode': 'hybrid'})
+    r = client.post('/api/corpus/search', json={'q': 'data', 'method': 'hybrid'})
     assert r.status_code == 200
-    results = r.json()['results']
+    results = r.json()['hits']
     assert results
     for item in results:
         assert isinstance(item.get('rank_fusion'), int)

--- a/contract_review_app/tests/api/test_openapi_dto_contract.py
+++ b/contract_review_app/tests/api/test_openapi_dto_contract.py
@@ -1,0 +1,44 @@
+from contract_review_app.api.app import app
+
+
+REF = "#/components/schemas/{}"
+
+
+def test_openapi_dto_contract():
+    schema = app.openapi()
+    paths = schema["paths"]
+
+    analyze = paths["/api/analyze"]["post"]
+    assert (
+        analyze["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+        == REF.format("AnalyzeRequest")
+    )
+    assert (
+        analyze["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+        == REF.format("AnalyzeResponse")
+    )
+
+    for p in ("/api/citation/resolve", "/api/citations/resolve"):
+        op = paths[p]["post"]
+        assert (
+            op["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+            == REF.format("CitationResolveRequest")
+        )
+        assert (
+            op["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+            == REF.format("CitationResolveResponse")
+        )
+
+    corpus = paths["/api/corpus/search"]["post"]
+    assert (
+        corpus["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+        == REF.format("CorpusSearchRequest")
+    )
+    assert (
+        corpus["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+        == REF.format("CorpusSearchResponse")
+    )
+
+    comps = schema["components"]["schemas"]
+    for name in ["Finding", "Span", "Segment", "SearchHit", "Citation"]:
+        assert name in comps


### PR DESCRIPTION
## Summary
- define strict pydantic DTOs for analysis, citation resolve and corpus search endpoints
- bind DTOs to FastAPI routes so OpenAPI references shared schemas
- switch corpus search to typed POST endpoint

## Testing
- `python -m pytest -q contract_review_app/tests/api/test_openapi_dto_contract.py --maxfail=1`
- `python -m pytest -q contract_review_app/tests/api/test_api_citations_block2_autosmoke.py::test_api_citations_block2_no_flag --maxfail=1`
- `python -m pytest -q contract_review_app/tests/api/test_api_citations_block2_autosmoke.py::test_api_citations_block2_with_feature_flag --maxfail=1`
- `python -m pytest -q contract_review_app/tests/api/test_citation_resolver_api.py --maxfail=1`
- `python -m pytest -q contract_review_app/tests/api/test_corpus_search_highlight.py --maxfail=1`
- `python -m pytest -q -p no:cov --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b4b7f5ebe083258e22682fbd80abcf