### PR TITLE
Align analyze API contract and fix QA recheck crash

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1089,22 +1089,23 @@ def api_analyze(req: AnalyzeRequest, request: Request):
 
     # status passthrough (do not force to "ok")
     if isinstance(analysis, dict):
-        status_out = str(analysis.get("status", "ok")).upper()
-        analysis_out = analysis
+        status_out = str(analysis.get("status", "ok")).lower()
+        analysis_out = dict(analysis)
         analysis_out["status"] = status_out
     else:
-        status_out = "OK"
+        status_out = "ok"
         analysis_out = {"findings": analysis, "status": status_out}
 
     envelope = {
         "status": status_out,
         "analysis": analysis_out,
         "meta": PROVIDER_META,
-        "schema_version": SCHEMA_VERSION,
+        "x_schema_version": SCHEMA_VERSION,
     }
     IDEMPOTENCY_CACHE.set(cid, envelope)
 
     resp = JSONResponse(envelope)
+    # x-schema-version header is set by _set_std_headers
     _set_std_headers(resp, cid=cid, xcache="miss", schema=SCHEMA_VERSION)
     return resp
 

--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -7,6 +7,9 @@ const DEFAULT_BACKEND = "http://127.0.0.1:9000";
 const LS_KEY = "contract_ai_backend";
 const DRAFT_PATH = "/api/gpt-draft";
 
+const isOk = (s: any) => String(s).toLowerCase() === "ok";
+const getSchemaVer = (b: any) => b?.x_schema_version || b?.schema_version || null;
+
 function getBackend(): string {
   try {
     const v = (localStorage.getItem(LS_KEY) || "").trim();
@@ -109,6 +112,10 @@ const DraftAssistantPanel: React.FC = () => {
         text: clauseText,
         clause_type: clauseType || undefined,
       });
+      getSchemaVer(env);
+      if (!isOk(env?.status) || !isOk(env?.analysis?.status)) {
+        throw new Error("API error");
+      }
       const a = (env?.analysis ?? env) as AnalysisOutput;
       // Backfill minimal fields
       a.clause_type = a.clause_type || clauseType || undefined;

--- a/contract_review_app/gpt/prompts/qa.txt
+++ b/contract_review_app/gpt/prompts/qa.txt
@@ -1,4 +1,4 @@
-# Check the clause against the provided rules context and respond with a JSON array of objects ({id, status (ok|warn|fail), note}).
+# Check the clause against the provided rules context and respond with a JSON array of objects ({{id, status, note}}).
 You are a contract QA checker.
 
 Context rules:
@@ -6,7 +6,7 @@ Context rules:
 
 Task:
 Review the clause below and produce JSON with an "issues" array.
-Each element: id, status (ok|warn|fail), note.
+Each element: id, status, note.
 
 Clause:
 {text}

--- a/contract_review_app/gpt/service.py
+++ b/contract_review_app/gpt/service.py
@@ -101,7 +101,17 @@ class LLMService:
         if profile == "smart" and not rules_context:
             raise ValueError("qa_prompt_invalid: missing rules context")
         prompt_tpl = self._read_prompt("qa")
-        prompt = self._safe_format_prompt(prompt_tpl, text=text, rules=rules_context)
+        safe_rules = []
+        for r in rules_context.get("rules", []):
+            safe_rules.append(
+                {
+                    "id": str(r.get("id", "")),
+                    "status": str(r.get("status", "")).lower(),
+                    "note": r.get("note", ""),
+                }
+            )
+        rules_ctx = {"rules": safe_rules}
+        prompt = self._safe_format_prompt(prompt_tpl, text=text, rules=rules_ctx)
         to = timeout or self.cfg.timeout_s
         result = self.client.qa_recheck(prompt, to)
         result.meta["profile"] = profile

--- a/contract_review_app/tests/api/test_analyze_contract.py
+++ b/contract_review_app/tests/api/test_analyze_contract.py
@@ -1,0 +1,22 @@
+import pytest
+from httpx import AsyncClient
+from contract_review_app.api.app import app
+from contract_review_app.core.schemas import SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_analyze_ok_contract():
+    async with AsyncClient(app=app, base_url="https://test", trust_env=False) as ac:
+        r = await ac.post(
+            "/api/analyze",
+            json={
+                "text": "Governing law: England and Wales. Force majeure applies.",
+                "mode": "live",
+            },
+        )
+        assert r.status_code == 200
+        j = r.json()
+        assert j["status"] == "ok"
+        assert j["analysis"]["status"] == "ok"
+        assert j["x_schema_version"] == SCHEMA_VERSION
+        assert r.headers.get("x-schema-version") == SCHEMA_VERSION

--- a/contract_review_app/tests/api/test_qa_recheck_prompt.py
+++ b/contract_review_app/tests/api/test_qa_recheck_prompt.py
@@ -1,0 +1,11 @@
+import pytest
+from httpx import AsyncClient
+from contract_review_app.api.app import app
+
+
+@pytest.mark.asyncio
+async def test_qa_recheck_no_500():
+    async with AsyncClient(app=app, base_url="https://test", trust_env=False) as ac:
+        body = {"text": "Clause text", "rules": [{"id": "R1", "status": "warn", "note": "check"}]}
+        r = await ac.post("/api/qa-recheck", json=body)
+        assert r.status_code in (200, 400, 422)

--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -1,6 +1,9 @@
 const input = document.getElementById('input') as HTMLTextAreaElement;
 const output = document.getElementById('output') as HTMLPreElement;
 
+const isOk = (s: any) => String(s).toLowerCase() === 'ok';
+const getSchemaVer = (b: any) => (b?.x_schema_version || b?.schema_version || null);
+
 async function callApi(endpoint: string) {
   output.textContent = '...';
   try {
@@ -10,7 +13,10 @@ async function callApi(endpoint: string) {
       body: JSON.stringify({text: input.value})
     });
     const data = await resp.json();
-    if (!resp.ok) throw new Error(JSON.stringify(data));
+    getSchemaVer(data);
+    if (!resp.ok || !isOk(data.status) || !isOk(data?.analysis?.status)) {
+      throw new Error(JSON.stringify(data));
+    }
     output.textContent = JSON.stringify(data, null, 2);
   } catch (err: any) {
     output.textContent = err.message || String(err);


### PR DESCRIPTION
## Summary
- normalize analyze API response casing and schema version envelope
- sanitize QA recheck prompt and format rules safely
- harden panel clients against legacy analyze responses

## Testing
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_analyze_contract.py contract_review_app/tests/api/test_qa_recheck_prompt.py -q`
- `curl -s http://localhost:8000/health`
- `curl -s -H "Content-Type: application/json" --data-binary @analyze_body.json http://localhost:8000/api/analyze -D -`

------
https://chatgpt.com/codex/tasks/task_e_68b810911544832595c24a26ef50a0e8