### PR TITLE
Fix draft provider schema version and exports

### DIFF
--- a/contract_review_app/llm/provider/__init__.py
+++ b/contract_review_app/llm/provider/__init__.py
@@ -1,10 +1,21 @@
-from ..provider import DraftResult, MockProvider, AzureProvider, provider_from_env
+from .base import LLMConfig, LLMResult, LLMProvider
+from .mock_provider import MockProvider
 from .proxy import ProxyProvider
+from ..draft import (
+    DraftResult,
+    DraftMockProvider,
+    AzureProvider,
+    provider_from_env,
+)
 
 __all__ = [
-    "DraftResult",
+    "LLMConfig",
+    "LLMResult",
+    "LLMProvider",
     "MockProvider",
+    "ProxyProvider",
+    "DraftResult",
+    "DraftMockProvider",
     "AzureProvider",
     "provider_from_env",
-    "ProxyProvider",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ httpx
 SQLAlchemy>=2.0,<3
 numpy>=1.26
 cryptography>=42
+requests>=2.31


### PR DESCRIPTION
## Summary
- provide draft provider factory lazily and restore legacy exports
- wire `/api/gpt-draft` to global provider and schema constant
- document `requests` dependency for Azure provider

## Testing
- `PYTHONPATH=. pytest -q --maxfail=1` *(fails: AssertionError: assert 503 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d570bb708325b323e387c9790db6