### PR TITLE
Add B-block IP and Call-Off compliance rules with tests

### DIFF
--- a/core/rules/uk/calloff/01_calloff_exclude_other_terms.yaml
+++ b/core/rules/uk/calloff/01_calloff_exclude_other_terms.yaml
@@ -1,0 +1,56 @@
+rule:
+  id: "uk.calloff.exclude_other_terms"
+  version: "1.0.0"
+  title: "Call-Off: exclude other T&Cs and reference order of precedence"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["call-off","orders","clause_2_2"]
+  triggers:
+    any:
+      - regex: "(?i)Call[-\\s]?Off|Purchase\\s+Order\\b|Order\\b"
+  checks:
+    - id: "no_exclusion_of_other_terms"
+      when:
+        all:
+          - regex: "(?i)Call[-\\s]?Off|Order"
+          - not_regex: "(?i)no\\s+other\\s+terms|exclude[s]?\\s+(all\\s+)?other\\s+terms|exclude[s]?\\s+(the\\s+)?Contractor'?s?\\s+terms|terms\\s+and\\s+conditions\\s+do\\s+not\\s+apply"
+      finding:
+        message: "No explicit exclusion of the counterparty T&Cs for Call-Offs (battle of forms risk)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "State that no other terms (including Contractor T&Cs) apply; Call-Offs are subject to Clause 2.2 (Order of Precedence)."
+        score_delta: -25
+    - id: "no_precedence_link"
+      when:
+        all:
+          - regex: "(?i)Call[-\\s]?Off|Order"
+          - not_regex: "(?i)Clause\\s*2\\.2|Order\\s+of\\s+Precedence"
+      finding:
+        message: "No link to Order of Precedence for Call-Offs."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Reference Clause 2.2 to ensure Call-Offs cannot override core terms."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CallOffExclusionGap
+    score: 80
+    problem: "Call-Offs may import third-party terms or lack precedence control."
+    recommendation: "Add exclusion of other T&Cs and link to Clause 2.2."
+    law_reference: []
+    category: "Call-Off"
+    keywords: ["battle of forms","exclusion","precedence"]
+metadata:
+  tags: ["call-off","precedence"]
+  tests:
+    positive:
+      - "Each Call-Off excludes all other terms and conditions (including Contractor terms) and is subject to Clause 2.2 (Order of Precedence)."
+    negative:
+      - "A Call-Off Order may apply with the Contractor’s terms."

--- a/core/rules/uk/calloff/02_calloff_formation_by_performance_controls.yaml
+++ b/core/rules/uk/calloff/02_calloff_formation_by_performance_controls.yaml
@@ -1,0 +1,43 @@
+rule:
+  id: "uk.calloff.formation_by_performance_controls"
+  version: "1.0.0"
+  title: "Call-Off: formation by performance requires explicit controls and precedence"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["call-off","orders","formation","precedence"]
+  triggers:
+    any:
+      - regex: "(?i)effective\\s+upon\\s+performance|acceptance\\s+by\\s+performance|upon\\s+commencement\\s+of\\s+Work"
+  checks:
+    - id: "no_controls_for_performance_acceptance"
+      when:
+        any:
+          - not_regex: "(?i)subject\\s+to\\s+Clause\\s*2\\.2|Order\\s+of\\s+Precedence"
+          - not_regex: "(?i)no\\s+other\\s+terms|exclude[s]?\\s+(all\\s+)?other\\s+terms|Contractor'?s?\\s+terms\\s+do\\s+not\\s+apply"
+      finding:
+        message: "Acceptance by performance without precedence control and exclusion of other terms."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "If performance forms a Call-Off, state it is subject to Clause 2.2 and excludes other T&Cs."
+        score_delta: -25
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CallOffPerformanceFormationRisk
+    score: 80
+    problem: "Performance-based formation may import unintended terms."
+    recommendation: "Gate performance-formation by precedence and T&C exclusion."
+    law_reference: []
+    category: "Call-Off"
+    keywords: ["performance acceptance","precedence","exclusion"]
+metadata:
+  tags: ["call-off","formation"]
+  tests:
+    positive:
+      - "A Call-Off may be accepted by performance, provided it excludes all other terms and is subject to Clause 2.2 (Order of Precedence)."
+    negative:
+      - "A Call-Off becomes effective upon commencement of Work."

--- a/core/rules/uk/calloff/03_calloff_minimum_content.yaml
+++ b/core/rules/uk/calloff/03_calloff_minimum_content.yaml
@@ -1,0 +1,46 @@
+rule:
+  id: "uk.calloff.minimum_content"
+  version: "1.0.0"
+  title: "Call-Off: minimum content must include parties, scope, price and schedule"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["call-off","orders","content"]
+  triggers:
+    any:
+      - regex: "(?i)Call[-\\s]?Off|Order\\b"
+  checks:
+    - id: "missing_minimum_elements"
+      when:
+        all:
+          - regex: "(?i)Call[-\\s]?Off|Order\\b"
+          - not_regex: "(?i)parties|between\\s+the\\s+Company\\s+and\\s+the\\s+Contractor"
+          - not_regex: "(?i)scope|description|Work|Goods"
+          - not_regex: "(?i)price|rates|compensation|charge"
+          - not_regex: "(?i)schedule|programme|delivery\\s+date"
+      finding:
+        message: "Call-Off definition lacks one or more minimum elements (parties/scope/price/schedule)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Ensure each Call-Off states parties, scope/description, price/rates and schedule/delivery."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CallOffContentGap
+    score: 80
+    problem: "Minimum content for Call-Off not enforced."
+    recommendation: "Add explicit list of mandatory elements."
+    law_reference: []
+    category: "Call-Off"
+    keywords: ["content","parties","scope","price","schedule"]
+metadata:
+  tags: ["call-off","content"]
+  tests:
+    positive:
+      - "Each Call-Off identifies the parties, describes the Work, sets the price/rates and includes a schedule."
+    negative:
+      - "Call-Off means an order issued by the Company."

--- a/core/rules/uk/definitions/b_block/01_bipr_perimeter_and_license.yaml
+++ b/core/rules/uk/definitions/b_block/01_bipr_perimeter_and_license.yaml
@@ -1,0 +1,74 @@
+rule:
+  id: "uk.def.bipr.perimeter_and_license"
+  version: "1.0.0"
+  title: "BIPR: perimeter tightness and licence to exploit results"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","ip","bipr","foreground","clause_17"]
+    industries: ["generic","oil_gas"]
+  triggers:
+    any:
+      - regex: "(?i)Background\\s+Intellectual\\s+Property|BIPR\\b"
+  checks:
+    - id: "foreground_excludes_bipr"
+      when:
+        all:
+          - regex: "(?i)Foreground"
+          - not_regex: "(?i)Foreground\\s+excludes\\s+Background|does\\s+not\\s+include\\s+BIPR"
+      finding:
+        message: "Foreground IPR does not explicitly exclude BIPR."
+        severity_level: "major"
+        risk: "high"
+        legal_basis:
+          - "Commercial certainty of title/licence split"
+        suggestion:
+          text: "State expressly that Foreground excludes Background IPR and modifications thereof unless agreed."
+        score_delta: -15
+    - id: "no_bipr_licence_for_exploitation"
+      when:
+        all:
+          - regex: "(?i)Background\\s+Intellectual\\s+Property|BIPR\\b"
+          - not_regex: "(?i)royalty[-\\s]?free|perpetual|worldwide|irrevocable"
+          - not_regex: "(?i)licen[cs]e\\s+to\\s+(use|copy|modify|maintain|repair|integrate)"
+      finding:
+        message: "No explicit licence over BIPR to operate/maintain/modify the results; lock-in risk."
+        severity_level: "major"
+        risk: "high"
+        legal_basis:
+          - "CDPA 1988 s.90 (assignment in writing)"
+          - "Database Regulations 1997 (database right)"
+        suggestion:
+          text: "Grant irrevocable, perpetual, worldwide, royalty-free licence over BIPR for use/support/repair/modification/integration within the Company Group."
+        score_delta: -25
+    - id: "mods_of_bipr_unclear"
+      when:
+        any:
+          - regex: "(?i)modif(ication|y|ications)\\s+of\\s+BIPR"
+          - regex: "(?i)adapt(ation|)\\s+of\\s+BIPR"
+      finding:
+        message: "Treatment of modifications/adaptations of BIPR during the Work is unclear."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Clarify whether Work-made modifications to BIPR remain BIPR (with broad licence) or become Foreground; align with clause 17 and Exhibit L."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: BIPRPerimeterAndLicenceGap
+    score: 80
+    problem: "BIPR/Foreground boundary or BIPR licence insufficiently defined."
+    recommendation: "Exclude BIPR from Foreground; grant broad BIPR licence; define treatment of modifications."
+    law_reference: ["CDPA 1988 s.90","Database Regs 1997"]
+    category: "Definitions"
+    keywords: ["BIPR","Foreground","licence","modifications","Company Group"]
+metadata:
+  tags: ["ip","bipr","licence"]
+  tests:
+    positive:
+      - "Foreground excludes Background Intellectual Property. Company has a perpetual, worldwide, royalty-free licence to use, maintain, modify and integrate BIPR within the Company Group."
+    negative:
+      - "Background Intellectual Property includes all IP and modifications. Foreground shall include all created during the Work."

--- a/core/rules/uk/definitions/b_block/02_bribe_ukba_poca_fcpa.yaml
+++ b/core/rules/uk/definitions/b_block/02_bribe_ukba_poca_fcpa.yaml
@@ -1,0 +1,71 @@
+rule:
+  id: "uk.def.bribe.ukba_poca_fcpa"
+  version: "1.0.0"
+  title: "Bribe: UKBA s.1-2-6-7 & adequate procedures; POCA/FCPA; flow-down and audit/remedies"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","anti-bribery","compliance","audit","termination","subcontracting"]
+  triggers:
+    any:
+      - regex: "(?i)Bribe|Anti[-\\s]?Bribery"
+  checks:
+    - id: "ukba_core_missing"
+      when:
+        any:
+          - not_regex: "(?i)section\\s*7|failure\\s+to\\s+prevent"
+          - not_regex: "(?i)adequate\\s+procedures"
+          - not_regex: "(?i)facilitation\\s+payments?\\s+(are\\s+)?prohibit(ed|s)?"
+      finding:
+        message: "UKBA coverage weak: missing s.7 failure to prevent / adequate procedures / ban on facilitation payments."
+        severity_level: "major"
+        risk: "high"
+        legal_basis:
+          - "UK Bribery Act 2010 (s.1, s.2, s.6, s.7)"
+        suggestion:
+          text: "Add s.7 and adequate procedures; explicitly prohibit facilitation payments and regulate hospitality."
+        score_delta: -25
+    - id: "poca_fcpa_missing"
+      when:
+        any:
+          - not_regex: "(?i)Proceeds\\s+of\\s+Crime\\s+Act|POCA"
+          - not_regex: "(?i)FCPA|books\\s+and\\s+records|internal\\s+controls"
+      finding:
+        message: "POCA/FCPA not referenced (AML/confiscation; books & records/internal controls)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Reference POCA AML/confiscation and FCPA books & records/internal controls obligations."
+        score_delta: -15
+    - id: "no_flowdown_audit_remedies"
+      when:
+        any:
+          - not_regex: "(?i)associated\\s+persons|flow[-\\s]?down|subcontractor"
+          - not_regex: "(?i)audit|inspect|withhold|suspend|termination\\s+for\\s+breach"
+      finding:
+        message: "No flow-down to associated persons or no audit/withholding/termination remedies."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Flow-down obligations to subcontractors/agents; add audit rights and termination/withholding on breach or investigation."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: BriberyCoverageGap
+    score: 80
+    problem: "Bribe/anti-bribery coverage incomplete."
+    recommendation: "Add UKBA s.7/adequate procedures, POCA/FCPA, flow-down and remedies."
+    law_reference: ["UKBA 2010","POCA 2002","FCPA"]
+    category: "Definitions"
+    keywords: ["bribe","UKBA s.7","POCA","FCPA","flow-down","audit"]
+metadata:
+  tags: ["compliance","anti-bribery"]
+  tests:
+    positive:
+      - "Anti-Bribery Laws include UKBA 2010 (including section 7 failure to prevent and adequate procedures), POCA 2002 and the US FCPA (books and records/internal controls), with flow-down to associated persons and audit/termination rights."
+    negative:
+      - "Bribe means any improper payment under applicable anti-corruption laws."

--- a/core/rules/uk/definitions/b_block/03_business_day_precision.yaml
+++ b/core/rules/uk/definitions/b_block/03_business_day_precision.yaml
@@ -1,0 +1,69 @@
+rule:
+  id: "uk.def.business_day.precision"
+  version: "1.0.0"
+  title: "Business Day: jurisdictional calendar, cut-off time, and Notices link"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","NDA"]
+    clauses: ["definitions","business day","notices","payments"]
+  triggers:
+    any:
+      - regex: "(?i)Business\\s+Day\\s+means"
+  checks:
+    - id: "no_jurisdiction_or_bank_holidays"
+      when:
+        any:
+          - not_regex: "(?i)England\\s+and\\s+Wales|Clause\\s*29\\.3|Company\\s+address"
+          - not_regex: "(?i)Banking\\s+and\\s+Financial\\s+Dealings\\s+Act\\s*1971|bank\\s+holiday"
+      finding:
+        message: "Business Day lacks clear jurisdictional calendar reference (E&W/bank holidays)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Anchor to England and Wales bank holidays (Banking and Financial Dealings Act 1971) or Clause 29.3 address."
+        score_delta: -15
+    - id: "no_cutoff_time"
+      when:
+        all:
+          - regex: "(?i)Business\\s+Day"
+          - not_regex: "(?i)17:00|5\\.?00\\s*pm|close\\s+of\\s+business"
+      finding:
+        message: "Cut-off time for Business Day not specified (risk for deemed receipt/payments)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Specify 17:00 UK time (or close of business) for notices/payments/deemed receipt."
+        score_delta: -15
+    - id: "no_notices_link"
+      when:
+        all:
+          - regex: "(?i)Business\\s+Day"
+          - not_regex: "(?i)Clause\\s*29|Notices"
+      finding:
+        message: "No link to Notices clause for deemed receipt mechanics."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Reference Clause 29 (Notices) so Business Day aligns with delivery mechanics."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: BusinessDayImprecision
+    score: 80
+    problem: "Business Day definition lacks jurisdiction, cut-off time or Notices link."
+    recommendation: "Anchor to E&W calendar, add 17:00 cut-off, cross-link to Clause 29."
+    law_reference: ["Banking and Financial Dealings Act 1971"]
+    category: "Definitions"
+    keywords: ["Business Day","bank holidays","cut-off","Notices"]
+metadata:
+  tags: ["timing","notices"]
+  tests:
+    positive:
+      - "Business Day means a day other than Saturday, Sunday or a public holiday in England and Wales (under the Banking and Financial Dealings Act 1971); ends at 17:00 UK time; references Clause 29 for deemed receipt."
+    negative:
+      - "Business Day means any day other than Saturday or Sunday."

--- a/tests/rules/definitions/test_b_block_and_calloff.py
+++ b/tests/rules/definitions/test_b_block_and_calloff.py
@@ -1,0 +1,88 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+def AI(text, clause="definitions", doc="Master Agreement"):
+    return AnalysisInput(clause_type=clause, text=text, metadata={"jurisdiction":"UK","doc_type":doc})
+
+# 1) BIPR
+def test_bipr_negative_no_licence_and_boundary():
+    spec = load_rule("core/rules/uk/definitions/b_block/01_bipr_perimeter_and_license.yaml")
+    t = "Background Intellectual Property includes all IP and modifications. Foreground shall include all created during the Work."
+    out = run_rule(spec, AI(t))
+    assert out is not None and len(out.findings) >= 1
+
+def test_bipr_positive_clear_boundary_and_licence():
+    spec = load_rule("core/rules/uk/definitions/b_block/01_bipr_perimeter_and_license.yaml")
+    t = ("Foreground excludes Background Intellectual Property. Company has a perpetual, worldwide, royalty-free licence "
+         "to use, maintain, modify and integrate BIPR within the Company Group.")
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 2) Bribe
+def test_bribe_negative_missing_ukba7_poca_fcpa_flowdown():
+    spec = load_rule("core/rules/uk/definitions/b_block/02_bribe_ukba_poca_fcpa.yaml")
+    t = "Bribe means any improper payment under applicable anti-corruption laws."
+    out = run_rule(spec, AI(t, clause="definitions"))
+    assert out is not None and any("ukba coverage weak" in f.message.lower() or "poca" in f.message.lower() or "flow-down" in (f.suggestion.text.lower() if getattr(f, 'suggestion', None) else "") for f in out.findings)
+
+def test_bribe_positive_full_coverage():
+    spec = load_rule("core/rules/uk/definitions/b_block/02_bribe_ukba_poca_fcpa.yaml")
+    t = ("Anti-Bribery Laws include the UK Bribery Act 2010 (including section 7 failure to prevent and adequate procedures), "
+         "POCA 2002 and the US FCPA (books and records/internal controls), with flow-down to associated persons and audit/termination rights; "
+         "facilitation payments are prohibited.")
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 3) Business Day
+def test_business_day_negative_generic():
+    spec = load_rule("core/rules/uk/definitions/b_block/03_business_day_precision.yaml")
+    t = "Business Day means any day other than Saturday or Sunday."
+    out = run_rule(spec, AI(t))
+    assert out is not None and len(out.findings) >= 1
+
+def test_business_day_positive_precise():
+    spec = load_rule("core/rules/uk/definitions/b_block/03_business_day_precision.yaml")
+    t = ("Business Day means a day other than Saturday, Sunday or a public holiday in England and Wales "
+         "(under the Banking and Financial Dealings Act 1971); ends at 17:00 UK time; references Clause 29 for deemed receipt.")
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 4) Call-Off — exclusion/precedence
+def test_calloff_negative_no_exclusion_or_precedence():
+    spec = load_rule("core/rules/uk/calloff/01_calloff_exclude_other_terms.yaml")
+    t = "A Call-Off Order may apply with the Contractor’s terms."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is not None and any("exclusion" in f.message.lower() or "precedence" in f.message.lower() for f in out.findings)
+
+def test_calloff_positive_exclusion_and_precedence():
+    spec = load_rule("core/rules/uk/calloff/01_calloff_exclude_other_terms.yaml")
+    t = "Each Call-Off excludes all other terms and conditions (including Contractor terms) and is subject to Clause 2.2 (Order of Precedence)."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 5) Call-Off — formation by performance
+def test_calloff_negative_performance_no_controls():
+    spec = load_rule("core/rules/uk/calloff/02_calloff_formation_by_performance_controls.yaml")
+    t = "A Call-Off becomes effective upon commencement of Work."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is not None and any("acceptance by performance" in f.message.lower() or "precedence" in (f.suggestion.text.lower() if getattr(f, 'suggestion', None) else "") for f in out.findings)
+
+def test_calloff_positive_performance_with_controls():
+    spec = load_rule("core/rules/uk/calloff/02_calloff_formation_by_performance_controls.yaml")
+    t = "A Call-Off may be accepted by performance, provided it excludes all other terms and is subject to Clause 2.2 (Order of Precedence)."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 6) Call-Off — minimum content
+def test_calloff_negative_minimum_content():
+    spec = load_rule("core/rules/uk/calloff/03_calloff_minimum_content.yaml")
+    t = "Call-Off means an order issued by the Company."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is not None and any("minimum elements" in f.message.lower() for f in out.findings)
+
+def test_calloff_positive_minimum_content():
+    spec = load_rule("core/rules/uk/calloff/03_calloff_minimum_content.yaml")
+    t = "Each Call-Off identifies the parties, describes the Work, sets the price/rates and includes a schedule."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0


### PR DESCRIPTION
## Summary
- define BIPR perimeter and license rule
- add anti-bribery coverage, POCA/FCPA and flow-down checks
- clarify Business Day definition and Call-Off controls

## Testing
- `pytest tests/rules/definitions/test_b_block_and_calloff.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba9f849af48325b8eca6d4db3bc9bc