### PR TITLE
feat: cache analyze results with replay endpoint

### DIFF
--- a/contract_review_app/core/cache.py
+++ b/contract_review_app/core/cache.py
@@ -1,0 +1,32 @@
+from collections import OrderedDict
+import time
+
+
+class TTLCache:
+    def __init__(self, max_items=128, ttl_s=900):
+        self.max = max_items
+        self.ttl = ttl_s
+        self._data = OrderedDict()
+
+    def _purge(self):
+        now = time.time()
+        keys = [k for k, (v, ts) in self._data.items() if now - ts > self.ttl]
+        for k in keys:
+            self._data.pop(k, None)
+        # LRU trim
+        while len(self._data) > self.max:
+            self._data.popitem(last=False)
+
+    def get(self, key):
+        self._purge()
+        if key not in self._data:
+            return None
+        v, ts = self._data.pop(key)
+        self._data[key] = (v, ts)  # refresh LRU
+        return v
+
+    def set(self, key, value):
+        self._purge()
+        if key in self._data:
+            self._data.pop(key)
+        self._data[key] = (value, time.time())

--- a/contract_review_app/tests/api/test_analyze_cache_replay.py
+++ b/contract_review_app/tests/api/test_analyze_cache_replay.py
@@ -1,0 +1,35 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from contract_review_app.api.app import app
+
+
+@pytest.mark.asyncio
+async def test_analyze_cache_and_replay():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as ac:
+        body = {
+            "text": "Governing law: England and Wales. Force majeure applies.",
+            "mode": "live",
+        }
+        r1 = await ac.post("/api/analyze", json=body)
+        assert r1.status_code == 200
+        j1 = r1.json()
+        cid = r1.headers.get("x-cid")
+        h = r1.headers.get("x-doc-hash")
+        assert cid and h
+        assert r1.headers.get("x-cache") in ("miss", "hit")
+
+        r2 = await ac.post("/api/analyze", json=body)
+        assert r2.status_code == 200
+        assert r2.headers.get("x-cache") == "hit"
+        assert r2.headers.get("x-doc-hash") == h
+        assert r2.json() == j1
+
+        r3 = await ac.get(f"/api/analyze/replay?cid={cid}")
+        assert r3.status_code == 200
+        assert r3.headers.get("x-cache") == "replay"
+        assert r3.json() == j1
+
+        r4 = await ac.get(f"/api/analyze/replay?hash={h}")
+        assert r4.status_code == 200
+        assert r4.json() == j1

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -30,6 +30,16 @@ export async function safeFetch(input, init={}) {
   return res;
 }
 
+export async function replayAnalyze({ cid, hash }) {
+  const u = new URL("/api/analyze/replay", window.CONTRACTAI_BACKEND);
+  if (cid) u.searchParams.set("cid", cid);
+  if (hash) u.searchParams.set("hash", hash);
+  const r = await fetch(u, { method: "GET", credentials: "include" });
+  if (!r.ok) throw new Error(`Replay failed: ${r.status}`);
+  const body = await r.json();
+  return { body, headers: Object.fromEntries(r.headers.entries()) };
+}
+
 (function (root, factory) {
   if (typeof define === "function" && define.amd) {
     define([], factory);

--- a/word_addin_dev/app/assets/store.js
+++ b/word_addin_dev/app/assets/store.js
@@ -52,3 +52,18 @@ export function debounce(fn, ms = 450) {
     __debounceTimers.set(key, setTimeout(() => fn(...args), ms));
   };
 }
+
+const KEY = "cai:last_analyze";
+export function saveLastAnalyze({ cid, docHash, risk }) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify({ cid, docHash, risk, ts: Date.now() }));
+  } catch {}
+}
+
+export function getLastAnalyze() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY) || "null");
+  } catch {
+    return null;
+  }
+}

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -240,6 +240,7 @@
     <textarea id="originalClause" placeholder="Paste text or load from selection/document…"></textarea>
     <div class="row flex" style="margin-top:8px">
       <button id="analyzeBtn" class="btn-grey js-disable-while-busy">Analyze</button>
+      <button id="btnReplay" class="btn-grey js-disable-while-busy">Replay last</button>
       <button id="draftBtn" class="btn js-disable-while-busy">Get AI Draft</button>
       <button id="copyResultBtn" class="btn-grey js-disable-while-busy">Copy result</button>
     </div>


### PR DESCRIPTION
## Summary
- cache /api/analyze responses by document hash and expose replay endpoint
- store last analysis client-side with replay button in Word add-in
- add integration test for analyze caching and replay

## Testing
- `pre-commit run --files contract_review_app/core/cache.py contract_review_app/api/app.py word_addin_dev/app/assets/api-client.js word_addin_dev/app/assets/store.js word_addin_dev/taskpane.bundle.js word_addin_dev/taskpane.html contract_review_app/tests/api/test_analyze_cache_replay.py`
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_analyze_cache_replay.py`


------
https://chatgpt.com/codex/tasks/task_e_68b973d60d248325a1bda7ec7c587ed3