### PR TITLE
fix: unify panel slots and draft meta handling

### DIFF
--- a/tests/panel/test_gpt_draft_payload.py
+++ b/tests/panel/test_gpt_draft_payload.py
@@ -13,7 +13,12 @@ def _post(path, payload):
     )
     return urllib.request.urlopen(req, timeout=5)
 
-def test_gpt_draft_accepts_before_after():
+def test_gpt_draft_payload_and_response():
     payload = {"text":"Ping", "mode":"friendly", "before_text":"", "after_text":""}
     with _post("/api/gpt-draft", payload) as r:
         assert r.status == 200
+        data = json.load(r)
+    for k in ("text", "mode", "before_text", "after_text"):
+        assert k in payload and isinstance(payload[k], str)
+    assert isinstance(data.get("proposed_text"), str)
+    assert data["proposed_text"].strip() != ""

--- a/tests/panel/test_slots_exist.py
+++ b/tests/panel/test_slots_exist.py
@@ -1,0 +1,27 @@
+import pathlib
+
+HTML = pathlib.Path('word_addin_dev/taskpane.html').read_text(encoding='utf-8')
+
+
+def _exists(id_sel: str, role: str) -> bool:
+    return (f'id="{id_sel}"' in HTML) or (f'data-role="{role}"' in HTML)
+
+
+def test_clause_type_slot_exists():
+    assert _exists('resClauseType', 'clause-type')
+
+
+def test_findings_list_slot_exists():
+    assert _exists('findingsList', 'findings')
+
+
+def test_recommendations_list_slot_exists():
+    assert _exists('recoList', 'recommendations')
+
+
+def test_raw_json_toggle_slot_exists():
+    assert _exists('toggleRaw', 'toggle-raw-json')
+
+
+def test_raw_json_pre_slot_exists():
+    assert _exists('rawJson', 'raw-json')

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -1,38 +1,38 @@
 // === meta helpers and API client for panel (ESM) ===
-export function metaFromResponse(r) {
-  const h = r.headers;
-  const js = r.json || {};
-  const llm = js.llm || js;
+
+export function metaFromResponse(res) {
+  const h = res?.headers || new Headers();
+  const pick = (name) => {
+    const v = h.get(name);
+    return v == null ? '' : v;
+  };
   return {
-    cid: h.get('x-cid'),
-    xcache: h.get('x-cache'),
-    latencyMs: h.get('x-latency-ms'),
-    schema: h.get('x-schema-version'),
-    provider: h.get('x-provider') || llm.provider || js.provider || null,
-    model: h.get('x-model') || llm.model || js.model || null,
-    llm_mode: h.get('x-llm-mode') || llm.mode || js.mode || null,
-    usage: h.get('x-usage-total'),
-    status: r.status != null ? String(r.status) : null,
+    provider: pick('x-provider'),
+    model: pick('x-model'),
+    mode: pick('x-llm-mode'),
+    usage: pick('x-usage-total'),
+    schema: pick('x-schema-version'),
+    latency: pick('x-latency-ms'),
+    cid: pick('x-cid'),
+    xcache: pick('x-cache')
   };
 }
 
-export function applyMetaToBadges(m) {
+export function applyMetaToBadges(meta) {
   const set = (id, v) => {
     const el = document.getElementById(id);
     if (el) el.textContent = v && v.length ? v : '—';
   };
-  set('status', m.status);
-  set('cid', m.cid);
-  set('xcache', m.xcache);
-  set('latency', m.latencyMs);
-  set('schema', m.schema);
-  set('provider', m.provider);
-  set('model', m.model);
-  set('mode', m.llm_mode);
-  set('usage', m.usage);
+  set('cidBadge', meta.cid); set('cid', meta.cid);
+  set('xcacheBadge', meta.xcache); set('xcache', meta.xcache);
+  set('latencyBadge', meta.latency); set('latency', meta.latency);
+  set('schemaBadge', meta.schema); set('schema', meta.schema);
+  set('providerBadge', meta.provider); set('provider', meta.provider);
+  set('modelBadge', meta.model); set('model', meta.model);
+  set('modeBadge', meta.mode); set('mode', meta.mode);
+  set('usageBadge', meta.usage); set('usage', meta.usage);
 }
 
-// минимальный API-клиент под панель (ESM)
 const DEFAULT_BASE = 'https://localhost:9443';
 function base() {
   try { return (localStorage.getItem('backendUrl') || DEFAULT_BASE).replace(/\/+$/, ''); }
@@ -47,29 +47,27 @@ async function req(path, { method='GET', body=null, key=path } = {}) {
     credentials: 'include'
   });
   const json = await r.json().catch(() => ({}));
-  const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
-  try { applyMetaToBadges(meta); } catch {}
   try {
     const w = window;
     w.__last = w.__last || {};
     w.__last[key] = { status: r.status, req: { path, method, body }, json };
   } catch {}
-  return { ok: r.ok, json, resp: r, meta };
+  return { ok: r.ok, json, resp: r };
 }
 
 export async function apiHealth() {
-  const { ok, json, resp, meta } = await req('/health', { key: 'health' });
-  return { ok, json, resp, meta };
+  return await req('/health', { key: 'health' });
 }
+
 export async function apiAnalyze(text) {
-  const { ok, json, resp, meta } = await req('/api/analyze', { method: 'POST', body: { text, mode: 'live' }, key: 'analyze' });
-  return { ok, json, resp, meta };
+  return await req('/api/analyze', { method: 'POST', body: { text, mode: 'live' }, key: 'analyze' });
 }
+
 export async function apiGptDraft(text, mode='friendly', extra={}) {
-  const { ok, json, resp, meta } = await req('/api/gpt-draft', { method: 'POST', body: { text, mode, ...extra }, key: 'gpt-draft' });
-  return { ok, json, resp, meta };
+  return await req('/api/gpt-draft', { method: 'POST', body: { text, mode, ...extra }, key: 'gpt-draft' });
 }
+
 export async function apiQaRecheck(text, rules=[]) {
-  const { ok, json, resp, meta } = await req('/api/qa-recheck', { method: 'POST', body: { text, rules }, key: 'qa-recheck' });
-  return { ok, json, resp, meta };
+  return await req('/api/qa-recheck', { method: 'POST', body: { text, rules }, key: 'qa-recheck' });
 }
+

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1,4 +1,4 @@
-import { apiHealth, apiAnalyze, apiQaRecheck, apiGptDraft } from "./api-client";
+import { apiHealth, apiAnalyze, apiQaRecheck, apiGptDraft, metaFromResponse, applyMetaToBadges } from "./api-client";
 import { notifyOk, notifyErr, notifyWarn } from "./notifier";
 import { getWholeDocText } from "./office"; // у вас уже есть хелпер; если имя иное — поправьте импорт.
 
@@ -8,6 +8,56 @@ const Q = {
   proposed: 'textarea#proposedText, textarea[name="proposed"], textarea[data-role="proposed-text"]',
   original: 'textarea#originalClause, textarea[name="original"], textarea[data-role="original-clause"]'
 };
+
+function slot(id: string, role: string): HTMLElement | null {
+  return (
+    document.querySelector(`[data-role="${role}"]`) as HTMLElement | null
+  ) || document.getElementById(id);
+}
+
+function renderResults(res: any) {
+  const clause = slot("resClauseType", "clause-type");
+  if (clause) clause.textContent = res?.clause_type || "—";
+
+  const findingsArr = Array.isArray(res?.findings) ? res.findings : [];
+  const findingsList = slot("findingsList", "findings") as HTMLElement | null;
+  if (findingsList) {
+    findingsList.innerHTML = "";
+    findingsArr.forEach((f: any) => {
+      const li = document.createElement("li");
+      li.textContent = typeof f === "string" ? f : JSON.stringify(f);
+      findingsList.appendChild(li);
+    });
+  }
+
+  const recoArr = Array.isArray(res?.recommendations) ? res.recommendations : [];
+  const recoList = slot("recoList", "recommendations") as HTMLElement | null;
+  if (recoList) {
+    recoList.innerHTML = "";
+    recoArr.forEach((r: any) => {
+      const li = document.createElement("li");
+      li.textContent = typeof r === "string" ? r : JSON.stringify(r);
+      recoList.appendChild(li);
+    });
+  }
+
+  const count = slot("resFindingsCount", "findings-count");
+  if (count) count.textContent = String(findingsArr.length);
+
+  const pre = slot("rawJson", "raw-json") as HTMLElement | null;
+  if (pre) pre.textContent = JSON.stringify(res ?? {}, null, 2);
+}
+
+function wireResultsToggle() {
+  const toggle = slot("toggleRaw", "toggle-raw-json");
+  const pre = slot("rawJson", "raw-json") as HTMLElement | null;
+  if (toggle && pre) {
+    pre.style.display = "none";
+    toggle.addEventListener("click", () => {
+      pre.style.display = pre.style.display === "none" ? "block" : "none";
+    });
+  }
+}
 
 function setConnBadge(ok: boolean | null) {
   const el = document.getElementById("connBadge");
@@ -93,18 +143,25 @@ async function onGetAIDraft(ev?: Event) {
     const src = $(Q.original);
     const dst = $(Q.proposed);
 
-    const text = (src?.value ?? "").trim();
+    let text = (src?.value ?? "").trim();
+    if (!text) {
+      try {
+        text = await getSelectionAsync();
+        if (src) src.value = text;
+      } catch {}
+    }
     if (!text) { notifyWarn("No source text"); return; }
 
     const modeSel = document.getElementById("cai-mode") as HTMLSelectElement | null;
     const mode = modeSel?.value || "friendly";
     const ctx = await getSelectionContext(200);
-    const { ok, json } = await apiGptDraft(
-      "Please draft a neutral confidentiality clause.",
+    const { ok, json, resp } = await apiGptDraft(
+      text,
       mode,
       { before_text: ctx.before, after_text: ctx.after }
     );
     if (!ok) { notifyWarn("Draft failed"); return; }
+    try { applyMetaToBadges(metaFromResponse(resp)); } catch {}
     const proposed = (json?.proposed_text ?? "").toString();
 
     if (dst) {
@@ -125,7 +182,8 @@ async function onGetAIDraft(ev?: Event) {
 
 async function doHealth() {
   try {
-    const { ok, json } = await apiHealth();
+    const { ok, json, resp } = await apiHealth();
+    try { applyMetaToBadges(metaFromResponse(resp)); } catch {}
     setConnBadge(ok);
     notifyOk(`Health: ${json.status} (schema ${json.schema})`);
   } catch (e) {
@@ -138,14 +196,17 @@ async function doHealth() {
 async function doAnalyzeDoc() {
   const text = await getWholeDocText();
   if (!text || !text.trim()) { notifyErr("В документе нет текста"); return; }
-  const { json } = await apiAnalyze(text);
+  const { json, resp } = await apiAnalyze(text);
+  try { applyMetaToBadges(metaFromResponse(resp)); } catch {}
+  renderResults(json);
   (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.results", { detail: json }));
   notifyOk("Analyze OK");
 }
 
 async function doQARecheck() {
   const text = await getWholeDocText();
-  const { json } = await apiQaRecheck(text, []);
+  const { json, resp } = await apiQaRecheck(text, []);
+  try { applyMetaToBadges(metaFromResponse(resp)); } catch {}
   (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
   notifyOk("QA recheck OK");
 }
@@ -184,10 +245,35 @@ function wireUI() {
   document.getElementById("btnGetAIDraft")?.addEventListener("click", onGetAIDraft);
   bindClick("#btn-use-selection", onUseSelection);
   bindClick("#btn-use-whole", onUseWholeDoc);
+  bindClick("#btnInsertIntoWord", onInsertIntoWord);
   bindClick("#btnApplyTracked", onApplyTracked);
   bindClick("#btnAcceptAll", () => notifyWarn("Not implemented"));
   bindClick("#btnRejectAll", () => notifyWarn("Not implemented"));
+  wireResultsToggle();
   console.log("Panel UI wired");
+}
+
+async function onInsertIntoWord() {
+  try {
+    const dst = $(Q.proposed);
+    const txt = (dst?.value || "").trim();
+    if (!txt) { notifyWarn("No draft to insert"); return; }
+    if ((window as any).Office && (window as any).Word) {
+      await Word.run(async ctx => {
+        const range = ctx.document.getSelection();
+        range.insertText(txt, "Replace");
+        await ctx.sync();
+      });
+      notifyOk("Inserted into Word");
+    } else {
+      await navigator.clipboard.writeText(txt);
+      notifyWarn("Not in Office environment; result copied to clipboard");
+    }
+  } catch (e) {
+    try { await navigator.clipboard.writeText($(Q.proposed)?.value || ""); } catch {}
+    notifyWarn("Not in Office environment; result copied to clipboard");
+    console.error(e);
+  }
 }
 
 async function bootstrap() {

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -302,23 +302,23 @@
   <div class="row card" id="resultsCard">
     <div class="muted" style="margin-bottom:6px">Results</div>
     <div class="grid">
-      <div class="kv"><strong>Clause type:</strong><span id="resClauseType">—</span></div>
-      <div class="kv"><strong>Findings:</strong><span id="resFindingsCount">—</span></div>
+      <div class="kv"><strong>Clause type:</strong><span id="resClauseType" data-role="clause-type">—</span></div>
+      <div class="kv"><strong>Findings:</strong><span id="resFindingsCount" data-role="findings-count">—</span></div>
     </div>
 
     <div class="row">
       <strong>Findings</strong>
-      <ul class="list" id="findingsList"></ul>
+      <ul class="list" id="findingsList" data-role="findings"></ul>
     </div>
 
     <div class="row">
       <strong>Recommendations</strong>
-      <ul class="list" id="recoList"></ul>
+      <ul class="list" id="recoList" data-role="recommendations"></ul>
     </div>
 
     <div class="row">
-      <span class="toggle" id="toggleRaw">Show raw JSON</span>
-      <pre id="rawJson" style="display:none"></pre>
+      <span class="toggle" id="toggleRaw" data-role="toggle-raw-json">Show raw JSON</span>
+      <pre id="rawJson" data-role="raw-json" style="display:none"></pre>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- extract response metadata into `metaFromResponse` and update badge utility
- render panel results via universal `id`/`data-role` slots and send full GPT draft context
- add regression tests for GPT draft payload and HTML result slots

## Testing
- `pytest -q tests/rules/recitals_and_clauses1/test_recitals_and_clauses1.py`
- `pytest -q tests/rules/definitions/test_b_block_and_calloff.py`
- `pytest -q tests/panel/test_gpt_draft_payload.py` *(fails: ConnectionRefusedError to https://localhost:9443)*
- `pytest -q tests/panel/test_slots_exist.py`


------
https://chatgpt.com/codex/tasks/task_e_68bad3051d188325a5c1b09a5ecf57d2