### PR TITLE
Normalize QA recheck rules input

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1580,7 +1580,9 @@ async def api_qa_recheck(
         return _problem_response(400, "Bad JSON", "Request body is not valid JSON")
 
     text = (payload or {}).get("text", "")
-    rules = (payload or {}).get("rules", {})
+    rules = (payload or {}).get("rules")
+    if isinstance(rules, list):
+        rules = {"rules": rules} if rules else None
     profile = (payload or {}).get("profile", "smart")
     cid = x_cid or _sha256_hex(str(t0) + text[:128])
     meta = LLM_CONFIG.meta()


### PR DESCRIPTION
## Summary
- Accept list and dict rule contexts in LLM service
- Normalize `rules` payload in `/api/qa-recheck`

## Testing
- `python -m pytest contract_review_app/tests/test_api_qa_recheck_range.py contract_review_app/tests/test_qa_recheck_mixed_types.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac716f048325abff041ecd54b442