### PR TITLE
fix: wire Get AI Draft and stable proposed selector

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -67,4 +67,88 @@ async function bootstrap() {
   try { await doHealth(); } catch {}
 }
 
-bootstrap();
+  bootstrap();
+
+// --- helpers to locate and fill the "Proposed draft" textarea ---
+function findProposedTextarea(): HTMLTextAreaElement | null {
+  const primarySel = '#proposedText, textarea[name="proposed"], [data-role="proposed-text"]';
+  let el = document.querySelector(primarySel) as HTMLTextAreaElement | null;
+  if (el) return el;
+
+  // Фолбэк: ищем textarea по тексту окружения
+  const all = Array.from(document.querySelectorAll<HTMLTextAreaElement>('textarea'));
+  return (
+    all.find((t) => {
+      const around =
+        (t.getAttribute('placeholder') || '') +
+        ' ' +
+        (t.id || '') +
+        ' ' +
+        (t.name || '') +
+        ' ' +
+        (t.closest('.card, .form-group, section')?.textContent || '');
+      return /proposed|suggest(ed)? edits|draft/i.test(around);
+    }) || null
+  );
+}
+
+function injectProposedText(text: string) {
+  const target = findProposedTextarea();
+  if (!target) {
+    // мягкое уведомление: места для вставки не нашли
+    (window as any).toast?.('Draft created, but target field not found', 'warn');
+    return;
+  }
+  target.value = text || '';
+  target.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+// --- handler for "Get AI Draft" ---
+async function onGetAIDraft(ev?: Event) {
+  ev?.preventDefault?.();
+
+  const original =
+    (document.getElementById('originalClause') as HTMLTextAreaElement | null)?.value?.trim() || '';
+
+  const body = {
+    text: original || 'Please propose a neutral confidentiality clause.',
+    mode: 'friendly',
+    before_text: '',
+    after_text: '',
+  };
+
+  const resp = await fetch('/api/gpt-draft', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  // применим мета-бейджи, если они есть
+  try {
+    // эти функции уже есть в api-client.js
+    // @ts-ignore
+    const { metaFromResponse, applyMetaToBadges } = await import('./api-client.js');
+    applyMetaToBadges(metaFromResponse(resp));
+  } catch {}
+
+  const json = await resp.json();
+  (window as any).__last = (window as any).__last || {};
+  (window as any).__last['/api/gpt-draft'] = { json };
+
+  if (json?.proposed_text) {
+    injectProposedText(json.proposed_text);
+    (window as any).toast?.('Draft ready', 'success');
+  } else {
+    (window as any).toast?.('Draft API returned no proposed_text', 'warn');
+  }
+}
+
+// навешиваем обработчик
+document.addEventListener('DOMContentLoaded', () => {
+  const btn =
+    document.getElementById('btnGetAIDraft') ||
+    Array.from(document.querySelectorAll('button')).find((b) =>
+      /get ai draft/i.test(b.textContent || ''),
+    );
+  if (btn) btn.addEventListener('click', onGetAIDraft, { once: false });
+});

--- a/word_addin_dev/taskpane.bundle.js
+++ b/word_addin_dev/taskpane.bundle.js
@@ -61,4 +61,48 @@ async function bootstrap() {
   try { await doHealth(); } catch {}
 }
 
-bootstrap();
+  bootstrap();
+
+(function () {
+  function findProposedTextarea() {
+    var el = document.querySelector('#proposedText, textarea[name="proposed"], [data-role="proposed-text"]');
+    if (el) return el;
+    var all = Array.prototype.slice.call(document.querySelectorAll('textarea'));
+    for (var i = 0; i < all.length; i++) {
+      var t = all[i];
+      var around = (t.getAttribute('placeholder') || '') + ' ' +
+        (t.id || '') + ' ' + (t.name || '') + ' ' +
+        ((t.closest && t.closest('.card, .form-group, section') || {}).textContent || '');
+      if (/proposed|suggest(ed)? edits|draft/i.test(around)) return t;
+    }
+    return null;
+  }
+  function injectProposedText(text) {
+    var target = findProposedTextarea();
+    if (!target) { window.toast && window.toast('Draft created, but target field not found', 'warn'); return; }
+    target.value = text || '';
+    target.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  async function onGetAIDraft(ev) {
+    ev && ev.preventDefault && ev.preventDefault();
+    var origEl = document.getElementById('originalClause');
+    var original = (origEl && origEl.value || '').trim();
+    var body = { text: original || 'Please propose a neutral confidentiality clause.', mode: 'friendly', before_text: '', after_text: '' };
+    var resp = await fetch('/api/gpt-draft', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    try {
+      var mod = await import('./app/assets/api-client.js');
+      mod.applyMetaToBadges(mod.metaFromResponse(resp));
+    } catch (e) {}
+    var json = await resp.json();
+    window.__last = window.__last || {}; window.__last['/api/gpt-draft'] = { json: json };
+    if (json && json.proposed_text) { injectProposedText(json.proposed_text); window.toast && window.toast('Draft ready', 'success'); }
+    else { window.toast && window.toast('Draft API returned no proposed_text', 'warn'); }
+  }
+  document.addEventListener('DOMContentLoaded', function () {
+    var btn = document.getElementById('btnGetAIDraft') ||
+      Array.prototype.slice.call(document.querySelectorAll('button')).find(function (b) {
+        return /get ai draft/i.test((b.textContent || ''));
+      });
+    if (btn) btn.addEventListener('click', onGetAIDraft, { once: false });
+  });
+})();

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -249,7 +249,7 @@
     <div class="row flex" style="margin-top:8px">
       <button id="analyzeBtn" class="btn-grey js-disable-while-busy">Analyze</button>
       <button id="btnReplay" class="btn-grey js-disable-while-busy">Replay last</button>
-      <button id="draftBtn" class="btn js-disable-while-busy">Get AI Draft</button>
+      <button id="btnGetAIDraft" class="btn js-disable-while-busy">Get AI Draft</button>
       <button id="copyResultBtn" class="btn-grey js-disable-while-busy">Copy result</button>
     </div>
     <div class="row">
@@ -367,7 +367,14 @@
 
   <div class="row card">
     <div class="muted" style="margin-bottom:6px">Proposed draft (from analysis or edited manually):</div>
-    <textarea id="draftText" placeholder="Will be filled from analysis.proposed_text if provided…"></textarea>
+    <textarea
+      id="proposedText"
+      name="proposed"
+      data-role="proposed-text"
+      class="form-control"
+      rows="8"
+      placeholder="Will be filled from analysis.proposed_text if provided…">
+    </textarea>
     <div class="row flex" style="margin-top:8px">
       <button id="btnPreviewDiff" class="btn-grey" disabled>Preview diff</button>
       <button id="btnApplyTracked" class="btn js-disable-while-busy" disabled title="Select text in Word before applying edits.">Apply (tracked + comment)</button>


### PR DESCRIPTION
## Summary
- attach Get AI Draft handler and robust textarea lookup
- expose proposed draft textarea with stable attributes
- mirror changes in compiled bundle

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'starlette')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba9c9a4be48325a996a0775092cd0e