### PR TITLE
Ensure draft API constant and safer text handling

### DIFF
--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -5,6 +5,7 @@ type Status = "ok" | "warn" | "fail";
 
 const DEFAULT_BACKEND = "http://127.0.0.1:9000";
 const LS_KEY = "contract_ai_backend";
+const DRAFT_PATH = "/api/gpt-draft";
 
 function getBackend(): string {
   try {
@@ -128,7 +129,7 @@ const DraftAssistantPanel: React.FC = () => {
     setLoadingDraft(true);
     setError(null);
     try {
-      const env = await postJSON<DraftEnvelope>("/api/gpt/draft", {
+      const env = await postJSON<DraftEnvelope>(DRAFT_PATH, {
         analysis,
         mode: "friendly",
       });

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -250,13 +250,34 @@
       setJSON("resp", r.body);
       return r;
     }
-  async function testAnalyze(){
+    async function getTextOrWord(){
+      const area = document.getElementById("testText");
+      let t = (area.value || "").trim();
+      if(t) return t;
+      if(window.Word && Word.run){
+        try{
+          return await Word.run(async ctx => {
+            const sel = ctx.document.getSelection(); sel.load("text");
+            await ctx.sync();
+            if(sel.text && sel.text.trim()) return sel.text;
+            const body = ctx.document.body; body.load("text");
+            await ctx.sync();
+            return body.text || "";
+          });
+        }catch{}
+      }
+      return "";
+    }
+
+    async function testAnalyze(){
+      const text = await getTextOrWord();
+      if(!text){ alert("Select text or click 'Use whole doc'"); return; }
       const r = await callEndpoint({
         name:"analyze", method:"POST", path:"/api/analyze",
-        body:{ text: document.getElementById("testText").value }
+        body:{ text }
       });
       setStatusRow("row-analyze", r);
-      setJSON("resp", r.body);
+      alert(r.ok ? `HTTP ${r.code}` : `HTTP ${r.code}`);
       return r;
     }
     async function testSummary(){
@@ -310,21 +331,25 @@
       return r;
     }
     async function testSuggest(){
+      const text = await getTextOrWord();
+      if(!text){ alert("Select text or click 'Use whole doc'"); return; }
       const r = await callEndpoint({
         name:"suggest", method:"POST", path:"/api/suggest_edits",
-        body:{ text:"Payment within 30 days.", clause:"Payment within 30 days.", mode:"friendly" }
+        body:{ text, clause:text, mode:"friendly" }
       });
       setStatusRow("row-suggest", r);
-      setJSON("resp", r.body);
+      alert(r.ok ? `HTTP ${r.code}` : `HTTP ${r.code}`);
       return r;
     }
     async function testQA(){
+      const text = await getTextOrWord();
+      if(!text){ alert("Select text or click 'Use whole doc'"); return; }
       const r = await callEndpoint({
         name:"qa", method:"POST", path:"/api/qa-recheck",
-        body:{ text:"Hello world", applied_changes:[{ range:{ start:6, length:5 }, text:"TEAM" }] }
+        body:{ text, applied_changes:[] }
       });
       setStatusRow("row-qa", r);
-      setJSON("resp", r.body);
+      alert(r.ok ? `HTTP ${r.code}` : `HTTP ${r.code}`);
       return r;
     }
     async function testCalloff(){


### PR DESCRIPTION
## Summary
- centralize GPT draft API path via `DRAFT_PATH` constant and use it in React draft panel
- add `/api/gpt/draft` backend alias to proxy new `/api/gpt-draft`
- make Word add-in always send non-empty text, add toast messages, and load diff via draft API
- update self-test panel to auto-read Word text and show compact alerts

## Testing
- `pre-commit run --files contract_review_app/frontend/draft_panel/index.tsx contract_review_app/api/app.py word_addin_dev/taskpane.bundle.js word_addin_dev/panel_selftest.html`
- `pytest` *(fails: ModuleNotFoundError and other dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f7a85a6c8325830081def1fca2f0