### PR TITLE
test: ensure package visible for pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = .
 testpaths = contract_review_app/tests tests
 addopts = -m "not slow"
 markers =

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -1,12 +1,8 @@
-import os
-import sys
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
 
 client = TestClient(app)
+
 
 def test_health_ok():
     r = client.get("/health")
@@ -14,11 +10,13 @@ def test_health_ok():
     r2 = client.get("/api/health")
     assert r2.status_code == 200
 
+
 def test_llm_ping_ok():
     r = client.get("/api/llm/ping")
     assert r.status_code == 200
     r2 = client.get("/llm/ping")
     assert r2.status_code == 200
+
 
 def test_analyze_ok():
     payload = {"text": "Hello world"}
@@ -27,12 +25,14 @@ def test_analyze_ok():
     r2 = client.post("/analyze", json=payload)
     assert r2.status_code == 200
 
+
 def test_suggest_ok():
     payload = {"text": "Hello world"}
     r = client.post("/api/suggest_edits", json=payload)
     assert r.status_code == 200
     r2 = client.post("/suggest_edits", json=payload)
     assert r2.status_code == 200
+
 
 def test_gpt_draft_ok():
     payload = {"prompt": "Draft confidentiality clause"}


### PR DESCRIPTION
## Summary
- configure pytest to add repository root to Python path
- clean up route smoke test and rely on standard imports

## Testing
- `python -m pytest -q tests/test_routes_smoke.py --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68b6f4e605788325a777f9e8b2793b53