### PR TITLE
Add recitals and clauses 1 rules with tests

### DIFF
--- a/core/rules/uk/master/recitals_and_clauses1/01_recitals_no_minimum_purchase.yaml
+++ b/core/rules/uk/master/recitals_and_clauses1/01_recitals_no_minimum_purchase.yaml
@@ -1,0 +1,40 @@
+rule:
+  id: "uk.master.recitals.no_min_purchase"
+  version: "1.0.0"
+  title: "Recitals: no minimum purchase/volume commitment"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","NDA"]
+    clauses: ["recitals","preamble"]
+    industries: ["generic","oil_gas"]
+  triggers:
+    any:
+      - regex: "(?i)therefore agree as follows"
+      - regex: "(?i)recitals?|preamble"
+  checks:
+    - id: "volume_commitment_in_recitals"
+      when:
+        any:
+          - regex: "(?i)minimum\\s+(purchase|commitment|order)"
+          - regex: "(?i)shall\\s+purchase\\s+at\\s+least"
+          - regex: "(?i)guarantee\\s+of\\s+(volume|work)"
+      finding:
+        message: "Recitals include a minimum purchase/volume commitment."
+        severity_level: "major"
+        risk: "high"
+        legal_basis:
+          - "Interpretation: Wood v Capita [2017] UKSC 24"
+        suggestion:
+          text: "Remove volume commitments from Recitals; operative commitments belong in Clauses/Call-Off and clause 3 should negate volume guarantees."
+        score_delta: -25
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: VolumeCommitmentInRecitals
+    score: 70
+    problem: "Minimum purchase/volume appears in Recitals."
+    recommendation: "Delete in Recitals; if needed, move to operative clauses with limits."
+    law_reference: ["Wood v Capita [2017] UKSC 24"]
+    category: "Recitals"
+    keywords: ["minimum purchase","guarantee of volume","recitals"]

--- a/core/rules/uk/master/recitals_and_clauses1/02_recitals_no_operational_shall.yaml
+++ b/core/rules/uk/master/recitals_and_clauses1/02_recitals_no_operational_shall.yaml
@@ -1,0 +1,36 @@
+rule:
+  id: "uk.master.recitals.no_operational_shall"
+  version: "1.0.0"
+  title: "Recitals must not contain operative 'shall' obligations"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","NDA"]
+    clauses: ["recitals","preamble"]
+  triggers:
+    any:
+      - regex: "(?i)recitals?|preamble"
+  checks:
+    - id: "operative_shall_in_recitals"
+      when:
+        any:
+          - regex: "(?i)\\bshall\\b"
+      finding:
+        message: "Recitals use 'shall' suggesting operative obligation."
+        severity_level: "major"
+        risk: "high"
+        legal_basis:
+          - "Interpretation: Arnold, Rainy Sky, Wood v Capita"
+        suggestion:
+          text: "Move obligations to Clauses/Call-Off; keep Recitals declarative."
+        score_delta: -20
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: OperativeObligationInRecitals
+    score: 70
+    problem: "Operative language in Recitals."
+    recommendation: "Recitals should be context only; obligations belong in Clauses."
+    law_reference: ["Wood v Capita [2017] UKSC 24"]
+    category: "Recitals"
+    keywords: ["shall","operative","recitals"]

--- a/core/rules/uk/master/recitals_and_clauses1/03_incorp_placeholders_clean.yaml
+++ b/core/rules/uk/master/recitals_and_clauses1/03_incorp_placeholders_clean.yaml
@@ -1,0 +1,39 @@
+rule:
+  id: "uk.master.incorp.placeholders_clean"
+  version: "1.0.0"
+  title: "Incorporation: remove placeholders and editorial notes"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","NDA"]
+    clauses: ["1.1","incorporation","exhibits","exhibit_j"]
+  triggers:
+    any:
+      - regex: "(?i)by reference (are|is) incorporated"
+      - regex: "(?i)Exhibit\\s+J|PCG|Performance\\s+Bond|Letter\\s+of\\s+Credit"
+  checks:
+    - id: "placeholder_or_editorial"
+      when:
+        any:
+          - regex: "\\[●"
+          - regex: "(?i)\\[DELETE AS APPROPRIATE\\]"
+          - regex: "(?i)\\[Amend prior to issuing externally\\]"
+      finding:
+        message: "Placeholders/editorial notes present in incorporated documents."
+        severity_level: "major"
+        risk: "high"
+        legal_basis:
+          - "Contract certainty"
+        suggestion:
+          text: "Resolve all placeholders and remove editorial notes before execution or external issue."
+        score_delta: -25
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: PlaceholdersLeft
+    score: 70
+    problem: "Unresolved placeholders in 1.1/Exhibits."
+    recommendation: "Replace [●]/notes with final details; re-issue clean exhibit files."
+    law_reference: []
+    category: "Incorporation"
+    keywords: ["Exhibit J","PCG","Bond","LC","placeholders"]

--- a/core/rules/uk/master/recitals_and_clauses1/04_incorp_heavy_terms_notice.yaml
+++ b/core/rules/uk/master/recitals_and_clauses1/04_incorp_heavy_terms_notice.yaml
@@ -1,0 +1,38 @@
+rule:
+  id: "uk.master.incorp.heavy_terms_notice"
+  version: "1.0.0"
+  title: "Incorporation: heavy/unusual terms require clear notice"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","NDA"]
+    clauses: ["1.1","incorporation","exhibits","policies"]
+  triggers:
+    any:
+      - regex: "(?i)by reference (are|is) incorporated"
+  checks:
+    - id: "heavy_terms_without_notice"
+      when:
+        all:
+          - regex: "(?i)indemnity|limitation of liability|exclude(d)?\\s+liability|liquidated damages|termination\\s+for\\s+convenience"
+          - not_regex: "(?i)clear\\s+notice|highlight|prominently\\s+notified|subject\\s+to\\s+UCTA|reasonableness"
+      finding:
+        message: "Heavy/unusual terms incorporated by reference without clear notice / reasonableness."
+        severity_level: "major"
+        risk: "high"
+        legal_basis:
+          - "Interfoto v Stiletto [1989] QB 433"
+          - "UCTA 1977 (reasonableness)"
+        suggestion:
+          text: "Add explicit notice/summary of heavy terms and confirm UCTA reasonableness; avoid burying exclusions in referenced documents."
+        score_delta: -25
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: HeavyTermsWithoutNotice
+    score: 80
+    problem: "Potentially unenforceable heavy terms if not clearly notified."
+    recommendation: "Provide conspicuous notice and reasonableness statement."
+    law_reference: ["Interfoto [1989] QB 433","UCTA 1977"]
+    category: "Incorporation"
+    keywords: ["incorporation by reference","heavy terms","UCTA","Interfoto"]

--- a/core/rules/uk/master/recitals_and_clauses1/05_incorp_dynamic_refs_change_control.yaml
+++ b/core/rules/uk/master/recitals_and_clauses1/05_incorp_dynamic_refs_change_control.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "uk.master.incorp.dynamic_refs_change_control"
+  version: "1.0.0"
+  title: "Incorporation: dynamic updates need Change Control"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["1.1","incorporation","standards","policies"]
+  triggers:
+    any:
+      - regex: "(?i)as\\s+may\\s+be\\s+updated\\s+from\\s+time\\s+to\\s+time"
+  checks:
+    - id: "no_change_control_reference"
+      when:
+        all:
+          - regex: "(?i)as\\s+may\\s+be\\s+updated\\s+from\\s+time\\s+to\\s+time"
+          - not_regex: "(?i)Change\\s+Control|Variation|Clause\\s+14"
+      finding:
+        message: "Dynamic reference without Change Control/Variation hook."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Tie updates to formal Change Control/Variation procedure (e.g., Clause 14)."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: DynamicRefWithoutChangeControl
+    score: 80
+    problem: "Unbounded one-sided updates via external docs."
+    recommendation: "Require Change Control for any update."
+    law_reference: []
+    category: "Incorporation"
+    keywords: ["dynamic reference","change control","variation"]

--- a/core/rules/uk/master/recitals_and_clauses1/06_exhibitj_deed_formalities.yaml
+++ b/core/rules/uk/master/recitals_and_clauses1/06_exhibitj_deed_formalities.yaml
@@ -1,0 +1,38 @@
+rule:
+  id: "uk.master.exhibitj.deed_formalities"
+  version: "1.0.0"
+  title: "Exhibit J deeds (PCG/Bond/LC) must satisfy s.44 CA 2006"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["exhibit_j","guarantee","bond","letter_of_credit"]
+  triggers:
+    any:
+      - regex: "(?i)Exhibit\\s+J|Parent\\s+Company\\s+Guarantee|Performance\\s+Bond|Letter\\s+of\\s+Credit"
+  checks:
+    - id: "missing_s44_elements"
+      when:
+        all:
+          - regex: "(?i)executed\\s+as\\s+a\\s+deed"
+          - not_regex: "(?i)(two\\s+directors|director\\s+and\\s+company\\s+secretary|witness)"
+      finding:
+        message: "Deed form lacks s.44 CA 2006 execution mechanics (signatories/witness)."
+        severity_level: "critical"
+        risk: "critical"
+        legal_basis:
+          - "Companies Act 2006 s.44"
+          - "Law Commission 2019 / GOV.UK IWG — e-execution"
+        suggestion:
+          text: "Provide execution blocks for two directors or a director and company secretary, or proper witnessing."
+        score_delta: -40
+  outcome:
+    status: fail
+    risk_level: critical
+    severity: S1
+    issue_type: DeedExecutionInvalid
+    score: 50
+    problem: "Deed may be unenforceable due to invalid execution."
+    recommendation: "Fix signatory blocks to comply with s.44, including e-sign best practice."
+    law_reference: ["CA 2006 s.44","Law Commission 2019"]
+    category: "Exhibits"
+    keywords: ["deed","PCG","Bond","LC","s.44"]

--- a/core/rules/uk/master/recitals_and_clauses1/07_term_extensions_notices.yaml
+++ b/core/rules/uk/master/recitals_and_clauses1/07_term_extensions_notices.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.master.term.extensions_notice"
+  version: "1.0.0"
+  title: "1.2: fixed dates, defined extensions, and notice mechanism"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["1.2","term","extensions","survival"]
+  triggers:
+    any:
+      - regex: "(?i)initial\\s+term|extend(ed)?\\s+term|Effective\\s+Date"
+  checks:
+    - id: "missing_term_fields"
+      when:
+        any:
+          - regex: "\\[●"
+          - not_regex: "(?i)\\b(\\d{1,2}\\s+months|\\d{4})\\b"
+      finding:
+        message: "Term/extension fields appear incomplete (dates/durations)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Populate end date and extension count/duration; avoid placeholders."
+        score_delta: -20
+    - id: "extension_without_notice_link"
+      when:
+        all:
+          - regex: "(?i)may\\s+extend"
+          - not_regex: "(?i)written\\s+notice|Clause\\s+29|Notices"
+      finding:
+        message: "Extension right lacks explicit written notice mechanism / Notices link."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Tie extensions to written notice under Clause 29 (Notices)."
+        score_delta: -15
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: TermFieldsIncomplete
+    score: 70
+    problem: "Term/extension data incomplete or missing notice link."
+    recommendation: "Fill dates and durations; reference Clause 29 for notice."
+    law_reference: []
+    category: "Term"
+    keywords: ["term","extensions","notice","Clause 29"]

--- a/core/rules/uk/master/recitals_and_clauses1/08_supplemental_docs_priority.yaml
+++ b/core/rules/uk/master/recitals_and_clauses1/08_supplemental_docs_priority.yaml
@@ -1,0 +1,46 @@
+rule:
+  id: "uk.master.supplemental.priority"
+  version: "1.0.0"
+  title: "1.3: supplemental docs act under Agreement and order of precedence"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["1.3","supplemental","purchase_orders","order_of_precedence"]
+  triggers:
+    any:
+      - regex: "(?i)supplemental\\s+document|purchase\\s+order|PO\\b"
+  checks:
+    - id: "missing_precedence_reference"
+      when:
+        all:
+          - regex: "(?i)shall\\s+continue\\s+to\\s+apply"
+          - not_regex: "(?i)subject\\s+to\\s+Clause\\s+2\\.2|order\\s+of\\s+precedence"
+      finding:
+        message: "Supplemental docs continuing post-Call-Off lack order-of-precedence reference."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add 'subject to Clause 2.2 (Order of Precedence)'; POs must not override Agreement."
+        score_delta: -20
+    - id: "po_changes_core_terms"
+      when:
+        any:
+          - regex: "(?i)PO\\s+may\\s+modify\\s+terms|purchase\\s+order\\s+prevails"
+      finding:
+        message: "PO purports to vary/override core Agreement terms."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Clarify POs are for scope/schedule/price only and subordinate to Agreement/Exhibits."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: SupplementalPriorityGap
+    score: 80
+    problem: "Risk of PO overriding Agreement or unclear precedence."
+    recommendation: "Reference Clause 2.2; limit PO to operational details."
+    law_reference: []
+    category: "Supplemental"
+    keywords: ["PO","order of precedence","Clause 2.2"]

--- a/tests/rules/recitals_and_clauses1/test_recitals_and_clauses1.py
+++ b/tests/rules/recitals_and_clauses1/test_recitals_and_clauses1.py
@@ -1,0 +1,56 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+def ai(text, clause="recitals"):
+    return AnalysisInput(clause_type=clause, text=text, metadata={"jurisdiction": "UK", "doc_type": "Master Agreement"})
+
+def test_r1_no_min_purchase_positive():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/01_recitals_no_minimum_purchase.yaml")
+    out = run_rule(spec, ai("Recitals: The parties intend to transact under Call-Offs."))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+def test_r1_no_min_purchase_negative():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/01_recitals_no_minimum_purchase.yaml")
+    out = run_rule(spec, ai("In Recitals, Contractor shall purchase at least 10,000 units per year."))
+    assert out is not None and any("minimum" in f.message.lower() or "volume" in f.message.lower() for f in out.findings)
+
+def test_r2_no_operational_shall_negative():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/02_recitals_no_operational_shall.yaml")
+    out = run_rule(spec, ai("Recitals: Contractor shall perform services."))
+    assert out is not None and any("shall" in f.message.lower() for f in out.findings)
+
+def test_r3_placeholders_negative():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/03_incorp_placeholders_clean.yaml")
+    out = run_rule(spec, AnalysisInput(clause_type="1.1", text="Exhibit J [Amend prior to issuing externally]", metadata={"jurisdiction": "UK", "doc_type": "Master Agreement"}))
+    assert out is not None and any("placeholder" in f.message.lower() or "editorial" in f.message.lower() for f in out.findings)
+
+def test_r4_heavy_terms_notice_negative():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/04_incorp_heavy_terms_notice.yaml")
+    text = "By reference are incorporated Supplier Policies, including limitation of liability and indemnity terms."
+    out = run_rule(spec, AnalysisInput(clause_type="1.1", text=text, metadata={"jurisdiction": "UK", "doc_type": "Master Agreement"}))
+    assert out is not None and any("heavy" in f.message.lower() or "ucta" in f.message.lower() for f in out.findings)
+
+def test_r5_dynamic_refs_change_control_negative():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/05_incorp_dynamic_refs_change_control.yaml")
+    text = "Standards shall apply as may be updated from time to time."
+    out = run_rule(spec, AnalysisInput(clause_type="1.1", text=text, metadata={"jurisdiction": "UK", "doc_type": "Master Agreement"}))
+    assert out is not None and any("change control" in f.message.lower() or "dynamic" in f.message.lower() for f in out.findings)
+
+def test_r6_exhibitj_deed_formalities_negative():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/06_exhibitj_deed_formalities.yaml")
+    text = "Exhibit J: Parent Company Guarantee executed as a deed by authorised signatory."
+    out = run_rule(spec, AnalysisInput(clause_type="exhibit_j", text=text, metadata={"jurisdiction": "UK", "doc_type": "Master Agreement"}))
+    assert out is not None and any("deed" in f.message.lower() or "s.44" in f.message.lower() for f in out.findings)
+
+def test_r7_term_extensions_notices_negative():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/07_term_extensions_notices.yaml")
+    text = "The Company may extend the Term."
+    out = run_rule(spec, AnalysisInput(clause_type="1.2", text=text, metadata={"jurisdiction": "UK", "doc_type": "Master Agreement"}))
+    assert out is not None and any("notice" in f.message.lower() or "term" in f.message.lower() for f in out.findings)
+
+def test_r8_supplemental_priority_negative():
+    spec = load_rule("core/rules/uk/master/recitals_and_clauses1/08_supplemental_docs_priority.yaml")
+    text = "After expiry, any Purchase Order shall continue to apply and shall prevail over this Agreement."
+    out = run_rule(spec, AnalysisInput(clause_type="1.3", text=text, metadata={"jurisdiction": "UK", "doc_type": "Master Agreement"}))
+    assert out is not None and any("precedence" in f.message.lower() or "override" in f.message.lower() for f in out.findings)


### PR DESCRIPTION
## Summary
- add UK master recitals rules for minimum purchase, operative shall, and placeholder cleanup
- check incorporation for heavy terms, dynamic references, and Exhibit J deed formalities
- validate term completeness and supplemental document precedence in clauses 1.2-1.3

## Testing
- `pytest tests/rules/recitals_and_clauses1/test_recitals_and_clauses1.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba903fba1c8325a1a9fe86999269dc