### PR TITLE
feat: add deterministic API headers and examples

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -182,3 +182,23 @@ curl -X POST localhost:8000/api/gpt/draft -d '{}' -H 'Content-Type: application/
 ```
 
 Both calls return `{"type":"/errors/general","title":...,"status":422}`.
+
+# Block B8-S3 — Standard API headers
+
+## Summary
+
+Every API response now includes three standard headers:
+
+* `x-schema-version` – current schema version (`1.3`).
+* `x-latency-ms` – request processing time in milliseconds.
+* `x-cid` – deterministic SHA256 hash of the canonical request (`path + sorted(query) + JSON body`).
+
+## How to verify
+
+```bash
+curl -i -X POST localhost:8000/api/analyze \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"hello"}'
+```
+
+Repeated calls with the same payload yield identical `x-cid`, while changing the body alters the hash. The headers are also present on error responses.

--- a/contract_review_app/api/error_handlers.py
+++ b/contract_review_app/api/error_handlers.py
@@ -1,9 +1,11 @@
 import logging
+import time
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from .models import ProblemDetail
+from .headers import apply_std_headers
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +14,9 @@ def register_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(RequestValidationError)
     async def _handle_validation_error(request: Request, exc: RequestValidationError):
         problem = ProblemDetail(title="Validation error", status=422)
-        return JSONResponse(problem.model_dump(), status_code=422)
+        resp = JSONResponse(problem.model_dump(), status_code=422)
+        apply_std_headers(resp, request, getattr(request.state, "started_at", time.perf_counter()))
+        return resp
 
     @app.exception_handler(HTTPException)
     async def _handle_http_exception(request: Request, exc: HTTPException):
@@ -20,10 +24,14 @@ def register_error_handlers(app: FastAPI) -> None:
             logger.exception("HTTPException", exc_info=exc)
         title = exc.detail if isinstance(exc.detail, str) else "Error"
         problem = ProblemDetail(title=title, status=exc.status_code)
-        return JSONResponse(problem.model_dump(), status_code=exc.status_code)
+        resp = JSONResponse(problem.model_dump(), status_code=exc.status_code)
+        apply_std_headers(resp, request, getattr(request.state, "started_at", time.perf_counter()))
+        return resp
 
     @app.exception_handler(Exception)
     async def _handle_exception(request: Request, exc: Exception):
         logger.exception("Unhandled exception", exc_info=exc)
         problem = ProblemDetail(title="Internal Server Error", status=500)
-        return JSONResponse(problem.model_dump(), status_code=500)
+        resp = JSONResponse(problem.model_dump(), status_code=500)
+        apply_std_headers(resp, request, getattr(request.state, "started_at", time.perf_counter()))
+        return resp

--- a/contract_review_app/api/headers.py
+++ b/contract_review_app/api/headers.py
@@ -1,0 +1,43 @@
+import hashlib
+import json
+import time
+from typing import Any
+
+from fastapi import Request, Response
+
+from .models import SCHEMA_VERSION
+
+
+def compute_cid(request: Request) -> str:
+    """Compute deterministic content id for a request.
+
+    POST/PUT/PATCH: path + sorted(query) + canonical JSON body
+    GET/DELETE: path + sorted(query)
+    """
+    path = request.url.path
+    query_items = sorted(request.query_params.multi_items())
+    query = "&".join(f"{k}={v}" for k, v in query_items)
+    body_part = ""
+    if request.method.upper() in {"POST", "PUT", "PATCH"}:
+        body_bytes = getattr(request.state, "body", b"")
+        try:
+            obj: Any = json.loads(body_bytes.decode("utf-8")) if body_bytes else None
+        except Exception:
+            obj = body_bytes.decode("utf-8", "ignore")
+        if obj is None:
+            body_part = ""
+        elif isinstance(obj, (dict, list)):
+            body_part = json.dumps(obj, sort_keys=True, ensure_ascii=False)
+        else:
+            body_part = str(obj)
+    raw = f"{path}{query}{body_part}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def apply_std_headers(response: Response, request: Request, started_at: float) -> None:
+    """Apply standard headers to the response."""
+    latency_ms = int((time.perf_counter() - started_at) * 1000)
+    cid = compute_cid(request)
+    response.headers["x-schema-version"] = SCHEMA_VERSION
+    response.headers["x-latency-ms"] = str(latency_ms)
+    response.headers["x-cid"] = cid

--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -5,6 +5,9 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from contract_review_app.core.schemas import AppBaseModel
 
 
+SCHEMA_VERSION = "1.3"
+
+
 class _DTOBase(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 

--- a/contract_review_app/tests/api/test_api_headers.py
+++ b/contract_review_app/tests/api/test_api_headers.py
@@ -1,0 +1,33 @@
+import json
+import hashlib
+import re
+
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
+
+client = TestClient(app)
+
+import pytest
+
+
+@pytest.mark.parametrize("path", ["/api/analyze", "/api/gpt/draft"])
+def test_std_headers_present_and_valid(path):
+    payload1 = {"text": "hello"}
+    payload2 = {"text": "world"}
+    r1 = client.post(path, json=payload1)
+    r2 = client.post(path, json=payload1)
+    r3 = client.post(path, json=payload2)
+    assert r1.headers["x-cid"] == r2.headers["x-cid"]
+    assert r1.headers["x-cid"] != r3.headers["x-cid"]
+    assert r1.headers["x-schema-version"] == SCHEMA_VERSION
+    assert int(r1.headers["x-latency-ms"]) >= 0
+    assert re.fullmatch(r"[0-9a-f]{64}", r1.headers["x-cid"])
+
+
+def test_error_handlers_also_emit_headers():
+    r = client.post("/api/analyze", json={})
+    assert r.status_code == 422
+    for h in ("x-schema-version", "x-latency-ms", "x-cid"):
+        assert h in r.headers

--- a/contract_review_app/tests/api/test_openapi_headers_contract.py
+++ b/contract_review_app/tests/api/test_openapi_headers_contract.py
@@ -1,0 +1,19 @@
+import importlib
+import os
+
+os.environ.setdefault("CONTRACTAI_LLM_API", "1")
+app = importlib.reload(importlib.import_module("contract_review_app.api.app")).app
+
+
+def test_openapi_headers_contract():
+    schema = app.openapi()
+    headers = schema.get("components", {}).get("headers", {})
+    assert "XSchemaVersion" in headers
+    assert "XLatencyMs" in headers
+    assert "XCid" in headers
+    for path in ["/api/analyze", "/api/gpt/draft"]:
+        op = schema["paths"][path]["post"]
+        resp_headers = op["responses"]["200"]["headers"]
+        assert resp_headers["x-schema-version"]["$ref"] == "#/components/headers/XSchemaVersion"
+        assert resp_headers["x-latency-ms"]["$ref"] == "#/components/headers/XLatencyMs"
+        assert resp_headers["x-cid"]["$ref"] == "#/components/headers/XCid"


### PR DESCRIPTION
## Summary
- add shared module for computing x-cid and applying standard headers
- instrument FastAPI app with middleware + error handlers to emit schema version, latency and cid
- document standard headers in OpenAPI and MIGRATION guide with examples

## Testing
- `pytest contract_review_app/tests/api/test_api_headers.py contract_review_app/tests/api/test_openapi_headers_contract.py contract_review_app/tests/test_api_headers_and_qarecheck.py`


------
https://chatgpt.com/codex/tasks/task_e_68b584389b088325ba3c71c8810501cf