### PR TITLE
feat: add automatic comment insertion on analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## B9-S1
+- Auto-add Word comments for findings after Analyze (toggleable)

--- a/word_addin_dev/MIGRATION.md
+++ b/word_addin_dev/MIGRATION.md
@@ -1,0 +1,13 @@
+# Migration: Add comments on Analyze
+
+## Toggle
+- The Task Pane now includes **Add comments on Analyze** checkbox.
+- Enabled by default. Uncheck to skip automatic comment insertion.
+
+## Comment prefix
+- Comments inserted by Contract AI start with `"[CAI][cid:{CID}][rule:{RULE_ID}]"`.
+- Search for this prefix to locate all generated comments.
+
+## Limitations
+- Only comments are added; document text is not modified.
+- Track Changes are untouched.

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -216,6 +216,12 @@
       <button id="btnClearAnnots" class="btn-grey" title="Select text in Word before applying edits.">Clear Annotations</button>
       <span class="pill right" id="qaDeltaBadge" title="QA deltas">Δ: —</span>
     </div>
+    <div class="row">
+      <label class="toggle">
+        <input id="cai-comment-on-analyze" type="checkbox" checked>
+        <span>Add comments on Analyze</span>
+      </label>
+    </div>
     <div id="qaResiduals" class="row" style="display:none">
       <strong>Residual risks</strong>
       <ul class="list" id="qaResidualList"></ul>


### PR DESCRIPTION
## Summary
- add UI toggle to control comment insertion on Analyze
- batch insert Word comments for each finding, deduplicated by cid and rule
- document comment feature in migration notes and changelog

## Testing
- `pre-commit run --files word_addin_dev/taskpane.html word_addin_dev/taskpane.bundle.js word_addin_dev/MIGRATION.md CHANGELOG.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b953d23b648325b718bfb8514255c3