### PR TITLE
Panel → learning/log: wire events + offline queue & retry

### DIFF
--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -30,6 +30,24 @@ export async function safeFetch(input, init={}) {
   return res;
 }
 
+export async function logLearning(event, baseUrl) {
+  const url = `${baseUrl}/api/learning/log`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(event),
+    credentials: "omit",
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    const err = new Error(`learning/log ${res.status}`);
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+  return await res.json().catch(() => ({}));
+}
+
 export async function replayAnalyze({ cid, hash }) {
   const u = new URL("/api/analyze/replay", window.CONTRACTAI_BACKEND);
   if (cid) u.searchParams.set("cid", cid);

--- a/word_addin_dev/app/assets/store.js
+++ b/word_addin_dev/app/assets/store.js
@@ -69,3 +69,26 @@ export function getLastAnalyze() {
     return null;
   }
 }
+
+// === learning event queue ===
+const QKEY = "cai_learning_queue_v1";
+
+export function enqueueLearning(evt) {
+  try {
+    const q = JSON.parse(localStorage.getItem(QKEY) || "[]");
+    const id = `${evt.cid||"nocid"}|${evt.ts}|${evt.action}|${evt.rule_id||"norule"}`;
+    if (!q.find(x => x._id === id)) { q.push({ ...evt, _id: id }); }
+    localStorage.setItem(QKEY, JSON.stringify(q));
+  } catch {}
+}
+
+export function readQueue() {
+  try { return JSON.parse(localStorage.getItem(QKEY) || "[]"); } catch { return []; }
+}
+
+export function dropFromQueue(ids) {
+  try {
+    const q = readQueue().filter(x => !ids.includes(x._id));
+    localStorage.setItem(QKEY, JSON.stringify(q));
+  } catch {}
+}


### PR DESCRIPTION
Files to change:

word_addin_dev/app/assets/store.js

word_addin_dev/app/assets/api-client.js

word_addin_dev/taskpane.bundle.js

1) API-клиент: logLearning(event) + очередь

word_addin_dev/app/assets/api-client.js

// ADD
export async function logLearning(event, baseUrl) {
  const url = `${baseUrl}/api/learning/log`;
  const res = await fetch(url, {
    method: "POST",
    headers: {"Content-Type": "application/json"},
    body: JSON.stringify(event),
    credentials: "omit",
  });
  if (!res.ok) {
    const text = await res.text().catch(()=> "");
    const err = new Error(`learning/log ${res.status}`);
    err.status = res.status;
    err.body = text;
    throw err;
  }
  return await res.json().catch(()=> ({}));
}


word_addin_dev/app/assets/store.js

// ADD queue utils (idempotent)
const QKEY = "cai_learning_queue_v1";

export function enqueueLearning(evt) {
  try {
    const q = JSON.parse(localStorage.getItem(QKEY) || "[]");
    // de-dupe by cid+ts+action+rule_id
    const id = `${evt.cid||"nocid"}|${evt.ts}|${evt.action}|${evt.rule_id||"norule"}`;
    if (!q.find(x => x._id === id)) { q.push({...evt, _id: id}); }
    localStorage.setItem(QKEY, JSON.stringify(q));
  } catch {}
}

export function readQueue() {
  try { return JSON.parse(localStorage.getItem(QKEY) || "[]"); } catch { return []; }
}

export function dropFromQueue(ids) {
  try {
    const q = readQueue().filter(x => !ids.includes(x._id));
    localStorage.setItem(QKEY, JSON.stringify(q));
  } catch {}
}

2) Панель: централизованный эмиттер и авто-флаш очереди

word_addin_dev/taskpane.bundle.js

import { logLearning } from "./app/assets/api-client.js";
import { enqueueLearning, readQueue, dropFromQueue } from "./app/assets/store.js";

// ADD: settings
const RETRIES = 3;
const BACKOFF_MS = [500, 1500, 4000];

// ADD: helper to build event
function buildLearningEvent({action, rule, excerpt, note, selectionHash, docHash, docName, cid}) {
  return {
    action,               // "accept" | "reject" | "manual_edit" | "apply"
    rule_id: rule?.rule_id || rule?.id || null,
    severity: rule?.severity || null,
    excerpt: excerpt || rule?.snippet || null,
    note: note || null,
    selection_hash: selectionHash || null,
    doc_hash: docHash || window.CAI?.docHash || null,
    doc_name: docName || window.CAI?.docName || null,
    cid: cid || window.CAI?.cid || null,
    ts: Date.now(),
    x_schema_version: "1.3"
  };
}

// ADD: central sender with retry + queue
async function sendLearningEvent(evt, baseUrl) {
  // optimistic enqueue (so we never lose it); will drop after success
  enqueueLearning(evt);
  const id = readQueue().slice(-1)[0]?._id; // last enqueued id
  let lastErr = null;
  for (let i = 0; i <= RETRIES; i++) {
    try {
      await logLearning(evt, baseUrl);
      dropFromQueue([id]);
      return true;
    } catch (e) {
      lastErr = e;
      // only retry on 5xx/0; 4xx — бессмысленно
      const s = (e && e.status) || 0;
      if (s && s < 500) break;
      await new Promise(r => setTimeout(r, BACKOFF_MS[Math.min(i, BACKOFF_MS.length-1)]));
    }
  }
  console.warn("[learning] queued (will retry later)", lastErr);
  return false;
}

// ADD: flush on load and when coming online
async function flushLearningQueue(baseUrl) {
  const q = readQueue();
  if (!q.length) return;
  const doomed = [];
  for (const item of q) {
    try {
      await logLearning(item, baseUrl);
      doomed.push(item._id);
    } catch (e) {
      const s = (e && e.status) || 0;
      if (s && s < 500) continue; // keep for manual inspection
    }
  }
  if (doomed.length) dropFromQueue(doomed);
}

// call flush on init and on online
async function initLearningFlush(baseUrl) {
  try { await flushLearningQueue(baseUrl); } catch {}
  window.addEventListener("online", ()=> flushLearningQueue(baseUrl));
}

3) Вызовы из UX-действий (Accept/Reject/Apply/Manual)

В том же taskpane.bundle.js — там, где уже обрабатываются клики (кнопки Accept/Reject для предложений, Apply правок и т.п.), добавьте вызовы:

// пример в обработчике Accept
async function onAcceptSuggestion(sugg) {
  // ... существующий код применения правки ...
  const evt = buildLearningEvent({
    action: "accept",
    rule: sugg.rule,
    excerpt: sugg.excerpt || sugg.before || null,
    cid: window.CAI?.cid
  });
  // BASE_URL уже есть в self-test/панели, например window.CAI.backend
  sendLearningEvent(evt, window.CAI?.backend);
}

// пример Reject
async function onRejectSuggestion(sugg) {
  const evt = buildLearningEvent({
    action: "reject",
    rule: sugg.rule,
    excerpt: sugg.excerpt || null,
    cid: window.CAI?.cid
  });
  sendLearningEvent(evt, window.CAI?.backend);
}

// пример Apply (применение diff/трек-чейндж)
async function onApplyChange(item) {
  // ... существующий код track changes ...
  const evt = buildLearningEvent({
    action: "apply",
    rule: item.rule,
    excerpt: item.excerpt || null,
    cid: window.CAI?.cid
  });
  sendLearningEvent(evt, window.CAI?.backend);
}

// пример Manual edit (кнопка «Log manual» или хук по событию)
async function onManualEdit(rangeInfo) {
  const evt = buildLearningEvent({
    action: "manual_edit",
    rule: null,
    excerpt: rangeInfo?.text || null,
    cid: window.CAI?.cid
  });
  sendLearningEvent(evt, window.CAI?.backend);
}

// при инициализации панели:
initLearningFlush(window.CAI?.backend);


Важно: никаких изменений на бэкенде не требуется — используем уже реализованный /api/learning/log (B10-S1). Поля события соответствуют LearningEvent.

Acceptance criteria

Accept/Reject/Apply/Manual генерируют POST на /api/learning/log с телом:

action ∈ {"accept","reject","apply","manual_edit"}

rule_id (может быть null для manual)

excerpt (строка или null)

cid, doc_hash, doc_name, ts, x_schema_version:"1.3"

При отсутствии сети/500 событие уходит в локальную очередь (localStorage:cai_learning_queue_v1) и досылается при следующем открытии панели/восстановлении сети.

Дедупликация: повторный клик не создаёт дубликаты (по _id = cid|ts|action|rule_id).

В консоли панели видны понятные логи: "[learning] queued" при офлайне, без красных ошибок.

Никаких регрессий: Analyze, Suggest, Apply продолжают работать.

------
https://chatgpt.com/codex/tasks/task_e_68b980462da8832581764b981b156c43