### PR TITLE
feat: add unified API client and panel bundle

### DIFF
--- a/word_addin_dev/panel/assets/api-client.js
+++ b/word_addin_dev/panel/assets/api-client.js
@@ -1,0 +1,41 @@
+// Unified API client for panel + self-test
+export const API = (() => {
+  const SCHEMA = "1.3";
+  const base = () => (localStorage.getItem("backendUrl") || "https://localhost:9443").replace(/\/+$/,"");
+
+  const parse = async (res) => {
+    const text = await res.text();
+    let data = {};
+    try { data = text ? JSON.parse(text) : {}; } catch { data = { status: "error", detail: "bad json", raw: text }; }
+    const headers = {
+      cid: res.headers.get("x-cid"),
+      cache: res.headers.get("x-cache"),
+      latency: res.headers.get("x-latency-ms"),
+      schema: res.headers.get("x-schema-version") || data.x_schema_version || data.schema_version,
+      provider: res.headers.get("x-provider"),
+      model: res.headers.get("x-model"),
+      mode: res.headers.get("x-llm-mode"),
+      usage: res.headers.get("x-usage-total"),
+    };
+    const ok = String(data?.status || "").toLowerCase() === "ok";
+    const aok = String(data?.analysis?.status || "ok").toLowerCase() === "ok";
+    return { ok: res.ok && ok && aok, http: res.status, headers, data };
+  };
+
+  const req = (path, init={}) => fetch(base()+path, {
+    method: init.method || "GET",
+    headers: Object.assign({ "content-type":"application/json", "x-cid": crypto.randomUUID() }, init.headers||{}),
+    body: init.body,
+    credentials: "include",
+  }).then(parse);
+
+  return {
+    health:   () => req("/health"),
+    analyze:  (text, mode="live") => req("/api/analyze", { method:"POST", body: JSON.stringify({ text, mode }) }),
+    summary:  (text) => req("/api/summary", { method:"POST", body: JSON.stringify({ text }) }),
+    gptDraft: (text, mode="friendly") => req("/api/gpt-draft", { method:"POST", body: JSON.stringify({ text, mode }) }),
+    suggest:  (text, mode="friendly") => req("/api/suggest_edits", { method:"POST", body: JSON.stringify({ text, mode }) }),
+    qaRecheck:(text, rules=[]) => req("/api/qa-recheck", { method:"POST", body: JSON.stringify({ text, rules }) }),
+    trace:    (cid) => req(`/api/trace/${encodeURIComponent(cid)}`),
+  };
+})();

--- a/word_addin_dev/panel/taskpane.bundle.js
+++ b/word_addin_dev/panel/taskpane.bundle.js
@@ -1,0 +1,131 @@
+console.info("[PANEL] Build:", "dev-"+Date.now());
+
+// import { API } from "./assets/api-client.js";
+import { API } from "./assets/api-client.js";
+
+const backendInput = document.getElementById("backendInput");
+if (backendInput) backendInput.value = localStorage.getItem("backendUrl") || "https://localhost:9443";
+
+document.getElementById("btnSave")?.addEventListener("click", () => {
+  const v = backendInput.value.trim();
+  if (v) localStorage.setItem("backendUrl", v);
+});
+
+function getOriginalClauseText(){
+  return document.getElementById("originalClause")?.value || "";
+}
+function getRiskMode(){
+  return document.getElementById("riskThreshold")?.value || "live";
+}
+function getDraftMode(){
+  return document.getElementById("cai-mode")?.value || "friendly";
+}
+function toast(msg){ console.log(msg); }
+
+function setMeta(k,v){
+  const ids={cid:"cidBadge",xcache:"xcacheBadge",latency:"latencyBadge",schema:"schemaBadge",provider:"providerBadge",model:"modelBadge",mode:"modeBadge"};
+  const el=document.getElementById(ids[k]);
+  if(el) el.textContent=v;
+}
+function setSnapshot(d){
+  const t=document.querySelector('[data-snap-type]');
+  const c=document.querySelector('[data-snap-type-confidence]');
+  if(t) t.textContent=d.type;
+  if(c) c.textContent=d.findingsCount ?? d.issuesCount ?? "";
+}
+function fillFindingsList(list){
+  const ul=document.getElementById("findingsList");
+  if(!ul) return;
+  ul.innerHTML="";
+  list.forEach(f=>{const li=document.createElement("li");li.textContent=f.message||JSON.stringify(f);ul.appendChild(li);});
+}
+function fillRecommendationsList(list){
+  const ul=document.getElementById("recommendationsList");
+  if(!ul) return;
+  ul.innerHTML="";
+  list.forEach(f=>{const li=document.createElement("li");li.textContent=f.message||JSON.stringify(f);ul.appendChild(li);});
+}
+function renderSummary(text){ const el=document.getElementById("summaryBox"); if(el) el.textContent=text; }
+function setProposedText(text){ const el=document.getElementById("draftBox"); if(el) el.value=text; }
+function applySuggestions(data){ console.log("applySuggestions", data); }
+
+function renderMeta(r){
+  setMeta("cid", r.headers.cid || "—");
+  setMeta("xcache", r.headers.cache || "—");
+  setMeta("latency", r.headers.latency || "—");
+  setMeta("schema", r.headers.schema || "—");
+  setMeta("provider", r.headers.provider || "—");
+  setMeta("model", r.headers.model || "—");
+  setMeta("mode", r.headers.mode || "—");
+}
+
+function renderFindings(analysis){
+  setSnapshot({
+    type: analysis?.clause_type || "unknown",
+    findingsCount: (analysis?.findings || []).length,
+    issuesCount: (analysis?.issues || []).length
+  });
+  fillFindingsList(analysis?.findings || []);
+  fillRecommendationsList(analysis?.issues || []);
+}
+
+function renderApiError(what, r){
+  console.warn(`[${what}] API error`, r);
+  toast(`✖ ${what} error: http ${r.http}`);
+}
+
+function clearStorageAndReload(){
+  try{ localStorage.clear(); }catch{}
+  if(window.caches){ caches.keys().then(keys=>keys.forEach(k=>caches.delete(k))); }
+  location.reload();
+}
+
+async function doHealth(){
+  const r = await API.health();
+  renderMeta(r);
+  toast(r.ok ? "Conn: 200" : `Conn error: http ${r.http}`);
+}
+
+async function doAnalyzeDoc(){
+  const text = getOriginalClauseText();
+  if(!text?.trim()) return toast("⚠️ Paste or copy text first.");
+  const r = await API.analyze(text, getRiskMode());
+  renderMeta(r);
+  if(r.ok){ renderFindings(r.data.analysis); }
+  else { renderApiError("Analyze", r); }
+}
+
+async function doSummary(){
+  const text = getOriginalClauseText();
+  if(!text?.trim()) return toast("⚠️ Paste or copy text first.");
+  const r = await API.summary(text);
+  renderMeta(r);
+  if(r.ok) renderSummary(r.data.summary);
+  else renderApiError("Summary", r);
+}
+
+async function doGptDraft(){
+  const text = getOriginalClauseText();
+  if(!text?.trim()) return toast("⚠️ Paste or copy text first.");
+  const r = await API.gptDraft(text, getDraftMode());
+  renderMeta(r);
+  if(r.ok) setProposedText(r.data.proposed_text || "");
+  else renderApiError("GPT draft", r);
+}
+
+async function doSuggest(){
+  const text = getOriginalClauseText();
+  if(!text?.trim()) return toast("⚠️ Analyze first.");
+  const r = await API.suggest(text, getDraftMode());
+  renderMeta(r);
+  if(r.ok) applySuggestions(r.data);
+  else renderApiError("Suggest", r);
+}
+
+document.getElementById("btnTest")?.addEventListener("click", doHealth);
+document.getElementById("analyzeBtn")?.addEventListener("click", doAnalyzeDoc);
+document.getElementById("btnAnalyzeDoc")?.addEventListener("click", doAnalyzeDoc);
+document.getElementById("btnSummary")?.addEventListener("click", doSummary);
+document.getElementById("draftBtn")?.addEventListener("click", doGptDraft);
+document.getElementById("btnSuggest")?.addEventListener("click", doSuggest);
+document.getElementById("btnClearStorage")?.addEventListener("click", clearStorageAndReload);


### PR DESCRIPTION
## Summary
- add shared API client for panel and self-test
- wire new panel bundle to use modular API and local backend settings

## Testing
- `pre-commit run --files word_addin_dev/panel/assets/api-client.js word_addin_dev/panel/taskpane.bundle.js`

------
https://chatgpt.com/codex/tasks/task_e_68b81c6009fc83259585158ec84aa3da