### PR TITLE
feat: implement LRU trace snapshots and export support

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,8 @@
 - Export analysis reports via `GET /api/report/{cid}.html` (always on) and
   `GET /api/report/{cid}.pdf` (returns 501 if PDF backend missing).
 - Use the `x-cid` response header from `/api/analyze` as the identifier.
+- Trace middleware now persists up to 200 entries (configurable via `TRACE_MAX`)
+  and accepts CID values matching ``^[A-Za-z0-9\-:]{3,64}$``.
 
 # Block B5 — Legal Corpus & Metadata
 

--- a/contract_review_app/api/error_handlers.py
+++ b/contract_review_app/api/error_handlers.py
@@ -15,7 +15,9 @@ def register_error_handlers(app: FastAPI) -> None:
     async def _handle_validation_error(request: Request, exc: RequestValidationError):
         problem = ProblemDetail(title="Validation error", status=422)
         resp = JSONResponse(problem.model_dump(), status_code=422)
-        apply_std_headers(resp, request, getattr(request.state, "started_at", time.perf_counter()))
+        apply_std_headers(
+            resp, request, getattr(request.state, "started_at", time.perf_counter())
+        )
         return resp
 
     @app.exception_handler(HTTPException)
@@ -23,9 +25,11 @@ def register_error_handlers(app: FastAPI) -> None:
         if exc.status_code >= 500:
             logger.exception("HTTPException", exc_info=exc)
         title = exc.detail if isinstance(exc.detail, str) else "Error"
-        problem = ProblemDetail(title=title, status=exc.status_code)
+        problem = ProblemDetail(title=title, detail=title, status=exc.status_code)
         resp = JSONResponse(problem.model_dump(), status_code=exc.status_code)
-        apply_std_headers(resp, request, getattr(request.state, "started_at", time.perf_counter()))
+        apply_std_headers(
+            resp, request, getattr(request.state, "started_at", time.perf_counter())
+        )
         return resp
 
     @app.exception_handler(Exception)
@@ -33,5 +37,7 @@ def register_error_handlers(app: FastAPI) -> None:
         logger.exception("Unhandled exception", exc_info=exc)
         problem = ProblemDetail(title="Internal Server Error", status=500)
         resp = JSONResponse(problem.model_dump(), status_code=500)
-        apply_std_headers(resp, request, getattr(request.state, "started_at", time.perf_counter()))
+        apply_std_headers(
+            resp, request, getattr(request.state, "started_at", time.perf_counter())
+        )
         return resp

--- a/contract_review_app/core/trace.py
+++ b/contract_review_app/core/trace.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any, Dict
+
+
+class TraceStore:
+    """Simple in-memory LRU store for trace snapshots."""
+
+    def __init__(self, maxlen: int = 200) -> None:
+        self.maxlen = maxlen
+        self._data: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+
+    def put(self, cid: str, item: Dict[str, Any]) -> None:
+        """Insert *item* under *cid* keeping only the latest *maxlen* items."""
+        if not cid:
+            return
+        if cid in self._data:
+            self._data.move_to_end(cid)
+        self._data[cid] = item
+        while len(self._data) > self.maxlen:
+            self._data.popitem(last=False)
+
+    def get(self, cid: str) -> Dict[str, Any] | None:
+        return self._data.get(cid)
+
+    def list(self) -> list[str]:
+        return list(self._data.keys())

--- a/contract_review_app/tests/api/test_app_contract.py
+++ b/contract_review_app/tests/api/test_app_contract.py
@@ -77,14 +77,14 @@ def test_qa_recheck_fallback_payload_and_deltas():
 
 
 def test_trace_middleware_records_events():
-    # produce at least one event
     client.get("/health")
     tr = client.get("/api/trace/health")
     assert tr.status_code == 200
     payload = tr.json()
-    assert payload["status"] == "ok"
     assert payload["cid"] == "health"
-    assert isinstance(payload.get("events"), list)
+    assert payload.get("analysis", {}).get("status") == "OK"
+    assert payload.get("meta", {}).get("path") == "/health"
+    assert payload.get("x_schema_version") == SCHEMA_VERSION
 
 
 def test_panel_static_and_cache_headers():


### PR DESCRIPTION
## Summary
- track recent analyses in an in-memory LRU store keyed by CID
- validate CID format and expose cached traces and reports with cache headers
- include error detail in HTTPException responses

## Testing
- `python -m pytest -q --maxfail=0 --disable-warnings tests/codex/test_trace_and_export.py contract_review_app/tests/api/test_app_contract.py -k test_trace_middleware_records_events`
- `python -m pytest -q --maxfail=0 --disable-warnings tests/codex/test_trace_and_export.py tests/codex/test_panel_exists.py tests/panel contract_review_app/tests/api/test_app_contract.py contract_review_app/tests/api/test_analyze_contract.py contract_review_app/tests/test_api_schemas_compat.py tests/test_doc_type_api.py tests/test_doc_type_backcompat.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9867c9e7083258914a398774d6a14