### PR TITLE
Serve panel assets and fix Clear storage handler

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1670,6 +1670,21 @@ def panel_js():
     return resp
 
 
+# --- STATIC: panel assets -----------------------------------------------------
+_ASSETS_DIR = Path(__file__).resolve().parents[2] / "word_addin_dev" / "app" / "assets"
+
+
+@app.get("/panel/app/assets/{asset_path:path}")
+def panel_assets(asset_path: str):
+    base = _ASSETS_DIR
+    fp = (base / asset_path).resolve()
+    # защита от выхода вверх по каталогу и 404
+    if not str(fp).startswith(str(base)) or not fp.exists() or not fp.is_file():
+        raise HTTPException(status_code=404, detail="asset not found")
+    mt = "application/javascript" if fp.suffix == ".js" else "text/plain"
+    return FileResponse(fp, media_type=mt)
+
+
 # --------------------------------------------------------------------
 # Static panel mount (/panel) with no-store headers and version endpoint
 # --------------------------------------------------------------------

--- a/word_addin_dev/taskpane.bundle.js
+++ b/word_addin_dev/taskpane.bundle.js
@@ -302,7 +302,7 @@
   }
 
   function clearStorageAndReload(){
-    try { localStorage.clear(); } catch {}
+    try { localStorage.clear(); } catch (e) {}
     if (window.caches) { caches.keys().then(function(keys){ keys.forEach(function(k){ caches.delete(k); }); }); }
     location.reload();
   }

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -157,7 +157,7 @@
   </div>
   <script>
   document.getElementById("btn-clear-storage").addEventListener("click", function(){
-    try { localStorage.clear(); } catch(){}
+    try { localStorage.clear(); } catch (e) {}
     if (window.caches) { caches.keys().then(keys => keys.forEach(k => caches.delete(k))).finally(()=>location.reload()); }
     else location.reload();
   });


### PR DESCRIPTION
## Summary
- Serve panel assets via /panel/app/assets to avoid 404s and define proper MIME types
- Fix "Clear storage & reload" handler to use valid catch blocks in HTML and bundle

## Testing
- `pre-commit run --files contract_review_app/api/app.py word_addin_dev/taskpane.html word_addin_dev/taskpane.bundle.js`
- `pytest` *(fails: async def functions are not natively supported, key errors, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b82a7514d88325bda9fb741841ac4a