### PR TITLE
feat: annotate findings and tracked edits in panel

### DIFF
--- a/tests/panel/test_analyze_offsets.py
+++ b/tests/panel/test_analyze_offsets.py
@@ -1,0 +1,24 @@
+import json
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def _norm(s: str) -> str:
+    return s.replace('\r\n', '\n').replace('\r', '\n')
+
+
+def test_analyze_offsets_match_snippets():
+    text = "Confidential information shall remain secret."
+    r = client.post("/api/analyze", json={"text": text})
+    assert r.status_code == 200
+    data = r.json()
+    findings = data.get("analysis", {}).get("findings") or data.get("findings") or data.get("issues") or []
+    norm = _norm(text)
+    for f in findings:
+        start = f.get("start")
+        end = f.get("end")
+        snippet = _norm(f.get("snippet", ""))
+        if isinstance(start, int) and isinstance(end, int) and snippet:
+            assert norm[start:end] == snippet

--- a/tests/panel/test_parse_findings.js
+++ b/tests/panel/test_parse_findings.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+let code = fs.readFileSync(__dirname + '/../../word_addin_dev/app/assets/api-client.js', 'utf8');
+// Strip ESM exports for vm execution
+code = code.replace(/export\s+/g, '');
+const sandbox = { console };
+vm.runInNewContext(code, sandbox);
+const parseFindings = sandbox.parseFindings;
+
+const sample = { rule_id: 'r1', clause_type: 'c', severity: 's', start: 0, end: 1, snippet: 'x' };
+assert.deepStrictEqual(parseFindings({ analysis: { findings: [sample] } }).length, 1);
+assert.deepStrictEqual(parseFindings({ findings: [sample] }).length, 1);
+assert.deepStrictEqual(parseFindings({ issues: [sample] }).length, 1);
+assert.deepStrictEqual(parseFindings({ analysis: { findings: null } }).length, 0);
+console.log('parseFindings tests ok');

--- a/tests/panel/test_slots_exist.py
+++ b/tests/panel/test_slots_exist.py
@@ -25,3 +25,15 @@ def test_raw_json_toggle_slot_exists():
 
 def test_raw_json_pre_slot_exists():
     assert _exists('rawJson', 'raw-json')
+
+
+def test_btn_annotate_exists():
+    assert _exists('btnAnnotate', 'annotate') or 'id="btnAnnotate"' in HTML
+
+
+def test_btn_apply_tracked_exists():
+    assert _exists('btnApplyTracked', 'apply-tracked') or 'id="btnApplyTracked"' in HTML
+
+
+def test_btn_accept_reject_exist():
+    assert 'id="btnAcceptAll"' in HTML and 'id="btnRejectAll"' in HTML

--- a/tests/panel/test_store_state.js
+++ b/tests/panel/test_store_state.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-const code = fs.readFileSync(__dirname + '/../../word_addin_dev/app/assets/store.js', 'utf8');
+let code = fs.readFileSync(__dirname + '/../../word_addin_dev/app/assets/store.js', 'utf8');
+code = code.replace(/export\s+/g, '');
 const globalCAI = {};
 const sandbox = {
   window: { CAI: globalCAI },

--- a/tests/panel/test_suggest_ops_minimal.py
+++ b/tests/panel/test_suggest_ops_minimal.py
@@ -1,0 +1,26 @@
+import json
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def _apply_ops(text: str, ops):
+    result = text
+    for op in sorted(ops, key=lambda o: o['start'], reverse=True):
+        result = result[:op['start']] + op['replacement'] + result[op['end']:]
+    return result
+
+
+def test_suggest_edits_ops_patch():
+    original = "bad clause"
+    r = client.post("/api/suggest_edits", json={"text": original})
+    assert r.status_code == 200
+    data = r.json()
+    proposed = data.get("proposed_text", "")
+    ops = data.get("ops", [])
+    assert isinstance(ops, list)
+    if proposed and proposed != original:
+        assert ops, "ops should describe edits"
+        patched = _apply_ops(original, ops)
+        assert patched == proposed

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -33,6 +33,11 @@ export function applyMetaToBadges(meta) {
   set('usageBadge', meta.usage); set('usage', meta.usage);
 }
 
+export function parseFindings(resp) {
+  const arr = resp?.analysis?.findings ?? resp?.findings ?? resp?.issues ?? [];
+  return Array.isArray(arr) ? arr.filter(Boolean) : [];
+}
+
 const DEFAULT_BASE = 'https://localhost:9443';
 function base() {
   try { return (localStorage.getItem('backendUrl') || DEFAULT_BASE).replace(/\/+$/, ''); }

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -10,6 +10,29 @@ export type Meta = {
   status?: string | null;
 };
 
+export type AnalyzeFinding = {
+  rule_id: string;
+  clause_type: string;
+  severity: string;
+  start: number;
+  end: number;
+  snippet: string;
+  advice?: string;
+};
+
+export type AnalyzeResponse = {
+  status: 'ok';
+  analysis?: { findings?: AnalyzeFinding[] };
+  findings?: AnalyzeFinding[];
+  issues?: AnalyzeFinding[];
+  meta?: any;
+};
+
+export function parseFindings(resp: AnalyzeResponse): AnalyzeFinding[] {
+  const arr = resp?.analysis?.findings ?? resp?.findings ?? resp?.issues ?? [];
+  return Array.isArray(arr) ? arr.filter(Boolean) : [];
+}
+
 export function metaFromResponse(r: { headers: Headers; json?: any; status?: number }): Meta {
   const h = r.headers;
   const js = r.json || {};

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1,4 +1,4 @@
-import { apiHealth, apiAnalyze, apiQaRecheck, apiGptDraft, metaFromResponse, applyMetaToBadges } from "./api-client";
+import { apiHealth, apiAnalyze, apiQaRecheck, apiGptDraft, metaFromResponse, applyMetaToBadges, parseFindings, AnalyzeFinding } from "./api-client";
 import { notifyOk, notifyErr, notifyWarn } from "./notifier";
 import { getWholeDocText } from "./office"; // у вас уже есть хелпер; если имя иное — поправьте импорт.
 
@@ -15,11 +15,134 @@ function slot(id: string, role: string): HTMLElement | null {
   ) || document.getElementById(id);
 }
 
+export function normalizeText(s: string): string {
+  return s.replace(/\r\n?/g, "\n").trim().replace(/[ \t]+/g, " ");
+}
+
+export function buildParagraphIndex(paragraphs: string[]): { starts: number[]; texts: string[] } {
+  const starts: number[] = [];
+  const texts: string[] = [];
+  let pos = 0;
+  for (const p of paragraphs) {
+    const t = normalizeText(p);
+    starts.push(pos);
+    texts.push(t);
+    pos += t.length + 1; // assume joined by \n
+  }
+  return { starts, texts };
+}
+
+export async function mapFindingToRange(f: AnalyzeFinding, index: { starts: number[]; texts: string[] }): Promise<Word.Range | null> {
+  try {
+    return await Word.run(async ctx => {
+      const body = ctx.document.body;
+      const searchRes = body.search(normalizeText(f.snippet), { matchCase: false, matchWholeWord: false });
+      searchRes.load("items");
+      await ctx.sync();
+      return searchRes.items.length ? searchRes.items[0] : null;
+    });
+  } catch (e) {
+    console.warn("mapFindingToRange fail", e);
+    return null;
+  }
+}
+
+export async function annotateFindingsIntoWord(findings: AnalyzeFinding[]) {
+  for (const f of findings) {
+    try {
+      await Word.run(async ctx => {
+        const body = ctx.document.body;
+        const searchRes = body.search(normalizeText(f.snippet), { matchCase: false, matchWholeWord: false });
+        searchRes.load("items");
+        await ctx.sync();
+        const range = searchRes.items[0];
+        if (range) {
+          const msg = `${f.rule_id} (${f.severity})${f.advice ? ": " + f.advice : ""}`;
+          range.insertComment(msg);
+        }
+        await ctx.sync();
+      });
+    } catch (e) {
+      console.warn("annotate fail", e);
+    }
+  }
+}
+
+export async function applyOpsTracked(ops: { start: number; end: number; replacement: string }[]) {
+  if (!ops || !ops.length) return;
+  const last: string = (window as any).__lastAnalyzed || "";
+  await Word.run(async ctx => {
+    const body = ctx.document.body;
+    (ctx.document as any).trackRevisions = true;
+    for (const op of ops) {
+      const snippet = last.slice(op.start, op.end);
+      const ranges = body.search(snippet, { matchCase: false, matchWholeWord: false });
+      ranges.load("items");
+      await ctx.sync();
+      const range = ranges.items[0];
+      if (range) {
+        range.insertText(op.replacement, "Replace");
+        try { range.insertComment("AI edit"); } catch {}
+      }
+      await ctx.sync();
+    }
+  });
+}
+
+async function acceptAll() {
+  try {
+    await Word.run(async ctx => {
+      ctx.document.body.acceptAllChanges();
+      await ctx.sync();
+    });
+    notifyOk("Accepted all changes");
+  } catch (e) {
+    notifyWarn("Accept failed");
+    console.error(e);
+  }
+}
+
+async function rejectAll() {
+  try {
+    await Word.run(async ctx => {
+      ctx.document.body.rejectAllChanges();
+      await ctx.sync();
+    });
+    notifyOk("Rejected all changes");
+  } catch (e) {
+    notifyWarn("Reject failed");
+    console.error(e);
+  }
+}
+
+async function navComments(dir: number) {
+  try {
+    await Word.run(async ctx => {
+      const comments = ctx.document.body.getComments();
+      comments.load("items");
+      await ctx.sync();
+      const list = comments.items;
+      if (!list.length) return;
+      const w: any = window as any;
+      w.__caiNavIdx = (w.__caiNavIdx ?? -1) + dir;
+      if (w.__caiNavIdx < 0) w.__caiNavIdx = list.length - 1;
+      if (w.__caiNavIdx >= list.length) w.__caiNavIdx = 0;
+      list[w.__caiNavIdx].getRange().select();
+      await ctx.sync();
+    });
+  } catch (e) {
+    console.warn("nav comment fail", e);
+  }
+}
+
+function onPrevIssue() { navComments(-1); }
+function onNextIssue() { navComments(1); }
+
 function renderResults(res: any) {
   const clause = slot("resClauseType", "clause-type");
   if (clause) clause.textContent = res?.clause_type || "—";
 
-  const findingsArr = Array.isArray(res?.findings) ? res.findings : [];
+  const findingsArr: AnalyzeFinding[] = parseFindings(res);
   const findingsList = slot("findingsList", "findings") as HTMLElement | null;
   if (findingsList) {
     findingsList.innerHTML = "";
@@ -110,33 +233,6 @@ async function getSelectionContext(chars = 200): Promise<{ before: string; after
   }
 }
 
-async function onUseSelection() {
-  try {
-    const txt = await getSelectionAsync();
-    const el = document.getElementById("originalClause") as HTMLTextAreaElement | null;
-    if (el) {
-      el.value = txt;
-      el.setAttribute("data-role", "source-loaded");
-    }
-  } catch (e) {
-    notifyWarn("Failed to load selection");
-    console.error(e);
-  }
-}
-
-async function onUseWholeDoc() {
-  try {
-    const txt = await getWholeDocText();
-    const el = document.getElementById("originalClause") as HTMLTextAreaElement | null;
-    if (el) {
-      el.value = txt;
-      el.setAttribute("data-role", "source-loaded");
-    }
-  } catch (e) {
-    notifyWarn("Failed to load document");
-    console.error(e);
-  }
-}
 
 async function onGetAIDraft(ev?: Event) {
   try {
@@ -193,12 +289,16 @@ async function doHealth() {
   }
 }
 
-async function doAnalyzeDoc() {
-  const text = await getWholeDocText();
-  if (!text || !text.trim()) { notifyErr("В документе нет текста"); return; }
+async function doAnalyze() {
+  const useSel = (document.getElementById("chkUseSelection") as HTMLInputElement | null)?.checked;
+  const raw = useSel ? await getSelectionAsync().catch(() => "") : await getWholeDocText();
+  const text = normalizeText(raw || "");
+  if (!text) { notifyErr("В документе нет текста"); return; }
+  (window as any).__lastAnalyzed = text;
   const { json, resp } = await apiAnalyze(text);
   try { applyMetaToBadges(metaFromResponse(resp)); } catch {}
   renderResults(json);
+  (document.getElementById("btnAnnotate") as HTMLButtonElement | null)?.removeAttribute("disabled");
   (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.results", { detail: json }));
   notifyOk("Analyze OK");
 }
@@ -221,17 +321,11 @@ function bindClick(sel: string, fn: () => void) {
 
 async function onApplyTracked() {
   try {
-    const dst = $(Q.proposed);
-    const proposed = (dst?.value || "").trim();
-    if (!proposed) { notifyWarn("No draft to insert"); return; }
-    await Word.run(async ctx => {
-      let range = ctx.document.getSelection();
-      (ctx.document as any).trackRevisions = true;
-      range.insertText(proposed, "Replace");
-      try { range.insertComment("AI draft"); } catch {}
-      await ctx.sync();
-    });
-    notifyOk("Inserted into Word");
+    const last = (window as any).__last || {};
+    const ops = last["gpt-draft"]?.json?.ops || last["suggest"]?.json?.ops || [];
+    if (!ops.length) { notifyWarn("No ops to apply"); return; }
+    await applyOpsTracked(ops);
+    notifyOk("Applied ops");
   } catch (e) {
     notifyWarn("Insert failed");
     console.error(e);
@@ -240,15 +334,20 @@ async function onApplyTracked() {
 
 function wireUI() {
   bindClick("#btnTest", doHealth);
-  bindClick("#btnAnalyzeDoc", doAnalyzeDoc);
+  bindClick("#btnAnalyze", doAnalyze);
   bindClick("#btnQARecheck", doQARecheck);
   document.getElementById("btnGetAIDraft")?.addEventListener("click", onGetAIDraft);
-  bindClick("#btn-use-selection", onUseSelection);
-  bindClick("#btn-use-whole", onUseWholeDoc);
   bindClick("#btnInsertIntoWord", onInsertIntoWord);
   bindClick("#btnApplyTracked", onApplyTracked);
-  bindClick("#btnAcceptAll", () => notifyWarn("Not implemented"));
-  bindClick("#btnRejectAll", () => notifyWarn("Not implemented"));
+  bindClick("#btnAcceptAll", acceptAll);
+  bindClick("#btnRejectAll", rejectAll);
+  bindClick("#btnPrevIssue", onPrevIssue);
+  bindClick("#btnNextIssue", onNextIssue);
+  bindClick("#btnAnnotate", () => {
+    const data = (window as any).__last?.analyze?.json || {};
+    const findings = parseFindings(data);
+    annotateFindingsIntoWord(findings);
+  });
   wireResultsToggle();
   console.log("Panel UI wired");
 }

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -205,9 +205,6 @@
   <div id="officeTools" class="row card" style="display:block">
     <div class="muted" style="margin-bottom:6px">Office tools</div>
     <div class="flex">
-      <!-- Поменяли местами и усилили whole -->
-      <button id="btn-use-whole" class="btn btn-lg btn-primary js-disable-while-busy" style="margin-right:8px">Use whole doc →</button>
-      <button id="btn-use-selection" class="btn btn-sm js-disable-while-busy">Use selection →</button>
       <button id="btnInsertIntoWord" class="btn">Insert result into Word</button>
     </div>
   </div>
@@ -225,9 +222,12 @@
       </div>
     </div>
     <div class="row flex" style="margin-top:6px">
-      <button id="btnAnalyzeDoc" class="btn-grey js-disable-while-busy">Analyze (doc)</button>
+      <button id="btnAnalyze" class="btn-grey js-disable-while-busy">Analyze</button>
+      <label class="inline" style="gap:4px"><input type="checkbox" id="chkUseSelection"/>Use selection</label>
       <small class="js-busy-indicator">⏳</small>
-      <button id="btnAnnotate" class="btn2 js-disable-while-busy">Annotate</button>
+      <button id="btnAnnotate" class="btn2 js-disable-while-busy" disabled>Annotate</button>
+      <button id="btnPrevIssue" class="btn-grey js-disable-while-busy">Prev issue</button>
+      <button id="btnNextIssue" class="btn-grey js-disable-while-busy">Next issue</button>
       <button id="btnQARecheck" class="btn-grey js-disable-while-busy">QA Recheck</button>
       <button id="btnClearAnnots" class="btn-grey js-disable-while-busy" title="Select text in Word before applying edits.">Clear Annotations</button>
       <span class="pill right" id="qaDeltaBadge" title="QA deltas">Δ: —</span>


### PR DESCRIPTION
## Summary
- unify analyze response parsing with `parseFindings` helper and types
- add Word annotation, navigation and tracked edit helpers in task pane
- expose diff operations from `/api/suggest_edits`
- simplify Analyze UI to single button with selection toggle
- add tests for findings parsing, analyze offsets and ops patching

## Testing
- `node tests/panel/test_parse_findings.js`
- `node tests/panel/test_store_state.js`
- `pytest -q tests/rules/recitals_and_clauses1/test_recitals_and_clauses1.py`
- `pytest -q tests/rules/definitions/test_b_block_and_calloff.py`
- `pytest -q tests/panel/test_slots_exist.py`
- `pytest -q tests/panel/test_analyze_offsets.py` *(fails: No module named 'fastapi')*
- `pytest -q tests/panel/test_suggest_ops_minimal.py` *(fails: No module named 'fastapi')*
- `pytest -q tests/panel/test_gpt_draft_payload.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68baecccc3b48325a158c01978f0dcd4