### PR TITLE
Add API timeouts, rate limiting and pagination

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -204,3 +204,40 @@ curl -i -X POST localhost:8000/api/analyze \
 Repeated calls with the same payload yield identical `x-cid`, while changing the body alters the hash. The headers are also present on error responses.
 
 Trace middleware теперь получает те же `x-cid`/`x-latency-ms`, что и клиент; порядок middleware фиксирован: trace → headers → endpoint → headers → trace.
+
+# Block B8-S4 — Timeouts, 429, Pagination
+
+## Summary
+
+* Added global request timeout and rate limiting.
+* List endpoints now support pagination.
+* OpenAPI documents new responses (429/504) and paging parameters.
+
+## Environment variables
+
+```bash
+CONTRACTAI_API_TIMEOUT_S   # default 30
+CONTRACTAI_RATE_PER_MIN    # default 60
+CONTRACTAI_PAGE_SIZE       # default 10
+CONTRACTAI_MAX_PAGE_SIZE   # default 50
+```
+
+## Examples
+
+Timeout (504):
+
+```bash
+curl -i /api/analyze -d '{"text":"slow"}' -H 'Content-Type: application/json'
+```
+
+Too many requests (429):
+
+```bash
+curl -i -X POST /api/analyze -d '{"text":"hi"}' -H 'Content-Type: application/json'
+```
+
+Pagination:
+
+```bash
+curl -X POST '/api/corpus/search?page=2&page_size=5' -d '{"q":"data"}' -H 'Content-Type: application/json'
+```

--- a/contract_review_app/api/limits.py
+++ b/contract_review_app/api/limits.py
@@ -1,0 +1,6 @@
+import os
+
+API_TIMEOUT_S = int(os.getenv("CONTRACTAI_API_TIMEOUT_S", "30"))
+API_RATE_LIMIT_PER_MIN = int(os.getenv("CONTRACTAI_RATE_PER_MIN", "60"))
+DEFAULT_PAGE_SIZE = int(os.getenv("CONTRACTAI_PAGE_SIZE", "10"))
+MAX_PAGE_SIZE = int(os.getenv("CONTRACTAI_MAX_PAGE_SIZE", "50"))

--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -115,5 +115,13 @@ class SearchHit(_DTOBase):
     rank_fusion: int | None = None
 
 
+class Paging(BaseModel):
+    page: int
+    page_size: int
+    total: int
+    pages: int
+
+
 class CorpusSearchResponse(_DTOBase):
     hits: List[SearchHit]
+    paging: Paging | None = None

--- a/contract_review_app/tests/api/test_corpus_search_pagination.py
+++ b/contract_review_app/tests/api/test_corpus_search_pagination.py
@@ -1,0 +1,54 @@
+import yaml
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from contract_review_app.corpus.db import get_engine, init_db, SessionLocal
+from contract_review_app.corpus.repo import Repo
+from contract_review_app.retrieval.indexer import rebuild_index
+from contract_review_app.api.corpus_search import router
+from contract_review_app.api.limits import MAX_PAGE_SIZE
+
+
+def _setup_demo(session):
+    repo = Repo(session)
+    for p in Path('data/corpus_demo').glob('*.yaml'):
+        with open(p, 'r', encoding='utf-8') as fh:
+            data = yaml.safe_load(fh)
+            for item in data['items']:
+                repo.upsert(item)
+
+
+def _make_client(tmp_path):
+    dsn = f"sqlite:///{tmp_path/'api.db'}"
+    engine = get_engine(dsn)
+    init_db(engine)
+    SessionLocal.configure(bind=engine)
+    with SessionLocal() as session:
+        _setup_demo(session)
+        rebuild_index(session)
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_pagination_basic(tmp_path):
+    client = _make_client(tmp_path)
+    r = client.post("/api/corpus/search?page=1&page_size=2", json={"q": "processing"})
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data['hits']) == 2
+    assert data['paging']['total'] == 5
+    assert data['paging']['pages'] == 3
+
+    r = client.post("/api/corpus/search?page=3&page_size=2", json={"q": "processing"})
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data['hits']) == 1
+
+
+def test_page_size_validation(tmp_path):
+    client = _make_client(tmp_path)
+    r = client.post(f"/api/corpus/search?page_size={MAX_PAGE_SIZE + 1}", json={"q": "processing"})
+    assert r.status_code == 422

--- a/contract_review_app/tests/api/test_openapi_limits_contract.py
+++ b/contract_review_app/tests/api/test_openapi_limits_contract.py
@@ -1,0 +1,20 @@
+from contract_review_app.api.app import app
+
+
+def test_openapi_contains_limits_and_paging():
+    schema = app.openapi()
+    paths = schema['paths']
+    for p in ('/api/analyze', '/api/corpus/search'):
+        op = paths[p]['post']
+        responses = op['responses']
+        assert '429' in responses
+        assert '504' in responses
+    search_op = paths['/api/corpus/search']['post']
+    params = search_op.get('parameters', [])
+    assert any(p['name'] == 'page' for p in params)
+    assert any(p['name'] == 'page_size' for p in params)
+    assert 'Paging' in schema['components']['schemas']
+    resp_ref = search_op['responses']['200']['content']['application/json']['schema']['$ref']
+    resp_name = resp_ref.split('/')[-1]
+    resp_schema = schema['components']['schemas'][resp_name]
+    assert 'paging' in resp_schema.get('properties', {})

--- a/contract_review_app/tests/api/test_rate_limit_and_timeouts.py
+++ b/contract_review_app/tests/api/test_rate_limit_and_timeouts.py
@@ -1,0 +1,38 @@
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_timeout_returns_504(monkeypatch):
+    monkeypatch.setattr("contract_review_app.api.app.API_TIMEOUT_S", 0.01)
+
+    async def slow(text: str) -> dict:
+        await asyncio.sleep(0.05)
+        return {}
+
+    monkeypatch.setattr("contract_review_app.api.app._analyze_document", slow)
+    r = client.post("/api/analyze", json={"text": "hello"})
+    assert r.status_code == 504
+    data = r.json()
+    assert data["type"] == "timeout"
+    for h in ("x-schema-version", "x-latency-ms", "x-cid"):
+        assert h in r.headers
+
+
+def test_rate_limit_returns_429(monkeypatch):
+    monkeypatch.setattr("contract_review_app.api.app.API_RATE_LIMIT_PER_MIN", 2)
+    monkeypatch.setattr("contract_review_app.api.app._RATE_BUCKETS", {})
+    payload = {"text": "hi"}
+    client.post("/api/analyze", json=payload)
+    client.post("/api/analyze", json=payload)
+    r = client.post("/api/analyze", json=payload)
+    assert r.status_code == 429
+    data = r.json()
+    assert data["type"] == "too_many_requests"
+    assert "Retry-After" in r.headers
+    for h in ("x-schema-version", "x-latency-ms", "x-cid"):
+        assert h in r.headers


### PR DESCRIPTION
## Summary
- add environment-based limits and paging model
- implement rate limit and timeout middleware with standard headers
- support pagination for corpus search and document OpenAPI 429/504 responses

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/api`


------
https://chatgpt.com/codex/tasks/task_e_68b594bdbb8c83258b68c9423ebe2cc5