### PR TITLE
fix: wire AI draft button and stabilize proposed textarea

### DIFF
--- a/word_addin_dev/taskpane.bundle.js
+++ b/word_addin_dev/taskpane.bundle.js
@@ -1,4 +1,4 @@
-import { metaFromResponse, applyMetaToBadges, apiHealth, apiAnalyze, apiGptDraft, apiQaRecheck } from "./app/assets/api-client.js";
+import { applyMetaToBadges, apiHealth, apiAnalyze, apiQaRecheck } from "./app/assets/api-client.js";
 import { notifyOk, notifyErr } from "./app/assets/notifier.js";
 import { getWholeDocText } from "./app/assets/office.js";
 
@@ -15,13 +15,6 @@ async function doAnalyzeDoc() {
   try { applyMetaToBadges(meta); } catch {}
   (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.results", { detail: json }));
   notifyOk("Analyze OK");
-}
-
-async function doGptDraft() {
-  const { json, meta } = await apiGptDraft("Ping draft");
-  try { applyMetaToBadges(meta); } catch {}
-  (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.draft", { detail: json }));
-  notifyOk("Draft OK");
 }
 
 async function doQARecheck() {
@@ -42,7 +35,6 @@ function bindClick(sel, fn) {
 function wireUI() {
   bindClick("#btnTest", doHealth);
   bindClick("#btnAnalyzeDoc", doAnalyzeDoc);
-  bindClick("#btnDraft", doGptDraft);
   bindClick("#btnQARecheck", doQARecheck);
   console.log("Panel UI wired");
 }
@@ -62,3 +54,47 @@ async function bootstrap() {
 }
 
 bootstrap();
+
+(function () {
+  function findProposedTextarea() {
+    var el = document.querySelector('#proposedText, textarea[name="proposed"], [data-role="proposed-text"]');
+    if (el) return el;
+    var all = Array.prototype.slice.call(document.querySelectorAll('textarea'));
+    for (var i = 0; i < all.length; i++) {
+      var t = all[i];
+      var around = (t.getAttribute('placeholder') || '') + ' ' +
+                   (t.id || '') + ' ' + (t.name || '') + ' ' +
+                   ((t.closest && t.closest('.card, .form-group, section') || {}).textContent || '');
+      if (/proposed|suggest(ed)? edits|draft/i.test(around)) return t;
+    }
+    return null;
+  }
+  function injectProposedText(text) {
+    var target = findProposedTextarea();
+    if (!target) { window.toast && window.toast('Draft created, but target field not found', 'warn'); return; }
+    target.value = text || '';
+    target.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  async function onGetAIDraft(ev) {
+    ev && ev.preventDefault && ev.preventDefault();
+    var origEl = document.getElementById('originalClause');
+    var original = (origEl && origEl.value || '').trim();
+    var body = { text: original || 'Please propose a neutral confidentiality clause.', mode: 'friendly', before_text: '', after_text: '' };
+    var resp = await fetch('/api/gpt-draft', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    try {
+      var mod = await import('./app/assets/api-client.js');
+      mod.applyMetaToBadges(mod.metaFromResponse(resp));
+    } catch (e) {}
+    var json = await resp.json();
+    window.__last = window.__last || {}; window.__last['/api/gpt-draft'] = { json: json };
+    if (json && json.proposed_text) { injectProposedText(json.proposed_text); window.toast && window.toast('Draft ready', 'success'); }
+    else { window.toast && window.toast('Draft API returned no proposed_text', 'warn'); }
+  }
+  document.addEventListener('DOMContentLoaded', function () {
+    var btn = document.getElementById('btnGetAIDraft') ||
+      Array.prototype.slice.call(document.querySelectorAll('button')).find(function (b) {
+        return /get ai draft/i.test((b.textContent || ''));
+      });
+    if (btn) btn.addEventListener('click', onGetAIDraft, { once: false });
+  });
+})();

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -367,7 +367,14 @@
 
   <div class="row card">
     <div class="muted" style="margin-bottom:6px">Proposed draft (from analysis or edited manually):</div>
-    <textarea id="draftText" placeholder="Will be filled from analysis.proposed_text if provided…"></textarea>
+    <textarea
+  id="proposedText"
+  name="proposed"
+  data-role="proposed-text"
+  class="form-control"
+  rows="8"
+  placeholder="Will be filled from analysis.proposed_text if provided…">
+</textarea>
     <div class="row flex" style="margin-top:8px">
       <button id="btnPreviewDiff" class="btn-grey" disabled>Preview diff</button>
       <button id="btnApplyTracked" class="btn js-disable-while-busy" disabled title="Select text in Word before applying edits.">Apply (tracked + comment)</button>


### PR DESCRIPTION
## Summary
- add stable selector for proposed draft textarea
- wire Get AI Draft button to fetch `/api/gpt-draft`
- update bundle with robust textarea search and injection

## Testing
- `ruff check .`
- `isort --check-only .` *(fails: imports not sorted)*
- `black --check .` *(fails: would reformat many files)*
- `PYTHONPATH=. pytest contract_review_app/tests -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68ba9c77a94483258e70781c6737a96e