### PR TITLE
feat(word-addin): persist risk and improve annotations

### DIFF
--- a/word_addin_dev/app/assets/store.js
+++ b/word_addin_dev/app/assets/store.js
@@ -3,17 +3,15 @@
   const DEFAULT_BASE = "https://localhost:9443";
   const S = {
     baseUrl: localStorage.getItem("backendUrl") || DEFAULT_BASE,
+    risk:    localStorage.getItem("risk") || "medium",
     lastCid: null,
     meta: { cid:"", cache:"", latencyMs:0, schema:"", provider:"", model:"", llm_mode:"", usage:"" },
     last: { analyze:null, summary:null, draft:null, suggest:null }
   };
-  function setBase(u){ 
-    const v = (String(u||"").trim() || DEFAULT_BASE).replace(/^http:\/\//i,"https://").replace(/\/+$/,"");
-    S.baseUrl = v; 
-    try { localStorage.setItem("backendUrl", v); } catch {}
-  }
+  function setBase(u){ S.baseUrl = u; try { localStorage.setItem("backendUrl", u); } catch {} }
+  function setRisk(r){ S.risk = r; try { localStorage.setItem("risk", r); } catch {} }
   function setMeta(m){ S.meta = { ...S.meta, ...m }; if (m && m.cid) S.lastCid = m.cid; }
   function get(){ return S; }
   root.CAI = root.CAI || {};
-  root.CAI.Store = { setBase, setMeta, get, DEFAULT_BASE };
+  root.CAI.Store = { setBase, setRisk, setMeta, get, DEFAULT_BASE };
 }(typeof self !== "undefined" ? self : this));

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -190,8 +190,9 @@
   <div id="officeTools" class="row card" style="display:block">
     <div class="muted" style="margin-bottom:6px">Office tools</div>
     <div class="flex">
-      <button id="useSelection" class="btn-grey">Use selection →</button>
-      <button id="useWholeDoc" class="btn-grey">Use whole doc →</button>
+      <!-- Поменяли местами и усилили whole -->
+      <button id="btn-use-whole" class="btn btn-lg btn-primary" style="margin-right:8px">Use whole doc →</button>
+      <button id="btn-use-selection" class="btn btn-sm">Use selection →</button>
       <button id="btnInsertIntoWord" class="btn">Insert result into Word</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- persist default backend URL and risk level in a shared store
- reorder copy buttons and highlight whole-document option
- analyze, annotate, and apply edits using stored risk and last analysis

## Testing
- `pytest` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b85b2b56488325b1550f89de9a77de