### PR TITLE
Fix draft assistant request/response wiring

### DIFF
--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -131,9 +131,13 @@ const DraftAssistantPanel: React.FC = () => {
     try {
       const env = await postJSON<DraftEnvelope>(DRAFT_PATH, {
         analysis,
+        text: analysis.text,
         mode: "friendly",
       });
-      setDraft({ ...env, draft_text: String(env?.draft_text || "") });
+      setDraft({
+        ...env,
+        draft_text: String(env?.draft?.text ?? env?.draft_text ?? ""),
+      });
     } catch (e: any) {
       setError(e?.message || "Draft failed");
     } finally {


### PR DESCRIPTION
## Summary
- ensure draft panel sends clause text with analysis when calling `/api/gpt-draft`
- surface returned draft text from `draft` payload

## Testing
- `pre-commit run --files contract_review_app/frontend/draft_panel/index.tsx`
- `npm --prefix contract_review_app/frontend run build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b760a50a848325b0fb9e27963ddd44