### PR TITLE
Add safe click binding and URL join helper

### DIFF
--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+def test_health_ok():
+    r = client.get("/health")
+    assert r.status_code == 200
+    r2 = client.get("/api/health")
+    assert r2.status_code == 200
+
+def test_llm_ping_ok():
+    r = client.get("/api/llm/ping")
+    assert r.status_code == 200
+    r2 = client.get("/llm/ping")
+    assert r2.status_code == 200
+
+def test_analyze_ok():
+    payload = {"text": "Hello world"}
+    r = client.post("/api/analyze", json=payload)
+    assert r.status_code == 200
+    r2 = client.post("/analyze", json=payload)
+    assert r2.status_code == 200
+
+def test_suggest_ok():
+    payload = {"text": "Hello world"}
+    r = client.post("/api/suggest_edits", json=payload)
+    assert r.status_code == 200
+    r2 = client.post("/suggest_edits", json=payload)
+    assert r2.status_code == 200
+
+def test_gpt_draft_ok():
+    payload = {"prompt": "Draft confidentiality clause"}
+    r = client.post("/api/gpt-draft", json=payload)
+    assert r.status_code == 200
+    r2 = client.post("/gpt-draft", json=payload)
+    assert r2.status_code == 200
+    r3 = client.post("/api/gpt_draft", json=payload)  # underscore alias
+    assert r3.status_code == 200

--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -17,10 +17,16 @@ async function callApi(endpoint: string) {
   }
 }
 
-(document.getElementById('btnAnalyze') as HTMLButtonElement).onclick = () => callApi('/api/analyze');
-(document.getElementById('btnSummary') as HTMLButtonElement).onclick = () => callApi('/api/summary');
-(document.getElementById('btnSuggest') as HTMLButtonElement).onclick = () => callApi('/api/suggest_edits');
-(document.getElementById('btnQA') as HTMLButtonElement).onclick = () => callApi('/api/qa-recheck');
+function onClick(id: string, handler: (ev: MouseEvent) => any) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.addEventListener('click', handler);
+}
+
+onClick('btnAnalyze', () => callApi('/api/analyze'));
+onClick('btnSummary', () => callApi('/api/summary'));
+onClick('btnSuggest', () => callApi('/api/suggest_edits'));
+onClick('btnQA', () => callApi('/api/qa-recheck'));
 
 async function pingHealth() {
   const badge = document.getElementById('health');

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -183,6 +183,11 @@
       s = s.replace(/^http:\/\/(127\.0\.0\.1|localhost)(:9443)(\/|$)/, "https://$1$2$3");
       return s.replace(/\/+$/, "");
     }
+    function joinUrl(base, path){
+      if (!base) throw new Error("backend base URL is empty");
+      if (!path.startsWith("/")) path = "/" + path;
+      return base.replace(/\/+$/, "") + path;
+    }
     function saveBase(){ try{ localStorage.setItem(LS_KEY, document.getElementById("backendInput").value.trim()); }catch{} }
     function loadBase(){
       let v = localStorage.getItem(LS_KEY) || document.getElementById("backendInput").value || "https://127.0.0.1:9443";
@@ -230,10 +235,16 @@
       setJSON("resp", r.body);
     }
 
+    function onClick(id, handler){
+      var el = document.getElementById(id);
+      if (!el) return;
+      el.addEventListener('click', handler);
+    }
+
     async function callEndpoint({name, method, path, body, dynamicPathFn}) {
       const base = normBase(document.getElementById("backendInput").value);
       if (!base) { alert("Please enter backend URL"); return { error:true }; }
-      const url = base + (dynamicPathFn ? dynamicPathFn() : path);
+      const url = joinUrl(base, dynamicPathFn ? dynamicPathFn() : path);
       const headers = { "content-type": "application/json", "x-cid": clientCid, "x-schema-version": "1.3" };
       const t0 = performance.now();
       let resp, json;
@@ -430,17 +441,17 @@
     }
 
     // ---------------------- init & events ----------------------
-    document.getElementById("saveBtn").addEventListener("click", () => { saveBase(); alert("Saved"); });
-    document.getElementById("runAllBtn").addEventListener("click", runAll);
-    document.getElementById("pingBtn").addEventListener("click", pingLLM);
-    document.getElementById("btnHealth").addEventListener("click", testHealth);
-    document.getElementById("btnAnalyze").addEventListener("click", testAnalyze);
-    document.getElementById("btnDraft").addEventListener("click", testDraft);
-    document.getElementById("btnSummary").addEventListener("click", testSummary);
-    document.getElementById("btnSuggest").addEventListener("click", testSuggest);
-    document.getElementById("btnQA").addEventListener("click", testQA);
-    document.getElementById("btnCalloff").addEventListener("click", testCalloff);
-    document.getElementById("btnTrace").addEventListener("click", testTrace);
+    onClick("saveBtn", () => { saveBase(); alert("Saved"); });
+    onClick("runAllBtn", runAll);
+    onClick("pingBtn", pingLLM);
+    onClick("btnHealth", testHealth);
+    onClick("btnAnalyze", testAnalyze);
+    onClick("btnDraft", testDraft);
+    onClick("btnSummary", testSummary);
+    onClick("btnSuggest", testSuggest);
+    onClick("btnQA", testQA);
+    onClick("btnCalloff", testCalloff);
+    onClick("btnTrace", testTrace);
 
     // Load defaults on first paint
     window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- Avoid `null` errors in panel scripts with new `onClick` helper
- Normalize backend paths using a `joinUrl` utility
- Add smoke tests covering core API routes

## Testing
- `pytest -q tests/test_routes_smoke.py -c pytest_smoke.ini`


------
https://chatgpt.com/codex/tasks/task_e_68b6e87a946083258b1aba4b9e01005b