### PR TITLE
fix: remove extraneous placeholders from QA prompt

### DIFF
--- a/contract_review_app/gpt/prompts/qa.txt
+++ b/contract_review_app/gpt/prompts/qa.txt
@@ -1,4 +1,4 @@
-# Check the clause against the provided rules context and respond with a JSON array of objects ({id, status (ok|warn|fail), note}).
+# Check the clause against the provided rules context and respond with a JSON array of objects (id, status (ok|warn|fail), note).
 You are a contract QA checker.
 
 Context rules:


### PR DESCRIPTION
## Summary
- avoid unknown placeholders in QA recheck prompt by removing braces around sample fields

## Testing
- `pre-commit run --files contract_review_app/gpt/prompts/qa.txt`
- `pytest contract_review_app/tests/test_api_validation_errors.py contract_review_app/tests/test_api_qa_recheck_range.py contract_review_app/tests/test_qa_recheck_mixed_types.py tests/api/test_qa_recheck_mock.py`


------
https://chatgpt.com/codex/tasks/task_e_68b80eb5182c8325ad02c25a836bc0b6