### PR TITLE
Add UK definitions I-to-P rules and tests

### DIFF
--- a/core/rules/uk/definitions/i_to_p_block/01_importer_of_record.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/01_importer_of_record.yaml
@@ -1,0 +1,63 @@
+rule:
+  id: "uk.def.ior.calloff_requirements"
+  version: "1.0.0"
+  title: "Importer of Record: assignment in each Call-Off; EORI; compliance duties"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","call-off","logistics","imports","tax"]
+    industries: ["generic","oil_gas"]
+  triggers:
+    any:
+      - regex: "(?i)Importer\\s+of\\s+Record|\\bIoR\\b"
+      - regex: "(?i)Call[-\\s]?Off"
+  checks:
+    - id: "ior_not_assigned_in_calloff"
+      when:
+        all:
+          - regex: "(?i)Importer\\s+of\\s+Record|\\bIoR\\b"
+          - not_regex: "(?i)Call[-\\s]?Off.*(?:assign|designat|specif)"
+      finding:
+        message: "IoR is defined but not expressly assigned per Call-Off."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State that each Call-Off specifies the Importer of Record party."
+        score_delta: -20
+    - id: "eori_missing"
+      when:
+        all:
+          - regex: "(?i)Importer\\s+of\\s+Record|\\bIoR\\b"
+          - not_regex: "(?i)\\bGB[0-9]{9,15}\\b|\\bXI[0-9]{9,15}\\b|EORI"
+      finding:
+        message: "EORI not provided for IoR (GB… / XI…)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Capture EORI (GB…; XI… when movement via NI), import jurisdiction, and who pays VAT/duties."
+        score_delta: -20
+    - id: "compliance_duties_missing"
+      when:
+        any:
+          - not_regex: "(?i)declarations|customs|SDE|simplified\\s+declaration"
+          - not_regex: "(?i)records?\\s+retention\\s*(?:of|for)?\\s*(?:at\\s+least\\s*)?4\\s*years?"
+      finding:
+        message: "IoR duties (declarations/SDE/records ≥4y) not articulated."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add duties: lodge declarations, SDE only if authorised, retain customs records ≥ 4 years."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: IoRComplianceGap
+    score: 80
+    problem: "IoR not fully specified at Call-Off level or lacks EORI/compliance duties."
+    recommendation: "Assign IoR per Call-Off; include EORI, duties, records retention and VAT/duties payer."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["IoR","EORI","Call-Off","SDE","customs","records 4y"]
+metadata:
+  tags: ["imports","tax","ior"]

--- a/core/rules/uk/definitions/i_to_p_block/02_indemnify_controls.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/02_indemnify_controls.yaml
@@ -1,0 +1,61 @@
+rule:
+  id: "uk.def.indemnify.controls_and_negligence"
+  version: "1.0.0"
+  title: "Indemnify: include defend; defence control & settlement consent; negligence test"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","indemnity","liability","insurance","ip"]
+  triggers:
+    any:
+      - regex: "(?i)defend,?\\s*indemnif(y|ies)|hold\\s+harmless|release"
+  checks:
+    - id: "defend_missing"
+      when:
+        all:
+          - regex: "(?i)indemnif(y|ies)|hold\\s+harmless|release"
+          - not_regex: "(?i)defend"
+      finding:
+        message: "Indemnity lacks 'defend' obligation (control and funding of defence)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add 'defend' and align with defence control, settlement consent and mitigation."
+        score_delta: -20
+    - id: "no_defence_control_or_consent"
+      when:
+        any:
+          - not_regex: "(?i)(control(?:s)?\\s+the\\s+defen[cs]e|control\\s+of\\s+defen[cs]e|conduct\\s+of\\s+defen[cs]e)"
+          - not_regex: "(?i)consent\\s+to\\s+any\\s+settlement|no\\s+settlement\\s+without\\s+(prior\\s+)?written\\s+consent"
+      finding:
+        message: "No express defence control or settlement consent mechanics."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Specify who controls defence and require prior written consent for settlement."
+        score_delta: -20
+    - id: "canada_steamship_negligence"
+      when:
+        all:
+          - regex: "(?i)indemnif(y|ies)"
+          - not_regex: "(?i)negligence|howsoever\\s+caused|own\\s+negligence"
+      finding:
+        message: "Indemnity may not clearly address beneficiary’s own negligence (Canada Steamship test)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Clarify whether negligence is included/excluded to meet the Canada Steamship standard."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: IndemnityControlsGap
+    score: 80
+    problem: "Indemnity lacks defend/control/consent and clarity on negligence."
+    recommendation: "Add defend/control/consent; clarify negligence; align with caps, knock-for-knock and exclusions."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["indemnify","defend","settlement consent","negligence"]
+metadata:
+  tags: ["indemnity","liability"]

--- a/core/rules/uk/definitions/i_to_p_block/03_ip_rights_coverage.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/03_ip_rights_coverage.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.def.iprights.coverage_and_moral_rights"
+  version: "1.0.0"
+  title: "IP Rights: full world-wide coverage; database right; assignment & moral rights"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","NDA"]
+    clauses: ["definitions","ip","clause_17"]
+  triggers:
+    any:
+      - regex: "(?i)Intellectual\\s+Property\\s+Rights|IP\\s+Rights"
+  checks:
+    - id: "database_right_missing"
+      when:
+        all:
+          - regex: "(?i)database|databases"
+          - not_regex: "(?i)database\\s+right|1997"
+      finding:
+        message: "Definition mentions databases but omits UK database right."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add UK database right (1997 Regulations) to the list."
+        score_delta: -15
+    - id: "assignment_and_moral_rights_missing"
+      when:
+        any:
+          - not_regex: "(?i)assignment\\s+in\\s+writing|assign\\s+in\\s+writing"
+          - not_regex: "(?i)waiver\\s+of\\s+moral\\s+rights|moral\\s+rights\\s+waiv"
+      finding:
+        message: "Assignment in writing and/or waiver of moral rights not surfaced."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Ensure clause 17 requires assignment in writing (CDPA s.90) and waiver of moral rights (CDPA s.77–87)."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: IPRightsCoverageGap
+    score: 80
+    problem: "IPR definition lacks database right and/or assignment/moral rights mechanics."
+    recommendation: "Add database right; ensure assignment-in-writing and moral rights waiver are in clause 17."
+    law_reference: ["CDPA 1988 s.90","CDPA 1988 s.77–87"]
+    category: "Definitions"
+    keywords: ["IP Rights","database right","assignment","moral rights"]
+metadata:
+  tags: ["ip","database","assignment"]

--- a/core/rules/uk/definitions/i_to_p_block/04_invitee_scope.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/04_invitee_scope.yaml
@@ -1,0 +1,51 @@
+rule:
+  id: "uk.def.invitee.scope_and_exclusions"
+  version: "1.0.0"
+  title: "Invitee: exclude regulators; do not conflate with tort categories"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","hse","site","liability"]
+    industries: ["oil_gas","generic"]
+  triggers:
+    any:
+      - regex: "(?i)Invitee"
+  checks:
+    - id: "regulators_as_invitees"
+      when:
+        all:
+          - regex: "(?i)Invitee"
+          - regex: "(?i)Regulator|Governmental\\s+Authority|Official"
+          - not_regex: "(?i)not\\s+an\\s+Invitee|excluded"
+      finding:
+        message: "Officials/Regulators must not be Invitees for risk allocation."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State that Governmental Authorities/Officials are not Invitees of either party."
+        score_delta: -20
+    - id: "tort_conflation"
+      when:
+        all:
+          - regex: "(?i)invitee|licensee"
+          - not_regex: "(?i)Occupiers'?\\s+Liability\\s+Act\\s+1957|OLA\\s*1957|common\\s+duty\\s+of\\s+care"
+      finding:
+        message: "Contract term appears to rely on outdated tort categories."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Keep contractual 'Invitee' distinct; do not rely on common law invitee/licensee taxonomy."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: InviteeScopeGap
+    score: 85
+    problem: "Invitee definition risks including regulators or conflating tort categories."
+    recommendation: "Exclude regulators; keep separate from OLA 1957 tort framework."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Invitee","Regulator","OLA 1957"]
+metadata:
+  tags: ["hse","site","liability"]

--- a/core/rules/uk/definitions/i_to_p_block/05_ip_rights_claim_mechanics.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/05_ip_rights_claim_mechanics.yaml
@@ -1,0 +1,60 @@
+rule:
+  id: "uk.def.ipclaim.mechanics_and_carveouts"
+  version: "1.0.0"
+  title: "IP Rights Claim: defence/notice/remedies; carve-outs; caps"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","ip","indemnity","remedies"]
+  triggers:
+    any:
+      - regex: "(?i)IP\\s+Rights?\\s+Claim|Intellectual\\s+Property\\s+Claim"
+  checks:
+    - id: "no_defence_or_notice"
+      when:
+        any:
+          - not_regex: "(?i)defend"
+          - not_regex: "(?i)notify\\s+within\\s+\\d+\\s+days|prompt\\s+notice"
+      finding:
+        message: "IP claim lacks defence obligation and/or prompt notice period."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add defence obligation and a defined notice window."
+        score_delta: -20
+    - id: "no_remedy_suite"
+      when:
+        all:
+          - not_regex: "(?i)replace|modify|procure\\s+a\\s+licen[cs]e"
+      finding:
+        message: "No remedy suite (replace/modify/licence) defined."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Provide standard remedies: replace, modify to avoid infringement, or procure a licence."
+        score_delta: -15
+    - id: "no_carveouts_for_combination_mod"
+      when:
+        all:
+          - not_regex: "(?i)combination|combined\\s+with\\s+non[-\\s]?Contractor"
+          - not_regex: "(?i)Company\\s+modif(y|ications?)|changes\\s+by\\s+Company"
+      finding:
+        message: "No carve-outs for combinations or Company modifications/spec changes."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Exclude liabilities where infringement arises from combinations or Company modifications/specs."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: IPClaimMechanicsGap
+    score: 80
+    problem: "IP claim mechanics incomplete."
+    recommendation: "Add defence/notice/remedies and carve-outs; align with caps/exclusions."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["IP claim","remedies","carve-outs"]
+metadata:
+  tags: ["ip","indemnity"]

--- a/core/rules/uk/definitions/i_to_p_block/06_key_personnel_controls.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/06_key_personnel_controls.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.def.key_personnel.list_ld_controls"
+  version: "1.0.0"
+  title: "Key Personnel: listed per Call-Off; removal consent; LDs proportional"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","call-off","personnel","ld","liquidated damages"]
+  triggers:
+    any:
+      - regex: "(?i)Key\\s+Personnel"
+  checks:
+    - id: "not_listed_in_calloff"
+      when:
+        all:
+          - regex: "(?i)Key\\s+Personnel"
+          - not_regex: "(?i)listed\\s+in\\s+each\\s+Call[-\\s]?Off|schedule\\s+of\\s+Key\\s+Personnel"
+      finding:
+        message: "Key Personnel not scheduled per Call-Off."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Attach list per Call-Off; require Company approval for changes."
+        score_delta: -15
+    - id: "no_consent_or_ld_rule"
+      when:
+        any:
+          - not_regex: "(?i)no\\s+removal|withdraw(al)?\\s+without\\s+prior\\s+written\\s+consent"
+          - not_regex: "(?i)liquidated\\s+damages|LDs"
+      finding:
+        message: "No removal consent and/or LDs not addressed."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Require consent for removal; if LDs apply, justify via legitimate interest and proportionality."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: KeyPersonnelControlsGap
+    score: 80
+    problem: "Key Personnel governance incomplete."
+    recommendation: "Schedule names; require consent; ensure LDs proportionate (Cavendish test)."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Key Personnel","LD","consent"]
+metadata:
+  tags: ["personnel","ld"]

--- a/core/rules/uk/definitions/i_to_p_block/07_legal_fault_consistency.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/07_legal_fault_consistency.yaml
@@ -1,0 +1,50 @@
+rule:
+  id: "uk.def.legal_fault.fm_indemnities_consistency"
+  version: "1.0.0"
+  title: "Legal Fault: consistency across Force Majeure and Indemnities/Knock-for-Knock"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","force majeure","indemnity","knock-for-knock"]
+  triggers:
+    any:
+      - regex: "(?i)Legal\\s+Fault|fault\\s+of\\s+a\\s+party"
+  checks:
+    - id: "fm_excludes_fault_missing"
+      when:
+        all:
+          - regex: "(?i)Force\\s+Majeure"
+          - not_regex: "(?i)shall\\s+not\\s+apply\\s+to\\s+events\\s+caused\\s+by\\s+the\\s+fault"
+      finding:
+        message: "FM does not clearly exclude events caused by a party’s own fault."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add carve-out: FM excludes events caused by the affected party’s fault."
+        score_delta: -15
+    - id: "indemnities_fault_irreconcilable"
+      when:
+        all:
+          - regex: "(?i)regardless\\s+of\\s+fault|without\\s+regard\\s+to\\s+fault"
+          - regex: "(?i)Force\\s+Majeure"
+          - not_regex: "(?i)for\\s+the\\s+avoidance\\s+of\\s+doubt|prevail(s)?"
+      finding:
+        message: "Potential inconsistency: indemnities apply regardless of fault while FM treats fault differently."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Clarify precedence and causal pathways between FM and knock-for-knock indemnities."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: LegalFaultInconsistency
+    score: 85
+    problem: "Fault concept may be inconsistent between FM and indemnities."
+    recommendation: "Align FM fault carve-out and KFK wording; add precedence note."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Force Majeure","fault","knock-for-knock"]
+metadata:
+  tags: ["fm","indemnity"]

--- a/core/rules/uk/definitions/i_to_p_block/08_nonconformity_vs_defect.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/08_nonconformity_vs_defect.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.def.nonconformity.scope_and_priority"
+  version: "1.0.0"
+  title: "Nonconformity: align with Defect; priority of stricter standard (MT Højgaard)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","quality","defect","acceptance","codes"]
+  triggers:
+    any:
+      - regex: "(?i)Nonconform(ity|ing)"
+  checks:
+    - id: "conflict_with_defect"
+      when:
+        all:
+          - regex: "(?i)Nonconform(ity|ing)"
+          - not_regex: "(?i)Nonconformity\\s+includes\\s+Defect|Defect\\s+includes\\s+Nonconformity|aligns?\\s+with\\s+Defect"
+      finding:
+        message: "Relationship of Nonconformity vs Defect not stated."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Define alignment (one includes the other) to avoid gaps."
+        score_delta: -15
+    - id: "no_priority_fitness_vs_codes"
+      when:
+        all:
+          - regex: "(?i)fitness\\s+for\\s+purpose|Codes?\\s+and\\s+Standards"
+          - not_regex: "(?i)stricter.*prevails|highest\\s+applicable\\s+standard"
+      finding:
+        message: "Priority between fitness-for-purpose and codes not stated."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State that the stricter requirement prevails (per MT Højgaard logic)."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: NonconformityPriorityGap
+    score: 80
+    problem: "Nonconformity/Defect scope and priority unclear."
+    recommendation: "Align terms; specify priority of stricter standard."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Nonconformity","Defect","fitness","codes"]
+metadata:
+  tags: ["quality","defect"]

--- a/core/rules/uk/definitions/i_to_p_block/09_parties_calloff_specificity.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/09_parties_calloff_specificity.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.def.parties.calloff_specificity_crtpa"
+  version: "1.0.0"
+  title: "Parties: specific entities per Call-Off; agent scope; CRTPA carve-outs"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","parties","call-off","third party rights","agency"]
+  triggers:
+    any:
+      - regex: "(?i)Parties?|Party\\b"
+  checks:
+    - id: "calloff_entities_not_named"
+      when:
+        all:
+          - regex: "(?i)Call[-\\s]?Off"
+          - not_regex: "(?i)(the\\s+Company\\s+entity\\s+and\\s+the\\s+Contractor\\s+entity\\s+shall\\s+be\\s+named|names?\\s+the\\s+issuing\\s+Company\\s+entity\\s+and\\s+the\\s+Contractor\\s+entity)"
+      finding:
+        message: "Call-Off does not require naming specific Company/Contractor entities."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Mandate naming of the issuing Company entity and the Contractor entity in each Call-Off."
+        score_delta: -15
+    - id: "agency_scope_not_limited"
+      when:
+        all:
+          - regex: "(?i)acting\\s+as\\s+agent"
+          - not_regex: "(?i)limited\\s+to\\s+the\\s+issuing\\s+(?:Call[-\\s]?Off\\s+)?entity"
+      finding:
+        message: "Agency wording not limited to the Call-Off issuing entity."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Limit agency to the named issuing entity and align with CRTPA carve-outs."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: PartiesSpecificityGap
+    score: 85
+    problem: "Parties/agency not tight enough at Call-Off level."
+    recommendation: "Name entities; constrain agency; align with CRTPA clause."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Parties","Call-Off","agency","CRTPA"]
+metadata:
+  tags: ["parties","agency"]

--- a/core/rules/uk/definitions/i_to_p_block/10_permit_authorisations_matrix.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/10_permit_authorisations_matrix.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.def.permit.authorisations_matrix"
+  version: "1.0.0"
+  title: "Permit: holder/responsibility matrix; evidence; ECJU/HSE links"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","permit","authorisations","compliance"]
+  triggers:
+    any:
+      - regex: "(?i)Permit(s)?\\b"
+  checks:
+    - id: "no_holder_or_evidence"
+      when:
+        any:
+          - not_regex: "(?i)holder|responsible\\s+for\\s+obtaining"
+          - not_regex: "(?i)evidence|copies(?:\\s+provided)?\\s+on\\s+request"
+      finding:
+        message: "Permit lacks holder assignment or evidence/copy obligation."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Assign holder, validity dates and provide copies on request."
+        score_delta: -15
+    - id: "no_authorisations_link"
+      when:
+        all:
+          - regex: "(?i)Permit"
+          - not_regex: "(?i)Authorisations|matrix|responsibility"
+      finding:
+        message: "No linkage of Permit to Authorisations responsibility matrix."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Reference Authorisations (umbrella) and responsibility matrix."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: PermitMatrixGap
+    score: 80
+    problem: "Permit responsibilities/evidence unclear."
+    recommendation: "Define holder/evidence/validity; link to Authorisations."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Permit","Authorisations","evidence"]
+metadata:
+  tags: ["permit","authorisations"]

--- a/core/rules/uk/definitions/i_to_p_block/11_personal_injury_scope_and_insurance.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/11_personal_injury_scope_and_insurance.yaml
@@ -1,0 +1,50 @@
+rule:
+  id: "uk.def.personal_injury.scope_and_el_insurance"
+  version: "1.0.0"
+  title: "Personal Injury: broad scope incl. death/disease/mental distress; EL insurance linkage"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","liability","insurance","knock-for-knock"]
+  triggers:
+    any:
+      - regex: "(?i)Personal\\s+Injury"
+  checks:
+    - id: "scope_not_broad"
+      when:
+        any:
+          - not_regex: "(?i)death"
+          - not_regex: "(?i)disease|illness"
+          - not_regex: "(?i)mental\\s+(distress|anguish)"
+      finding:
+        message: "Personal Injury scope not broad enough for KFK/insurance alignment."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Include death, disease/illness and mental distress/anguish."
+        score_delta: -15
+    - id: "no_el_insurance_reference"
+      when:
+        all:
+          - regex: "(?i)Personal\\s+Injury"
+          - not_regex: "(?i)Employer[s]?['’]?s?\\s+Liability|EL\\s+insurance|1969|\\£\\s*5\\s*m|five\\s+million"
+      finding:
+        message: "No linkage to Employers’ Liability insurance statutory minimums."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Reference EL insurance (statutory minimum, policy evidence) if applicable."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: PersonalInjuryScopeGap
+    score: 85
+    problem: "Personal Injury may be too narrow or not tied to EL insurance."
+    recommendation: "Broaden scope and link to EL insurance requirements."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Personal Injury","EL insurance","knock-for-knock"]
+metadata:
+  tags: ["insurance","liability"]

--- a/core/rules/uk/definitions/i_to_p_block/12_personnel_ir35_awr.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/12_personnel_ir35_awr.yaml
@@ -1,0 +1,48 @@
+rule:
+  id: "uk.def.personnel.coverage_ir35_awr"
+  version: "1.0.0"
+  title: "Personnel: coverage (employees/temps/consultants/seconded); IR35/AWR; PAYE/visa responsibility"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","NDA"]
+    clauses: ["definitions","personnel","tax","immigration"]
+  triggers:
+    any:
+      - regex: "(?i)Personnel"
+  checks:
+    - id: "coverage_too_narrow"
+      when:
+        any:
+          - not_regex: "(?i)agency|temps?|workers?|consultants?|contractors?|seconded"
+      finding:
+        message: "Personnel definition too narrow for compliance (IR35/AWR)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Include employees, temps/agency workers, consultants and seconded personnel under Contractor control."
+        score_delta: -15
+    - id: "no_ir35_or_awr"
+      when:
+        any:
+          - not_regex: "(?i)IR35|off[-\\s]?payroll"
+          - not_regex: "(?i)Agency\\s+Workers\\s+Regulations|AWR\\s*2010|12\\s+weeks"
+      finding:
+        message: "No IR35/off-payroll or AWR 2010 linkage."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State responsibility for PAYE/NI/visa; address IR35 status and AWR 12-week equal treatment where applicable."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: PersonnelComplianceGap
+    score: 80
+    problem: "Personnel scope/compliance incomplete."
+    recommendation: "Widen coverage; assign tax/visa duties; add IR35/AWR references."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Personnel","IR35","AWR 2010","PAYE","visa"]
+metadata:
+  tags: ["ir35","awr","immigration"]

--- a/core/rules/uk/definitions/i_to_p_block/13_property_exclusions_title_risk.yaml
+++ b/core/rules/uk/definitions/i_to_p_block/13_property_exclusions_title_risk.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.def.property.exclusions_title_risk"
+  version: "1.0.0"
+  title: "Property: exclusions (Company Items, Goods pre-acceptance, Agreement Documentation) and Title/Risk alignment"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","property","title","risk","insurance"]
+  triggers:
+    any:
+      - regex: "(?i)Property\\s+means"
+  checks:
+    - id: "exclusions_missing"
+      when:
+        any:
+          - not_regex: "(?i)Company\\s+Provided\\s+Items"
+          - not_regex: "(?i)Goods\\s+prior\\s+to\\s+delivery|acceptance"
+          - not_regex: "(?i)Agreement\\s+Documentation"
+      finding:
+        message: "Property definition missing key exclusions (Company Items, pre-acceptance Goods, Agreement Documentation)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Exclude Company Provided Items, Goods before delivery/acceptance, and Agreement Documentation."
+        score_delta: -20
+    - id: "no_title_risk_alignment"
+      when:
+        any:
+          - not_regex: "(?i)Title|Risk|Clause\\s*18|Clause\\s*19|Insurance"
+      finding:
+        message: "No alignment with Title/Risk/Insurance sections."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Cross-reference Title (18), Risk (19) and Insurance (20) for transfer points and coverage."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: PropertyExclusionsGap
+    score: 80
+    problem: "Property definition too broad or not aligned with Title/Risk/Insurance."
+    recommendation: "Add exclusions and cross-links to Title/Risk/Insurance."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Property","Title","Risk","Insurance","Company Items"]
+metadata:
+  tags: ["property","title","risk"]

--- a/tests/rules/definitions/test_i_to_p_block.py
+++ b/tests/rules/definitions/test_i_to_p_block.py
@@ -1,0 +1,180 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+def AI(text, clause="definitions", doc="Master Agreement"):
+    return AnalysisInput(clause_type=clause, text=text,
+                         metadata={"jurisdiction":"UK","doc_type":doc})
+
+# 1) IoR
+def test_ior_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/01_importer_of_record.yaml")
+    t = "Importer of Record (IoR) means the responsible party."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is not None and any("ior is defined" in f.message.lower() or "eori" in f.message.lower() for f in out.findings)
+
+def test_ior_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/01_importer_of_record.yaml")
+    t = ("Each Call-Off shall specify the Importer of Record and its EORI (GB123456789000), "
+         "declare the import jurisdiction, and confirm duties: customs declarations (SDE only if authorised) "
+         "and records retention for at least 4 years.")
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 2) Indemnify
+def test_indemnify_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/02_indemnify_controls.yaml")
+    t = "Contractor shall indemnify and hold harmless Company from all losses."
+    out = run_rule(spec, AI(t, clause="indemnity"))
+    assert out is not None and any("defend" in f.message.lower() or "negligence" in f.message.lower() for f in out.findings)
+
+def test_indemnify_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/02_indemnify_controls.yaml")
+    t = ("Contractor shall defend, indemnify and hold harmless; Contractor controls the defence subject to "
+         "Company’s consent to any settlement; wording clarifies treatment of negligence.")
+    out = run_rule(spec, AI(t, clause="indemnity"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 3) IP Rights
+def test_ip_rights_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/03_ip_rights_coverage.yaml")
+    t = "IP Rights include patents, copyright and designs."
+    out = run_rule(spec, AI(t))
+    assert out is not None and any("database right" in f.message.lower() or "assignment" in f.message.lower() for f in out.findings)
+
+def test_ip_rights_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/03_ip_rights_coverage.yaml")
+    t = ("IP Rights include worldwide rights in patents, copyright, database right (1997), "
+         "designs, trademarks, semiconductor topography and know-how; clause 17 requires assignment in writing and waiver of moral rights.")
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 4) Invitee
+def test_invitee_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/04_invitee_scope.yaml")
+    t = "Invitee includes any Regulator visiting the Site."
+    out = run_rule(spec, AI(t, clause="site"))
+    assert out is not None and any("regulators" in f.message.lower() for f in out.findings)
+
+def test_invitee_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/04_invitee_scope.yaml")
+    t = "Governmental Authorities are not Invitees of either party; Invitee is a contract term distinct from OLA 1957."
+    out = run_rule(spec, AI(t, clause="site"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 5) IP Rights Claim
+def test_ip_claim_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/05_ip_rights_claim_mechanics.yaml")
+    t = "IP Rights Claim means any allegation of infringement."
+    out = run_rule(spec, AI(t, clause="ip"))
+    assert out is not None and any("defence obligation" in f.message.lower() or "remedy suite" in f.message.lower() for f in out.findings)
+
+def test_ip_claim_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/05_ip_rights_claim_mechanics.yaml")
+    t = "Upon an IP Rights Claim, Contractor shall defend; Company shall promptly notify within 10 days; remedies include replace, modify or procure a licence; carve-outs for combinations and Company modifications apply."
+    out = run_rule(spec, AI(t, clause="ip"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 6) Key Personnel
+def test_key_personnel_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/06_key_personnel_controls.yaml")
+    t = "Key Personnel are those designated by Contractor."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is not None and any("scheduled" in f.message.lower() or "consent" in (f.suggestion.text.lower() if getattr(f,'suggestion',None) else "") for f in out.findings)
+
+def test_key_personnel_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/06_key_personnel_controls.yaml")
+    t = "Key Personnel are listed in each Call-Off; no removal without Company’s prior written consent; LDs apply proportionately."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 7) Legal Fault
+def test_legal_fault_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/07_legal_fault_consistency.yaml")
+    t = "Force Majeure may apply to any event beyond control."
+    out = run_rule(spec, AI(t, clause="force majeure"))
+    assert out is not None and any("fm does not clearly exclude" in f.message.lower() for f in out.findings)
+
+def test_legal_fault_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/07_legal_fault_consistency.yaml")
+    t = "Force Majeure shall not apply to events caused by the fault of the affected party; knock-for-knock indemnities clarify precedence."
+    out = run_rule(spec, AI(t, clause="force majeure"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 8) Nonconformity
+def test_nonconformity_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/08_nonconformity_vs_defect.yaml")
+    t = "Nonconformity means failure to meet specifications."
+    out = run_rule(spec, AI(t, clause="quality"))
+    assert out is not None and any("relationship" in f.message.lower() or "priority" in f.message.lower() for f in out.findings)
+
+def test_nonconformity_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/08_nonconformity_vs_defect.yaml")
+    t = "Nonconformity aligns with Defect; stricter of fitness-for-purpose or codes prevails."
+    out = run_rule(spec, AI(t, clause="quality"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 9) Parties
+def test_parties_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/09_parties_calloff_specificity.yaml")
+    t = "Call-Off may be issued by Company or its affiliates."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is not None and any("naming" in f.message.lower() or "agency" in f.message.lower() for f in out.findings)
+
+def test_parties_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/09_parties_calloff_specificity.yaml")
+    t = "Each Call-Off names the issuing Company entity and the Contractor entity; any agency is limited to the issuing entity and aligned with CRTPA carve-outs."
+    out = run_rule(spec, AI(t, clause="call-off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 10) Permit
+def test_permit_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/10_permit_authorisations_matrix.yaml")
+    t = "Permit means any approval."
+    out = run_rule(spec, AI(t, clause="permit"))
+    assert out is not None and any("holder" in f.message.lower() or "authorisations" in f.message.lower() for f in out.findings)
+
+def test_permit_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/10_permit_authorisations_matrix.yaml")
+    t = "Permit holder is Contractor; copies provided on request; permits link to the Authorisations responsibility matrix."
+    out = run_rule(spec, AI(t, clause="permit"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 11) Personal Injury
+def test_personal_injury_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/11_personal_injury_scope_and_insurance.yaml")
+    t = "Personal Injury means bodily injury."
+    out = run_rule(spec, AI(t, clause="liability"))
+    assert out is not None and any("scope not broad" in f.message.lower() or "el insurance" in f.message.lower() for f in out.findings)
+
+def test_personal_injury_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/11_personal_injury_scope_and_insurance.yaml")
+    t = "Personal Injury includes death, disease and mental distress; Employer’s Liability insurance evidence is maintained."
+    out = run_rule(spec, AI(t, clause="liability"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 12) Personnel
+def test_personnel_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/12_personnel_ir35_awr.yaml")
+    t = "Personnel means employees."
+    out = run_rule(spec, AI(t, clause="personnel"))
+    assert out is not None and any("too narrow" in f.message.lower() or "ir35" in (f.suggestion.text.lower() if getattr(f,'suggestion',None) else "") for f in out.findings)
+
+def test_personnel_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/12_personnel_ir35_awr.yaml")
+    t = "Personnel include employees, agency workers, consultants and seconded staff; Contractor bears PAYE/NI/visa; IR35/off-payroll and AWR 2010 (12 weeks) are addressed."
+    out = run_rule(spec, AI(t, clause="personnel"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 13) Property
+def test_property_negative():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/13_property_exclusions_title_risk.yaml")
+    t = "Property means any property of Company."
+    out = run_rule(spec, AI(t, clause="property"))
+    assert out is not None and any("exclusions" in f.message.lower() for f in out.findings)
+
+def test_property_positive():
+    spec = load_rule("core/rules/uk/definitions/i_to_p_block/13_property_exclusions_title_risk.yaml")
+    t = "Property excludes Company Provided Items, Goods before delivery/acceptance, and Agreement Documentation; cross-references Title, Risk and Insurance."
+    out = run_rule(spec, AI(t, clause="property"))
+    assert out is None or len(getattr(out, "findings", [])) == 0


### PR DESCRIPTION
## Summary
- add thirteen UK definition rules covering terms from Importer of Record to Property
- include comprehensive pytest covering each new rule

## Testing
- `pytest tests/rules/definitions/test_i_to_p_block.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa58edefc8325b11004d8cc20ec90