### PR TITLE
feat: add document risk summary panel

### DIFF
--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -134,3 +134,6 @@
 
   return API;
 }));
+
+window.CAI = window.CAI || {};
+CAI.pickFindings = (resp) => (resp?.analysis?.findings) || [];

--- a/word_addin_dev/app/assets/store.js
+++ b/word_addin_dev/app/assets/store.js
@@ -18,8 +18,8 @@
 
 window.CAI = window.CAI || {};
 CAI.store = CAI.store || {};
-CAI.store.get = (k, d) => { try { return JSON.parse(localStorage.getItem(k)) ?? d; } catch { return d; } };
-CAI.store.set = (k, v) => { localStorage.setItem(k, JSON.stringify(v)); };
+CAI.store.get = CAI.store.get || ((k, d) => { try { return JSON.parse(localStorage.getItem(k)) ?? d; } catch { return d; } });
+CAI.store.set = CAI.store.set || ((k, v) => { localStorage.setItem(k, JSON.stringify(v)); });
 CAI.store.updateSuggestion = (id, patch) => {
   const arr = CAI.store.get("cai:suggestions", []);
   const ix = arr.findIndex(x => x.id === id);

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -244,6 +244,29 @@
     </div>
   </div>
 
+  <section id="doc-risk-summary" hidden>
+    <header>
+      <h3>Document Risk Summary</h3>
+      <div class="badges">
+        <span class="badge risk-high">High: <b id="rs-high">0</b></span>
+        <span class="badge risk-med">Medium: <b id="rs-med">0</b></span>
+        <span class="badge risk-low">Low: <b id="rs-low">0</b></span>
+        <span class="badge risk-total">Total: <b id="rs-total">0</b></span>
+      </div>
+    </header>
+    <div class="table-wrap">
+      <table id="rs-table">
+        <thead><tr><th>Rule</th><th>Severity</th><th>Category</th><th>Clause</th><th>Count</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="actions">
+      <button id="rs-copy">Copy summary</button>
+      <button id="rs-export-md">Export .md</button>
+      <button id="rs-export-json">Export .json</button>
+    </div>
+  </section>
+
   <div class="row card" id="resultsCard">
     <div class="muted" style="margin-bottom:6px">Results</div>
     <div class="grid">


### PR DESCRIPTION
## Summary
- add Document Risk Summary section with counts, table, copy and export actions
- compute risk aggregates on client and persist summary for reload
- enable navigation to findings and clipboard/JSON/Markdown exports

## Testing
- `node --check word_addin_dev/taskpane.bundle.js`
- `node --check word_addin_dev/app/assets/api-client.js`
- `node --check word_addin_dev/app/assets/store.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b95fbab51c8325ad864d6e8fbde15c