### PR TITLE
feat: update draft assistant panel and self-test

### DIFF
--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -191,7 +191,7 @@
     function setStatusRow(rowId, {code, xcid, xcache, xschema, latencyMs, ok, error_code, detail}){
       const tr = document.getElementById(rowId);
       const cells = tr.getElementsByTagName('td');
-      const latencyText = (latencyMs != null ? `${latencyMs} ms` : (xcid ? "" : ""));
+      const latencyText = latencyMs != null ? `${latencyMs} ms` : "";
       cells[1].textContent = code ?? "";
       cells[2].textContent = xcid ?? "";
       cells[3].textContent = xcache ?? "";


### PR DESCRIPTION
## Summary
- add unified panel state and Word copy helpers
- handle new suggest/apply flow with diff preview and HTTP logging
- update self-test to hit /api/gpt-draft and log responses
- simplify latency text handling in self-test

## Testing
- `node -c word_addin_dev/taskpane.bundle.js`
- `pre-commit run --files word_addin_dev/taskpane.html word_addin_dev/taskpane.bundle.js word_addin_dev/panel_selftest.html`


------
https://chatgpt.com/codex/tasks/task_e_68b58409180c8325ab795279440bef97