### PR TITLE
Implement Accept/Reject actions for panel

### DIFF
--- a/tests/panel/test_slots_exist.py
+++ b/tests/panel/test_slots_exist.py
@@ -25,3 +25,63 @@ def test_raw_json_toggle_slot_exists():
 
 def test_raw_json_pre_slot_exists():
     assert _exists('rawJson', 'raw-json')
+
+
+def test_accept_all_button_exists():
+    assert _exists('btnAcceptAll', '')
+
+
+def test_reject_all_button_exists():
+    assert _exists('btnRejectAll', '')
+
+
+def test_accept_reject_click_smoke():
+    import subprocess, textwrap
+    js = textwrap.dedent(
+        """
+        const fs = require('fs');
+        const vm = require('vm');
+        const code = fs.readFileSync('word_addin_dev/taskpane.bundle.js', 'utf8');
+
+        function el(){
+          return {
+            textContent:'', value:'', style:{},
+            classList:{remove(){}},
+            addEventListener(ev,fn){this.fn=fn;},
+            removeAttribute(){}, dispatchEvent(){},
+            click(){this.fn&&this.fn({preventDefault(){}})}
+          }
+        }
+
+        const btnA=el(), btnR=el(), prop={value:'hi',dispatchEvent(){}};
+        const cidEl={textContent:'cid123'};
+        const doc={
+          readyState:'complete',
+          querySelector(s){ if(s==='#btnAcceptAll') return btnA; if(s==='#btnRejectAll') return btnR; if(s.includes('#proposedText')) return prop; return null; },
+          getElementById(id){ if(id==='btnAcceptAll') return btnA; if(id==='btnRejectAll') return btnR; if(id==='cid') return cidEl; return el(); },
+          body: el()
+        };
+        const win={document:doc, toast(){}};
+        global.fetch=async()=>({ok:true,headers:{get(){return null;}},json:async()=>({status:'ok',schema:'1'}),status:200});
+        global.Event=function(){};
+        const ctx={
+          window:win,
+          document:doc,
+          self:win,
+          console:console,
+          Word:{
+            run:async fn=>{
+              const range={insertText(){},insertComment(){},revisions:{load(){},items:[{reject(){}}]}};
+              await fn({document:{getSelection(){return range;}},sync:async()=>{}});
+            }
+          },
+          Office:{},
+          navigator:{clipboard:{writeText:async()=>{}}},
+          localStorage:{getItem(){return null;}},
+          Event:function(){}
+        };
+        vm.createContext(ctx); vm.runInContext(code, ctx);
+        btnA.click(); btnR.click();
+        """
+    )
+    subprocess.run(['node', '-e', js], check=True)

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -238,6 +238,58 @@ async function onApplyTracked() {
   }
 }
 
+async function onAcceptAll() {
+  try {
+    const dst = $(Q.proposed);
+    const proposed = (dst?.value || "").trim();
+    if (!proposed) { (window as any).toast?.("Nothing to accept"); return; }
+
+    const cid = (document.getElementById("cid")?.textContent || "").trim();
+    const base = (() => {
+      try { return (localStorage.getItem("backendUrl") || "https://localhost:9443").replace(/\/+$/, ""); }
+      catch { return "https://localhost:9443"; }
+    })();
+    const link = cid && cid !== "—" ? `${base}/api/trace/${cid}` : "AI draft";
+
+    await Word.run(async ctx => {
+      const range = ctx.document.getSelection();
+      (ctx.document as any).trackRevisions = true;
+      range.insertText(proposed, "Replace");
+      try { range.insertComment(link); } catch {}
+      await ctx.sync();
+    });
+
+    (window as any).toast?.("Accepted into Word");
+    console.log("[OK] Accepted into Word");
+  } catch (e) {
+    (window as any).toast?.("Accept failed");
+    console.error(e);
+  }
+}
+
+async function onRejectAll() {
+  try {
+    const dst = $(Q.proposed);
+    if (dst) {
+      dst.value = "";
+      dst.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+    await Word.run(async ctx => {
+      const range = ctx.document.getSelection();
+      const revs = range.revisions;
+      revs.load("items");
+      await ctx.sync();
+      (revs.items || []).forEach(r => { try { r.reject(); } catch {} });
+      await ctx.sync();
+    });
+    (window as any).toast?.("Rejected");
+    console.log("[OK] Rejected");
+  } catch (e) {
+    (window as any).toast?.("Reject failed");
+    console.error(e);
+  }
+}
+
 function wireUI() {
   bindClick("#btnTest", doHealth);
   bindClick("#btnAnalyzeDoc", doAnalyzeDoc);
@@ -247,8 +299,8 @@ function wireUI() {
   bindClick("#btn-use-whole", onUseWholeDoc);
   bindClick("#btnInsertIntoWord", onInsertIntoWord);
   bindClick("#btnApplyTracked", onApplyTracked);
-  bindClick("#btnAcceptAll", () => notifyWarn("Not implemented"));
-  bindClick("#btnRejectAll", () => notifyWarn("Not implemented"));
+  bindClick("#btnAcceptAll", onAcceptAll);
+  bindClick("#btnRejectAll", onRejectAll);
   wireResultsToggle();
   console.log("Panel UI wired");
 }


### PR DESCRIPTION
## Summary
- Implement Accept All and Reject All handlers to apply or revert drafts in Word, log results, and show toast notifications
- Link comments to the latest x-cid when accepting and clear proposals plus reject revisions when rejecting
- Add panel tests for accept/reject buttons and smoke-test click handlers

## Testing
- `npm run build --prefix word_addin_dev`
- `npx esbuild word_addin_dev/app/assets/taskpane.ts --bundle --outfile=word_addin_dev/taskpane.bundle.js --format=esm`
- `pytest tests/panel/test_slots_exist.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68badd3993d88325ab1209b6daed9652