### PR TITLE
Refactor provider and draft API

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -8,7 +8,6 @@ import json
 import os
 import re
 import time
-import difflib
 from collections import OrderedDict
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -46,6 +45,10 @@ from .models import (
     SCHEMA_VERSION,
 )
 from contract_review_app.llm.provider import provider_from_env
+
+
+LLM_PROVIDER = provider_from_env()
+
 
 # --------------------------------------------------------------------
 # Language segmentation helpers
@@ -163,16 +166,6 @@ try:
 except Exception:  # pragma: no cover
     rules_loader = None  # type: ignore
 
-
-# --- test hook (будет перезаписан monkeypatch в тестах) ---
-def run_gpt_draft(payload: dict | None = None, *args, **kwargs) -> dict:
-    """Placeholder для тестов: тесты заменяют эту функцию через monkeypatch.
-    Возвращаем минимальную структуру по умолчанию.
-    """
-    return {"text": "", "model": "noop"}
-
-
-# ----------------------------------------------------------
 
 # --------------------------------------------------------------------
 # Config
@@ -1377,63 +1370,48 @@ async def api_suggest_edits(
     return {"status": "ok", "edits": [dummy], "suggestions": [dummy]}
 
 
-class _DraftIn(BaseModel):
-    text: str = Field(min_length=1)
-    mode: str = Field(default="friendly")
-
-    @field_validator("mode")
-    @classmethod
-    def _norm_mode(cls, v: str) -> str:
-        v = (v or "friendly").lower()
-        if v not in {"friendly", "medium", "strict"}:
-            raise ValueError("mode must be friendly, medium or strict")
-        return v
+class DraftIn(BaseModel):
+    text: str = Field(..., min_length=1)
+    mode: str = Field("friendly", pattern="^(friendly|medium|strict)$")
 
 
-@router.post("/api/gpt-draft")
-async def api_gpt_draft_dash(body: _DraftIn, response: Response):
-    t0 = _now_ms()
-    provider = provider_from_env()
-    result = provider.draft(body.text, body.mode)
+class DraftOut(BaseModel):
+    status: str
+    mode: str
+    proposed_text: str
+    rationale: str
+    evidence: list
+    before_text: str
+    after_text: str
+    diff: dict
+    x_schema_version: str
 
-    diff_text = "\n".join(
-        difflib.unified_diff(
-            (result.before_text or "").splitlines(),
-            (result.after_text or "").splitlines(),
-            lineterm="",
-        )
-    )
 
-    payload = {
+@router.post(
+    "/api/gpt-draft",
+    response_model=DraftOut,
+    responses={422: {"model": ProblemDetail}},
+)
+async def gpt_draft(inp: DraftIn, request: Request):
+    started = time.perf_counter()
+    text = inp.text.strip()
+    if not text:
+        raise HTTPException(status_code=422, detail="text is required")
+    res = LLM_PROVIDER.draft(text=text, mode=inp.mode)
+    out = {
         "status": "ok",
-        "mode": result.mode,
-        "proposed_text": result.proposed_text,
-        "rationale": result.rationale,
-        "evidence": result.evidence,
-        "before_text": result.before_text,
-        "after_text": result.after_text,
-        "diff": {"type": "unified", "value": diff_text},
-        "x_schema_version": "1.3",
+        "mode": inp.mode,
+        "proposed_text": res.proposed_text,
+        "rationale": res.rationale,
+        "evidence": res.evidence,
+        "before_text": res.before_text,
+        "after_text": res.after_text,
+        "diff": {"type": "unified", "value": res.diff_unified},
+        "x_schema_version": SCHEMA_VERSION,
     }
-
-    _set_schema_headers(response)
-    _set_std_headers(
-        response,
-        cid="gpt-draft",
-        xcache="miss",
-        schema="1.3",
-        latency_ms=_now_ms() - t0,
-    )
-    _set_llm_headers(
-        response,
-        {
-            "provider": result.provider,
-            "model": result.model,
-            "mode": result.mode,
-            "usage": result.usage,
-        },
-    )
-    return payload
+    resp = JSONResponse(out)
+    apply_std_headers(resp, request, started)
+    return resp
 
 
 @router.post("/api/calloff/validate")

--- a/contract_review_app/llm/__init__.py
+++ b/contract_review_app/llm/__init__.py
@@ -1,5 +1,5 @@
 from .orchestrator import Orchestrator
-from .provider import DraftResult, MockProvider, AzureProvider, provider_from_env
+from .draft_provider import DraftResult, MockProvider, AzureProvider, provider_from_env
 
 __all__ = [
     "Orchestrator",

--- a/contract_review_app/llm/provider/__init__.py
+++ b/contract_review_app/llm/provider/__init__.py
@@ -1,10 +1,21 @@
-from ..provider import DraftResult, MockProvider, AzureProvider, provider_from_env
+from .base import LLMConfig, LLMResult, LLMProvider
+from .mock_provider import MockProvider
 from .proxy import ProxyProvider
+from ..draft_provider import (
+    DraftResult,
+    AzureProvider,
+    provider_from_env,
+    MockProvider as DraftMockProvider,
+)
 
 __all__ = [
-    "DraftResult",
+    "LLMConfig",
+    "LLMResult",
+    "LLMProvider",
     "MockProvider",
+    "ProxyProvider",
+    "DraftResult",
     "AzureProvider",
     "provider_from_env",
-    "ProxyProvider",
+    "DraftMockProvider",
 ]

--- a/contract_review_app/tests/gpt/test_gpt_draft_api.py
+++ b/contract_review_app/tests/gpt/test_gpt_draft_api.py
@@ -1,33 +1,25 @@
 import pytest
 from fastapi.testclient import TestClient
+
 from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
 
 client = TestClient(app)
 
+
 def test_gpt_draft_api_endpoint_returns_valid_response():
-    # 📝 Тестовий AnalysisOutput — як JSON
-    input_data = {
-        "clause_type": "Confidentiality",
+    payload = {
         "text": "The parties agree to keep all information confidential.",
-        "status": "FAIL",
-        "findings": [],
-        "recommendations": ["Clarify what information is considered confidential."],
-        "diagnostics": {
-            "rule": "confidentiality_check",
-            "rule_version": "1.0"
-        },
-        "trace": [],
-        "score": 42
+        "mode": "friendly",
     }
 
-    response = client.post("/api/gpt-draft", json=input_data)
-
+    response = client.post("/api/gpt-draft", json=payload)
     assert response.status_code == 200
     result = response.json()
 
-    # 🔍 Перевірки структури відповіді
-    assert result["clause_type"] == "Confidentiality"
-    assert result["text"] != input_data["text"]
-    assert "confidential" in result["text"].lower()
-    assert result["score"] >= input_data["score"]
-    assert "explanation" in result or "recommendations" in result
+    assert result["status"] == "ok"
+    assert result["mode"] == payload["mode"]
+    assert result["before_text"] == payload["text"]
+    assert result["after_text"]
+    assert result["diff"]["type"] == "unified"
+    assert result["x_schema_version"] == SCHEMA_VERSION

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ httpx
 SQLAlchemy>=2.0,<3
 numpy>=1.26
 cryptography>=42
+requests>=2.31


### PR DESCRIPTION
## Summary
- lazily import Azure `requests` client and restore provider package exports
- expose `LLM_PROVIDER` and modern `/api/gpt-draft` endpoint using `SCHEMA_VERSION`
- add requests dependency and align gpt-draft test with new contract

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5d57911b883258f396f0d2016cf60