### PR TITLE
Fix provider package imports and integrate draft endpoint

### DIFF
--- a/contract_review_app/llm/__init__.py
+++ b/contract_review_app/llm/__init__.py
@@ -1,11 +1,22 @@
 from .orchestrator import Orchestrator
-from .provider import DraftResult, MockProvider, AzureProvider, provider_from_env
+from .provider import (
+    DraftResult,
+    LLMConfig,
+    LLMResult,
+    LLMProvider,
+    MockProvider,
+    ProxyProvider,
+    provider_from_env,
+)
 
 __all__ = [
     "Orchestrator",
     "DraftResult",
+    "LLMConfig",
+    "LLMResult",
+    "LLMProvider",
     "MockProvider",
-    "AzureProvider",
+    "ProxyProvider",
     "provider_from_env",
 ]
 """Lightweight LLM utilities and orchestrator."""

--- a/contract_review_app/llm/provider/__init__.py
+++ b/contract_review_app/llm/provider/__init__.py
@@ -1,10 +1,21 @@
-from ..provider import DraftResult, MockProvider, AzureProvider, provider_from_env
+"""Provider utilities for Contract Review App.
+
+This package exposes the legacy ``LLMProvider`` abstraction used by the
+orchestrator as well as the lightweight draft helpers.  The latter are selected
+via :func:`provider_from_env` and power the ``/api/gpt-draft`` endpoint.
+"""
+
+from .base import LLMConfig, LLMResult, LLMProvider
+from .mock_provider import MockProvider
 from .proxy import ProxyProvider
+from .draft import DraftResult, provider_from_env
 
 __all__ = [
-    "DraftResult",
+    "LLMConfig",
+    "LLMResult",
+    "LLMProvider",
     "MockProvider",
-    "AzureProvider",
-    "provider_from_env",
     "ProxyProvider",
+    "DraftResult",
+    "provider_from_env",
 ]

--- a/contract_review_app/tests/gpt/test_gpt_draft_api.py
+++ b/contract_review_app/tests/gpt/test_gpt_draft_api.py
@@ -1,23 +1,14 @@
-import pytest
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
 
 client = TestClient(app)
 
+
 def test_gpt_draft_api_endpoint_returns_valid_response():
-    # 📝 Тестовий AnalysisOutput — як JSON
     input_data = {
-        "clause_type": "Confidentiality",
         "text": "The parties agree to keep all information confidential.",
-        "status": "FAIL",
-        "findings": [],
-        "recommendations": ["Clarify what information is considered confidential."],
-        "diagnostics": {
-            "rule": "confidentiality_check",
-            "rule_version": "1.0"
-        },
-        "trace": [],
-        "score": 42
+        "mode": "friendly",
     }
 
     response = client.post("/api/gpt-draft", json=input_data)
@@ -25,9 +16,7 @@ def test_gpt_draft_api_endpoint_returns_valid_response():
     assert response.status_code == 200
     result = response.json()
 
-    # 🔍 Перевірки структури відповіді
-    assert result["clause_type"] == "Confidentiality"
-    assert result["text"] != input_data["text"]
-    assert "confidential" in result["text"].lower()
-    assert result["score"] >= input_data["score"]
-    assert "explanation" in result or "recommendations" in result
+    assert result["status"] == "ok"
+    assert result["mode"] == "friendly"
+    assert result["proposed_text"]
+    assert result["x_schema_version"] == SCHEMA_VERSION

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ httpx
 SQLAlchemy>=2.0,<3
 numpy>=1.26
 cryptography>=42
+requests>=2.31


### PR DESCRIPTION
## Summary
- refactor llm provider package to export legacy classes and new draft helpers
- lazy-load Azure provider dependencies and add requests requirement
- wire `/api/gpt-draft` to shared provider with schema version handling and updated tests

## Testing
- `pip install -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d57a845c8325b2f9bc3fc2b15758