### PR TITLE
feat: unify llm config and profile fallback

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -274,3 +274,31 @@ Example response:
   "meta": {"provider": "mock", "model": "mock"}
 }
 ```
+
+## ENV matrix
+
+The Azure client now reads configuration from multiple environment variables. The
+following matrix shows the accepted names:
+
+| Setting   | Variables (priority order)                                  |
+|-----------|-------------------------------------------------------------|
+| endpoint  | `AZURE_OPENAI_ENDPOINT`                                     |
+| version   | `AZURE_OPENAI_API_VERSION`                                  |
+| deployment| `AZURE_OPENAI_DEPLOYMENT`                                   |
+| API key   | `AZURE_OPENAI_KEY` → `AZURE_OPENAI_API_KEY` → `OPENAI_API_KEY` |
+
+### curl examples
+
+```bash
+curl -s -X POST localhost:8000/api/gpt-draft \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"Example clause.","profile":"smart"}'
+
+curl -s -X POST localhost:8000/api/suggest_edits \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Confidential info"}'
+
+curl -s -X POST localhost:8000/api/qa-recheck \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Hello"}'
+```

--- a/contract_review_app/core/schemas.py
+++ b/contract_review_app/core/schemas.py
@@ -990,6 +990,7 @@ class DraftIn(AppBaseModel):
     mode: DraftMode = "friendly"
     jurisdiction: Optional[str] = None
     constraints: Optional[Dict[str, Any]] = None
+    profile: Optional[Literal["smart", "vanilla"]] = None
 
     @model_validator(mode="after")
     def _require_text_or_analysis(self):
@@ -1089,6 +1090,7 @@ class SuggestIn(AppBaseModel):
     text: str
     mode: DraftMode = "friendly"
     top_k: int = Field(default=3, ge=1, le=10)
+    profile: Optional[Literal["smart", "vanilla"]] = None
 
     @model_validator(mode="after")
     def _validate_requirements(self):
@@ -1146,6 +1148,7 @@ class QARecheckIn(AppBaseModel):
     document_name: Optional[str] = None
     text: str
     applied_changes: List[TextPatch] = Field(default_factory=list)
+    profile: Optional[Literal["smart", "vanilla"]] = None
 
     @model_validator(mode="after")
     def _validate_text(self):

--- a/contract_review_app/gpt/clients/azure_client.py
+++ b/contract_review_app/gpt/clients/azure_client.py
@@ -29,7 +29,7 @@ class AzureClient(BaseClient):
         self._api_key = cfg.azure_api_key or ""
         self._endpoint = (cfg.azure_endpoint or "").rstrip("/")
         self._deployment = cfg.azure_deployment or self.model
-        self._api_version = "2024-02-15"
+        self._api_version = cfg.azure_api_version or "2024-02-15"
 
     def _post(self, payload: dict, timeout: float) -> dict:
         url = f"{self._endpoint}/openai/deployments/{self._deployment}/chat/completions?api-version={self._api_version}"
@@ -44,7 +44,9 @@ class AzureClient(BaseClient):
             raise ProviderConfigError(self.provider, r.text)
         return r.json()
 
-    def draft(self, prompt: str, max_tokens: int, temperature: float, timeout: float) -> DraftResult:
+    def draft(
+        self, prompt: str, max_tokens: int, temperature: float, timeout: float
+    ) -> DraftResult:
         data = self._post(
             {
                 "model": self.model,
@@ -56,18 +58,48 @@ class AzureClient(BaseClient):
         )
         text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
         usage = data.get("usage") or {}
-        return DraftResult(text=text, meta={"provider": self.provider, "model": self.model, "mode": self.mode, "usage": usage})
+        return DraftResult(
+            text=text,
+            meta={
+                "provider": self.provider,
+                "model": self.model,
+                "mode": self.mode,
+                "usage": usage,
+            },
+        )
 
     def suggest_edits(self, prompt: str, timeout: float) -> SuggestResult:
-        data = self._post({"model": self.model, "messages": [{"role": "user", "content": prompt}]}, timeout)
+        data = self._post(
+            {"model": self.model, "messages": [{"role": "user", "content": prompt}]},
+            timeout,
+        )
         text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
         usage = data.get("usage") or {}
         items = [{"text": text}]
-        return SuggestResult(items=items, meta={"provider": self.provider, "model": self.model, "mode": self.mode, "usage": usage})
+        return SuggestResult(
+            items=items,
+            meta={
+                "provider": self.provider,
+                "model": self.model,
+                "mode": self.mode,
+                "usage": usage,
+            },
+        )
 
     def qa_recheck(self, prompt: str, timeout: float) -> QAResult:
-        data = self._post({"model": self.model, "messages": [{"role": "user", "content": prompt}]}, timeout)
+        data = self._post(
+            {"model": self.model, "messages": [{"role": "user", "content": prompt}]},
+            timeout,
+        )
         text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
         usage = data.get("usage") or {}
         items = [text]
-        return QAResult(items=items, meta={"provider": self.provider, "model": self.model, "mode": self.mode, "usage": usage})
+        return QAResult(
+            items=items,
+            meta={
+                "provider": self.provider,
+                "model": self.model,
+                "mode": self.mode,
+                "usage": usage,
+            },
+        )

--- a/tests/api/test_llm_endpoints_integration.py
+++ b/tests/api/test_llm_endpoints_integration.py
@@ -1,0 +1,36 @@
+import importlib
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _reload_app():
+    modules = [
+        "contract_review_app.api",
+        "contract_review_app.api.app",
+    ]
+    for m in modules:
+        sys.modules.pop(m, None)
+    os.environ["AI_PROVIDER"] = "mock"
+    from contract_review_app.api import app as app_module
+
+    importlib.reload(app_module)
+    return TestClient(app_module.app), modules
+
+
+@pytest.fixture()
+def client():
+    client, modules = _reload_app()
+    try:
+        yield client
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+def test_endpoints_ok(client):
+    assert client.post("/api/gpt-draft", json={"prompt": "hi"}).status_code == 200
+    assert client.post("/api/suggest_edits", json={"text": "hi"}).status_code == 200
+    assert client.post("/api/qa-recheck", json={"text": "hi"}).status_code == 200

--- a/tests/api/test_qa_profile_fallback.py
+++ b/tests/api/test_qa_profile_fallback.py
@@ -1,0 +1,47 @@
+import importlib
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _reload_app():
+    modules = [
+        "contract_review_app.api",
+        "contract_review_app.api.app",
+    ]
+    for m in modules:
+        sys.modules.pop(m, None)
+    os.environ["AI_PROVIDER"] = "mock"
+    from contract_review_app.api import app as app_module
+
+    importlib.reload(app_module)
+    return TestClient(app_module.app), modules
+
+
+@pytest.fixture()
+def client():
+    client, modules = _reload_app()
+    try:
+        yield client
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+def test_qa_profile_fallback_to_vanilla(client):
+    cid = "cid-fallback"
+    resp = client.post(
+        "/api/qa-recheck",
+        json={"text": "hello", "profile": "smart"},
+        headers={"x-cid": cid},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["meta"]["profile"] == "vanilla"
+
+
+def test_qa_empty_snapshot_defaults_vanilla(client):
+    resp = client.post("/api/qa-recheck", json={"text": "hello"})
+    assert resp.status_code == 200
+    assert resp.json()["meta"]["profile"] == "vanilla"


### PR DESCRIPTION
## Summary
- add generic `chat` interface and env-var matrix for Azure provider
- support request profile and fallback to vanilla in QA recheck
- document env matrix and LLM curl examples

## Testing
- `pre-commit run --files MIGRATION.md contract_review_app/api/app.py contract_review_app/core/schemas.py contract_review_app/gpt/clients/azure_client.py contract_review_app/gpt/config.py contract_review_app/gpt/service.py contract_review_app/llm/provider.py tests/api/test_llm_endpoints_integration.py tests/api/test_qa_profile_fallback.py`
- `pytest tests/api/test_qa_profile_fallback.py tests/api/test_llm_endpoints_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68b739f991688325a115a189437ea608