### PR TITLE
feat: simplify analyze API and panel wiring

### DIFF
--- a/word_addin_dev/manifest.xml
+++ b/word_addin_dev/manifest.xml
@@ -7,7 +7,7 @@
   xsi:schemaLocation="http://schemas.microsoft.com/office/appforoffice/1.1 https://appsforoffice.microsoft.com/lib/1.1/hosted/officeAppManifestv1_1.xsd">
 
   <Id>8f6f3c9e-8a7c-4d3e-9f6a-000000000001</Id>
-  <Version>1.0.2025.0825</Version>
+  <Version>1.0.2025.0902</Version>
   <ProviderName>Contract AI</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Contract AI — Draft Assistant (Dev)"/>

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -132,6 +132,13 @@
     let clientCid = genCid();
     let lastCid = ""; // from response headers
 
+    function showMeta(meta){
+      const prov = document.getElementById("llmProv");
+      const model = document.getElementById("llmModel");
+      prov.textContent = (meta && meta.provider) || "—";
+      model.textContent = (meta && meta.model) || "—";
+    }
+
     function pickDocType(summary) {
       summary = summary || {};
       let list = [];
@@ -266,25 +273,23 @@
       return r;
     }
     function getSampleText(){
-      const area = document.getElementById("testText");
-      return (area.value || "").trim() || SAMPLE;
+      return SAMPLE;
     }
 
     async function testAnalyze(){
-      const text = getSampleText();
       const r = await callEndpoint({
         name:"analyze", method:"POST", path:"/api/analyze",
-        body:{ text }
+        body:{ text: SAMPLE }
       });
       setStatusRow("row-analyze", r);
       showResp(r);
+      showMeta(r.body && r.body.meta || {});
       return r;
     }
     async function testSummary(){
-      const text = getSampleText();
       const r = await callEndpoint({
         name:"summary", method:"POST", path:"/api/summary",
-        body:{ text }
+        body:{ text: SAMPLE }
       });
       setStatusRow("row-summary", r);
       if(!r.ok || (r.body && r.body.status !== "ok")){
@@ -321,43 +326,37 @@
     }
 
     async function testDraft(){
-      const text = getSampleText();
       const r = await callEndpoint({
         name:"draft", method:"POST", path:DRAFT_PATH,
-        body:{ text }
+        body:{ text: SAMPLE }
       });
       const ok = r.ok && r.body && r.body.status === "ok";
       setStatusRow("row-draft", Object.assign({}, r, { ok: !!ok }));
       showResp(r);
-      const meta = r.body && r.body.meta ? r.body.meta : {};
-      document.getElementById("llmProv").textContent = meta.provider || "—";
-      document.getElementById("llmModel").textContent = meta.model || "—";
-      document.getElementById("llmMode").textContent = meta.mode || "—";
+      showMeta(r.body && r.body.meta || {});
       const badge = document.getElementById("llmBadge");
+      const meta = r.body && r.body.meta ? r.body.meta : {};
       if (meta.mode === "mock") { badge.style.display = "inline-block"; } else { badge.style.display = "none"; }
       return r;
     }
     async function testSuggest(){
-      const text = getSampleText();
       const r = await callEndpoint({
         name:"suggest", method:"POST", path:"/api/suggest_edits",
-        body:{ text }
+        body:{ text: SAMPLE }
       });
       setStatusRow("row-suggest", r);
       showResp(r);
-      const meta = r.body && r.body.meta ? r.body.meta : {};
-      document.getElementById("llmProv").textContent = meta.provider || "—";
-      document.getElementById("llmModel").textContent = meta.model || "—";
+      showMeta(r.body && r.body.meta || {});
       return r;
     }
     async function testQA(){
-      const text = getSampleText();
       const r = await callEndpoint({
         name:"qa", method:"POST", path:"/api/qa-recheck",
-        body:{ text, applied_changes:[] }
+        body:{ text: SAMPLE, applied_changes:[] }
       });
       setStatusRow("row-qa", r);
       showResp(r);
+      showMeta(r.body && r.body.meta || {});
       return r;
     }
     async function testCalloff(){


### PR DESCRIPTION
## Summary
- simplify `/api/analyze` to accept multiple alias keys and enforce SSOT payload
- serve taskpane assets with no-cache headers and bump panel manifest version
- harden taskpane client: fetch-based calls, selection fallbacks, and build metadata
- update panel self-test to use constant sample text and display LLM meta

## Testing
- `pre-commit run --files contract_review_app/api/app.py word_addin_dev/manifest.xml word_addin_dev/taskpane.bundle.js word_addin_dev/panel_selftest.html`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b6866d812083259f49645a23327c02