### PR TITLE
fix trace cid headers

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -202,3 +202,5 @@ curl -i -X POST localhost:8000/api/analyze \
 ```
 
 Repeated calls with the same payload yield identical `x-cid`, while changing the body alters the hash. The headers are also present on error responses.
+
+Trace middleware теперь получает те же `x-cid`/`x-latency-ms`, что и клиент; порядок middleware фиксирован: trace → headers → endpoint → headers → trace.


### PR DESCRIPTION
## Summary
- ensure trace middleware receives and logs same x-cid/x-latency-ms as client
- add test for consistent trace cid and latency
- document middleware ordering and trace behavior

## Testing
- `pre-commit run --files contract_review_app/api/app.py contract_review_app/tests/api/test_api_headers.py MIGRATION.md`
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_api_headers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b58e8b66e88325b353dec505dc0bcd