### PR TITLE
fix(panel): always populate meta badges; show last status; ping health on load

### DIFF
--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -1,27 +1,30 @@
-// === meta helpers for panel (ESM) ===
-export function metaFromResponse(resp) {
-  const h = resp.headers;
-  const get = (n) => h.get(n) || null;
+// === meta helpers and API client for panel (ESM) ===
+export function metaFromResponse(r) {
+  const h = r.headers;
+  const js = r.json || {};
+  const llm = js.llm || js;
   return {
-    cid: get('x-cid'),
-    xcache: get('x-cache'),
-    latencyMs: Number(get('x-latency-ms')) || null,
-    schema: get('x-schema-version'),
-    provider: get('x-provider'),
-    model: get('x-model'),
-    llm_mode: get('x-llm-mode'),
-    usage: get('x-usage-total'),
+    cid: h.get('x-cid'),
+    xcache: h.get('x-cache'),
+    latencyMs: h.get('x-latency-ms'),
+    schema: h.get('x-schema-version'),
+    provider: h.get('x-provider') || llm.provider || js.provider || null,
+    model: h.get('x-model') || llm.model || js.model || null,
+    llm_mode: h.get('x-llm-mode') || llm.mode || js.mode || null,
+    usage: h.get('x-usage-total'),
+    status: r.status != null ? String(r.status) : null,
   };
 }
 
 export function applyMetaToBadges(m) {
   const set = (id, v) => {
     const el = document.getElementById(id);
-    if (el) el.textContent = (v ?? '—');
+    if (el) el.textContent = v && v.length ? v : '—';
   };
+  set('status', m.status);
   set('cid', m.cid);
   set('xcache', m.xcache);
-  set('latency', m.latencyMs == null ? '—' : String(m.latencyMs));
+  set('latency', m.latencyMs);
   set('schema', m.schema);
   set('provider', m.provider);
   set('model', m.model);
@@ -32,10 +35,11 @@ export function applyMetaToBadges(m) {
 // минимальный API-клиент под панель (ESM)
 const DEFAULT_BASE = 'https://localhost:9443';
 function base() {
-  try { return (localStorage.getItem('backendUrl') || DEFAULT_BASE).replace(/\/+$/,''); }
+  try { return (localStorage.getItem('backendUrl') || DEFAULT_BASE).replace(/\/+$/, ''); }
   catch { return DEFAULT_BASE; }
 }
-async function req(path, { method='GET', body=null } = {}) {
+
+async function req(path, { method='GET', body=null, key=path } = {}) {
   const r = await fetch(base()+path, {
     method,
     headers: { 'content-type':'application/json' },
@@ -43,14 +47,29 @@ async function req(path, { method='GET', body=null } = {}) {
     credentials: 'include'
   });
   const json = await r.json().catch(() => ({}));
-  return { ok: r.ok, json, resp: r };
+  const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
+  try { applyMetaToBadges(meta); } catch {}
+  try {
+    const w = window;
+    w.__last = w.__last || {};
+    w.__last[key] = { status: r.status, req: { path, method, body }, json };
+  } catch {}
+  return { ok: r.ok, json, resp: r, meta };
 }
 
-export async function apiHealth()      { const {ok,json,resp} = await req('/health');      return {ok,json,meta: metaFromResponse(resp)}; }
-export async function apiAnalyze(text) { const {ok,json,resp} = await req('/api/analyze',   {method:'POST', body:{text, mode:'live'}}); return {ok,json,meta: metaFromResponse(resp)}; }
-export async function apiGptDraft(text){ const {ok,json,resp} = await req('/api/gpt-draft', {method:'POST', body:{text, mode:'friendly'}}); return {ok,json,meta: metaFromResponse(resp)}; }
-export async function apiQaRecheck(text,rules=[]){ const {ok,json,resp}=await req('/api/qa-recheck',{method:'POST', body:{text, rules}}); return {ok,json,meta: metaFromResponse(resp)}; }
-
-//////////////////////////////////////////////////////////////////////////
-// Конец файла
-//////////////////////////////////////////////////////////////////////////
+export async function apiHealth() {
+  const { ok, json, resp, meta } = await req('/health', { key: 'health' });
+  return { ok, json, resp, meta };
+}
+export async function apiAnalyze(text) {
+  const { ok, json, resp, meta } = await req('/api/analyze', { method: 'POST', body: { text, mode: 'live' }, key: 'analyze' });
+  return { ok, json, resp, meta };
+}
+export async function apiGptDraft(text, mode='friendly', extra={}) {
+  const { ok, json, resp, meta } = await req('/api/gpt-draft', { method: 'POST', body: { text, mode, ...extra }, key: 'gpt-draft' });
+  return { ok, json, resp, meta };
+}
+export async function apiQaRecheck(text, rules=[]) {
+  const { ok, json, resp, meta } = await req('/api/qa-recheck', { method: 'POST', body: { text, rules }, key: 'qa-recheck' });
+  return { ok, json, resp, meta };
+}

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -7,19 +7,23 @@ export type Meta = {
   model?: string | null;
   llm_mode?: string | null;
   usage?: string | null;
+  status?: string | null;
 };
 
-export function metaFromResponse(resp: Response): Meta {
-  const h = resp.headers;
+export function metaFromResponse(r: { headers: Headers; json?: any; status?: number }): Meta {
+  const h = r.headers;
+  const js = r.json || {};
+  const llm = js.llm || js;
   return {
     cid:       h.get('x-cid'),
     xcache:    h.get('x-cache'),
     latencyMs: h.get('x-latency-ms'),
     schema:    h.get('x-schema-version'),
-    provider:  h.get('x-provider'),
-    model:     h.get('x-model'),
-    llm_mode:  h.get('x-llm-mode'),
+    provider:  h.get('x-provider') || llm.provider || js.provider || null,
+    model:     h.get('x-model') || llm.model || js.model || null,
+    llm_mode:  h.get('x-llm-mode') || llm.mode || js.mode || null,
     usage:     h.get('x-usage-total'),
+    status:    r.status != null ? String(r.status) : null,
   };
 }
 
@@ -28,6 +32,7 @@ export function applyMetaToBadges(m: Meta) {
     const el = document.getElementById(id);
     if (el) el.textContent = v && v.length ? v : '—';
   };
+  set('status',    m.status);
   set('cid',       m.cid);
   set('xcache',    m.xcache);
   set('latency',   m.latencyMs);
@@ -36,4 +41,44 @@ export function applyMetaToBadges(m: Meta) {
   set('model',     m.model);
   set('mode',      m.llm_mode);
   set('usage',     m.usage);
+}
+
+const DEFAULT_BASE = 'https://localhost:9443';
+function base(): string {
+  try { return (localStorage.getItem('backendUrl') || DEFAULT_BASE).replace(/\/+$/, ''); }
+  catch { return DEFAULT_BASE; }
+}
+
+async function req(path: string, { method='GET', body=null, key=path }: { method?: string; body?: any; key?: string } = {}) {
+  const r = await fetch(base()+path, {
+    method,
+    headers: { 'content-type':'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+    credentials: 'include'
+  });
+  const json = await r.json().catch(() => ({}));
+  const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
+  try { applyMetaToBadges(meta); } catch {}
+  try {
+    const w = window as any;
+    if (!w.__last) w.__last = {};
+    w.__last[key] = { status: r.status, req: { path, method, body }, json };
+  } catch {}
+  return { ok: r.ok, json, resp: r, meta };
+}
+
+export async function apiHealth() {
+  return req('/health', { key: 'health' });
+}
+
+export async function apiAnalyze(text: string) {
+  return req('/api/analyze', { method: 'POST', body: { text, mode: 'live' }, key: 'analyze' });
+}
+
+export async function apiGptDraft(text: string, mode = 'friendly', extra: any = {}) {
+  return req('/api/gpt-draft', { method: 'POST', body: { text, mode, ...extra }, key: 'gpt-draft' });
+}
+
+export async function apiQaRecheck(text: string, rules: any[] = []) {
+  return req('/api/qa-recheck', { method: 'POST', body: { text, rules }, key: 'qa-recheck' });
 }

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -155,6 +155,7 @@
     </div>
     <div id="statusLine" class="muted">
       <span class="inline">
+        <span>status:</span><span class="badge" id="status">—</span>
         <span>cid:</span><span class="badge" id="cid">—</span>
         <span>X-Cache:</span><span class="badge" id="xcache">—</span>
         <span>latency:</span><span class="badge" id="latency">—</span>


### PR DESCRIPTION
## Summary
- ping `/health` on startup and display connection status
- propagate response meta and status via a unified fetch wrapper
- add status/Office badges and use wrapper for all panel calls

## Testing
- `pre-commit run --files word_addin_dev/taskpane.html word_addin_dev/app/assets/api-client.ts word_addin_dev/app/assets/api-client.js word_addin_dev/app/assets/taskpane.ts word_addin_dev/taskpane.bundle.js`


------
https://chatgpt.com/codex/tasks/task_e_68bad10f85708325b05f6331d9a28b76