### PR TITLE
feat: add LLM ping endpoint and slow test marker

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -390,6 +390,20 @@ PROVIDER_META = {
 }
 
 
+@app.get("/api/llm/ping")
+def llm_ping():
+    try:
+        res = PROVIDER.ping()
+        out = {
+            "status": "ok",
+            "meta": PROVIDER_META,
+            "latency_ms": res.get("latency_ms", 0),
+        }
+    except Exception as e:  # pragma: no cover - network issues
+        out = {"status": "error", "detail": str(e), "meta": PROVIDER_META}
+    return out
+
+
 class AnalyzeRequest(BaseModel):
     text: Optional[str] = None
     clause: Optional[str] = None

--- a/contract_review_app/llm/provider.py
+++ b/contract_review_app/llm/provider.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
-import os, requests
+
+import os
+import requests
 from typing import Dict, Any
 
+
 class ProviderError(RuntimeError): ...
+
 
 class MockProvider:
     name = "mock"
     model = "mock"
+
     def draft(self, prompt: str) -> Dict[str, Any]:
         return {"text": f"[MOCK DRAFT]\n{prompt}"}
+
     def suggest(self, text: str) -> Dict[str, Any]:
         # trivial, deterministic
-        return {"proposed_text": text.replace("Confidential", "Confidential (as defined)")}
+        return {
+            "proposed_text": text.replace("Confidential", "Confidential (as defined)")
+        }
+
+    def ping(self):
+        return {"ok": True}
+
 
 class AzureProvider:
     def __init__(self):
@@ -28,13 +40,23 @@ class AzureProvider:
         self.name = "azure"
         self.model = dep
 
-    def _chat(self, messages: list[dict], temperature: float = 0.0, max_tokens: int = 1024):
+    def _chat(
+        self,
+        messages: list[dict],
+        temperature: float = 0.0,
+        max_tokens: int = 1024,
+        timeout: int = 30,
+    ):
         url = f"{self.endpoint}/openai/deployments/{self.deployment}/chat/completions"
         r = requests.post(
             f"{url}?api-version={self.api_version}",
             headers={"api-key": self.key, "Content-Type": "application/json"},
-            json={"messages": messages, "temperature": temperature, "max_tokens": max_tokens},
-            timeout=30,
+            json={
+                "messages": messages,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            },
+            timeout=timeout,
         )
         if not r.ok:
             raise ProviderError(f"Azure HTTP {r.status_code}: {r.text[:300]}")
@@ -42,15 +64,40 @@ class AzureProvider:
         return data["choices"][0]["message"]["content"]
 
     def draft(self, prompt: str) -> Dict[str, Any]:
-        out = self._chat([{"role": "user", "content": f"Draft a concise clause revision:\n{prompt}"}])
+        out = self._chat(
+            [{"role": "user", "content": f"Draft a concise clause revision:\n{prompt}"}]
+        )
         return {"text": out}
 
     def suggest(self, text: str) -> Dict[str, Any]:
-        out = self._chat([
-            {"role": "system", "content": "You are a contract drafting assistant. Return only the revised clause."},
-            {"role": "user", "content": f"Revise the following for clarity and compliance, keep structure:\n{text}"}
-        ])
+        out = self._chat(
+            [
+                {
+                    "role": "system",
+                    "content": "You are a contract drafting assistant. Return only the revised clause.",
+                },
+                {
+                    "role": "user",
+                    "content": f"Revise the following for clarity and compliance, keep structure:\n{text}",
+                },
+            ]
+        )
         return {"proposed_text": out}
+
+    def ping(self):
+        # minimal 1-token chat; 5s timeout
+        import time
+
+        t0 = time.perf_counter()
+        _ = self._chat(
+            [{"role": "user", "content": "Reply with: pong"}],
+            temperature=0.0,
+            max_tokens=1,
+            timeout=5,
+        )
+        dt = int((time.perf_counter() - t0) * 1000)
+        return {"ok": True, "latency_ms": dt}
+
 
 def get_provider():
     # explicit selector; env var wins

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths = contract_review_app/tests tests
 addopts = -m "not slow"
+markers =
+    slow: long-running e2e tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ numpy>=1.26
 cryptography>=42
 requests
 python-dotenv==1.0.1
+pytest-xdist==3.6.1

--- a/serve_https_panel.py
+++ b/serve_https_panel.py
@@ -5,7 +5,6 @@ import argparse
 import os
 import sys
 import ssl
-import socket
 import signal
 import datetime
 import mimetypes
@@ -35,6 +34,7 @@ def _ensure_cryptography() -> None:
     """
     try:
         import cryptography  # noqa: F401
+
         return
     except Exception:
         pass
@@ -47,7 +47,10 @@ def _ensure_cryptography() -> None:
         )
     except Exception as e:
         print(f"failed to install cryptography: {e}", file=sys.stderr)
-        print("please install with: python -m pip install 'cryptography>=42'", file=sys.stderr)
+        print(
+            "please install with: python -m pip install 'cryptography>=42'",
+            file=sys.stderr,
+        )
         sys.exit(3)
 
     # Retry import
@@ -58,7 +61,9 @@ def _ensure_cryptography() -> None:
         sys.exit(3)
 
 
-def _generate_self_signed(cert_path: Path, key_path: Path, hostnames: list[str]) -> None:
+def _generate_self_signed(
+    cert_path: Path, key_path: Path, hostnames: list[str]
+) -> None:
     """
     Generate a self-signed certificate using cryptography.
     Auto-installs cryptography if missing.
@@ -80,16 +85,20 @@ def _generate_self_signed(cert_path: Path, key_path: Path, hostnames: list[str])
             x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "England"),
             x509.NameAttribute(NameOID.LOCALITY_NAME, "London"),
             x509.NameAttribute(NameOID.ORGANIZATION_NAME, "ContractAI"),
-            x509.NameAttribute(NameOID.COMMON_NAME, hostnames[0] if hostnames else "localhost"),
+            x509.NameAttribute(
+                NameOID.COMMON_NAME, hostnames[0] if hostnames else "localhost"
+            ),
         ]
     )
 
     # Subject Alternative Names for localhost development (with proper IPAddress entries)
-    sans = x509.SubjectAlternativeName([
-        x509.DNSName("localhost"),
-        x509.IPAddress(IPv4Address("127.0.0.1")),
-        x509.IPAddress(IPv6Address("::1")),
-    ])
+    sans = x509.SubjectAlternativeName(
+        [
+            x509.DNSName("localhost"),
+            x509.IPAddress(IPv4Address("127.0.0.1")),
+            x509.IPAddress(IPv6Address("::1")),
+        ]
+    )
 
     now = datetime.datetime.utcnow()
     cert = (
@@ -151,9 +160,7 @@ def _try_trust_windows_root(cert_path: Path) -> None:
             print(f"auto-trust: {msg}", file=sys.stderr)
         else:
             # Non-zero: print hint, do not terminate
-            hint = (
-                "auto-trust failed; you may need to trust the certificate manually or continue and accept the TLS warning in the browser."
-            )
+            hint = "auto-trust failed; you may need to trust the certificate manually or continue and accept the TLS warning in the browser."
             print(
                 f"auto-trust warning (exit={proc.returncode}): {hint}\nstdout: {proc.stdout}\nstderr: {proc.stderr}",
                 file=sys.stderr,
@@ -239,7 +246,10 @@ class NoCacheHandler(SimpleHTTPRequestHandler):
     def do_GET(self):
         # Log full Request-URL for debugging
         try:
-            host = self.headers.get("Host") or f"{self.server.server_address[0]}:{self.server.server_address[1]}"
+            host = (
+                self.headers.get("Host")
+                or f"{self.server.server_address[0]}:{self.server.server_address[1]}"
+            )
             sys.stderr.write(f"[REQ] https://{host}{self.path}\n")
             sys.stderr.flush()
         except Exception:
@@ -253,9 +263,7 @@ def _build_ssl_context(cert_file: Path, key_file: Path) -> ssl.SSLContext:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     try:
-        ctx.set_ciphers(
-            "ECDHE+AESGCM:ECDHE+CHACHA20:RSA+AESGCM:!aNULL:!MD5:!DSS"
-        )
+        ctx.set_ciphers("ECDHE+AESGCM:ECDHE+CHACHA20:RSA+AESGCM:!aNULL:!MD5:!DSS")
     except Exception:
         # use defaults if cipher set fails on older OpenSSL
         pass
@@ -273,7 +281,11 @@ def _bind_https_server(host: str, port: int, handler_cls, ssl_ctx: ssl.SSLContex
     except OSError as e:
         # Port busy or permission denied
         msg = str(e).lower()
-        if "address already in use" in msg or "permission denied" in msg or getattr(e, "winerror", None) in (10013, 10048):
+        if (
+            "address already in use" in msg
+            or "permission denied" in msg
+            or getattr(e, "winerror", None) in (10013, 10048)
+        ):
             print(f"port {port} busy", file=sys.stderr)
             sys.exit(2)
         raise
@@ -284,14 +296,36 @@ def _bind_https_server(host: str, port: int, handler_cls, ssl_ctx: ssl.SSLContex
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="HTTPS static server for Office Taskpane panel (dev)")
-    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default 127.0.0.1)")
-    parser.add_argument("--port", type=int, default=3000, help="Bind port (default 3000)")
+    parser = argparse.ArgumentParser(
+        description="HTTPS static server for Office Taskpane panel (dev)"
+    )
+    parser.add_argument(
+        "--host", default="127.0.0.1", help="Bind host (default 127.0.0.1)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=3000, help="Bind port (default 3000)"
+    )
     default_root = Path(__file__).resolve().parent / "word_addin_dev"
-    parser.add_argument("--root", default=str(default_root), help="Static root (default: word_addin_dev)")
-    parser.add_argument("--cert", default=str(default_root / "certs" / "panel-cert.pem"), help="Path to certificate PEM")
-    parser.add_argument("--key", default=str(default_root / "certs" / "panel-key.pem"), help="Path to private key PEM")
-    parser.add_argument("--regen-cert", action="store_true", help="Force regenerate self-signed certificate")
+    parser.add_argument(
+        "--root",
+        default=str(default_root),
+        help="Static root (default: word_addin_dev)",
+    )
+    parser.add_argument(
+        "--cert",
+        default=str(default_root / "certs" / "panel-cert.pem"),
+        help="Path to certificate PEM",
+    )
+    parser.add_argument(
+        "--key",
+        default=str(default_root / "certs" / "panel-key.pem"),
+        help="Path to private key PEM",
+    )
+    parser.add_argument(
+        "--regen-cert",
+        action="store_true",
+        help="Force regenerate self-signed certificate",
+    )
     args = parser.parse_args(argv)
 
     host = args.host
@@ -318,7 +352,10 @@ def main(argv=None):
         ssl_ctx = _build_ssl_context(cert_path, key_path)
     except Exception as e:
         if not args.regen_cert:
-            print(f"certificate or key invalid. Run with --regen-cert to recreate. Details: {e}", file=sys.stderr)
+            print(
+                f"certificate or key invalid. Run with --regen-cert to recreate. Details: {e}",
+                file=sys.stderr,
+            )
         else:
             print(f"failed to load regenerated certificate/key: {e}", file=sys.stderr)
         sys.exit(1)
@@ -333,7 +370,10 @@ def main(argv=None):
         raise
     except Exception as e:
         msg = str(e).lower()
-        if "address already in use" in msg or getattr(e, "winerror", None) in (10013, 10048):
+        if "address already in use" in msg or getattr(e, "winerror", None) in (
+            10013,
+            10048,
+        ):
             print(f"port {port} busy", file=sys.stderr)
             sys.exit(2)
         print(f"failed to bind HTTPS server: {e}", file=sys.stderr)

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -50,6 +50,7 @@
     <input id="backendInput" type="text" value="https://127.0.0.1:9443" class="mono" />
     <button id="saveBtn">Save</button>
     <button id="runAllBtn">Run All</button>
+    <button id="pingBtn">Ping LLM</button>
     <span class="small">Saved in localStorage</span>
   </div>
 
@@ -57,7 +58,7 @@
     <textarea id="testText" placeholder="Sample text" style="flex:1; min-height:60px;">Governing law: England and Wales.</textarea>
   </div>
 
-  <div class="row" id="llmInfo">LLM: <span id="llmProv">—</span> / <span id="llmModel">—</span> / <span id="llmMode">—</span> <span id="llmBadge" class="badge" style="display:none;background:#facc15;color:#000;">MOCK</span></div>
+  <div class="row" id="llmInfo">LLM: <span id="llmProv">—</span> / <span id="llmModel">—</span> / <span id="llmLatency">—</span> <span id="llmBadge" class="badge" style="display:none;background:#facc15;color:#000;">MOCK</span></div>
 
     <div class="card">
       <h3>Tests</h3>
@@ -137,6 +138,8 @@
       const model = document.getElementById("llmModel");
       prov.textContent = (meta && meta.provider) || "—";
       model.textContent = (meta && meta.model) || "—";
+      const badge = document.getElementById("llmBadge");
+      if (badge) badge.style.display = (meta && meta.mode === "mock") ? "inline-block" : "none";
     }
 
     function pickDocType(summary) {
@@ -263,6 +266,25 @@
         xcid: hdrCid, xcache: hdrCache, xschema: hdrSchema, latencyMs, ok,
         error_code, detail
       };
+    }
+
+    async function pingLLM(){
+      const base = normBase(document.getElementById("backendInput").value);
+      const latEl = document.getElementById("llmLatency");
+      if (!base) { alert("Please enter backend URL"); return; }
+      latEl.textContent = "…";
+      latEl.className = "";
+      try{
+        const resp = await fetch(base + "/api/llm/ping");
+        const data = await resp.json();
+        showMeta(data.meta || {});
+        const ms = (data.latency_ms != null) ? data.latency_ms : 0;
+        latEl.textContent = ms + "ms";
+        latEl.className = (resp.ok && data.status === "ok") ? "ok" : "err";
+      }catch(e){
+        latEl.textContent = "ERR";
+        latEl.className = "err";
+      }
     }
 
     // ---------------------- individual tests ----------------------
@@ -410,6 +432,7 @@
     // ---------------------- init & events ----------------------
     document.getElementById("saveBtn").addEventListener("click", () => { saveBase(); alert("Saved"); });
     document.getElementById("runAllBtn").addEventListener("click", runAll);
+    document.getElementById("pingBtn").addEventListener("click", pingLLM);
     document.getElementById("btnHealth").addEventListener("click", testHealth);
     document.getElementById("btnAnalyze").addEventListener("click", testAnalyze);
     document.getElementById("btnDraft").addEventListener("click", testDraft);

--- a/word_addin_dev/taskpane.bundle.js
+++ b/word_addin_dev/taskpane.bundle.js
@@ -271,6 +271,23 @@
     }
   }
 
+  async function pingLLM() {
+    try {
+      var r = await callEndpoint({ method: "GET", path: "/api/llm/ping", timeoutMs: 8000 });
+      var meta = (r.body && r.body.meta) || {};
+      applyMeta(meta);
+      if (r.ok && r.body && r.body.status === "ok") {
+        toast("LLM: " + (meta.provider || "?") + "/" + (meta.model || "?") + " " + r.body.latency_ms + " ms");
+      } else {
+        toast("LLM ping error");
+      }
+      return r;
+    } catch (e) {
+      toast("LLM ping error");
+      return {};
+    }
+  }
+
   async function apiAnalyze(opts) {
     opts = opts || {};
     var text = opts.text || "";
@@ -856,6 +873,7 @@
   async function doHealthFlow() {
     txt(els.connBadge, "Conn: …");
     var r = await doHealth();
+    await pingLLM();
     // Badges are applied by callEndpoint; just echo status result here
     return r;
   }


### PR DESCRIPTION
## Summary
- register pytest `slow` marker and include pytest-xdist for optional parallelism
- add LLM provider `ping` methods and expose `/api/llm/ping`
- wire Ping LLM button in self-test panel and taskpane bundle

## Testing
- `pre-commit run --files contract_review_app/api/app.py contract_review_app/llm/provider.py pytest.ini requirements-dev.txt serve_https_panel.py word_addin_dev/panel_selftest.html word_addin_dev/taskpane.bundle.js`
- `pytest -q -m "not slow"` *(fails: 26 errors during collection)*
- `pytest -q -n auto -m "not slow"` *(fails: 26 errors during collection; 231 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b69b71626883259085bf34cd603246