### PR TITLE
feat: allow https dev add-in on localhost and 127

### DIFF
--- a/manifest_head.txt
+++ b/manifest_head.txt
@@ -19,9 +19,9 @@
   <SupportUrl DefaultValue="https://localhost:3000/help.html"/>
   <AppDomains>
     <AppDomain>https://localhost:3000</AppDomain>
-    <AppDomain>https://localhost:3000</AppDomain>
+    <AppDomain>https://127.0.0.1:3000</AppDomain>
     <AppDomain>https://localhost:9443</AppDomain>
-    <AppDomain>https://localhost:9443</AppDomain>
+    <AppDomain>https://127.0.0.1:9443</AppDomain>
   </AppDomains>
 
   <Hosts>

--- a/word_addin_dev/manifest.xml
+++ b/word_addin_dev/manifest.xml
@@ -19,9 +19,9 @@
   <SupportUrl DefaultValue="https://localhost:3000/help.html"/>
   <AppDomains>
     <AppDomain>https://localhost:3000</AppDomain>
-    <AppDomain>https://localhost:3000</AppDomain>
+    <AppDomain>https://127.0.0.1:3000</AppDomain>
     <AppDomain>https://localhost:9443</AppDomain>
-    <AppDomain>https://localhost:9443</AppDomain>
+    <AppDomain>https://127.0.0.1:9443</AppDomain>
   </AppDomains>
 
   <Hosts>


### PR DESCRIPTION
## Summary
- allow taskpane dev manifest to trust localhost and 127.0.0.1 over HTTPS
- keep default source location on https for taskpane

## Testing
- `pre-commit run --files manifest_head.txt word_addin_dev/manifest.xml`
- `pytest contract_review_app/tests/panel/test_panel_urls.py tests/codex/test_doctor_addin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f3fa53bc8325954f9141effef648