### PR TITLE
Add UK definitions S-to-W block rules and tests

### DIFF
--- a/core/rules/uk/definitions/s_to_w_block/01_site_ownership_access_risk.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/01_site_ownership_access_risk.yaml
@@ -1,0 +1,76 @@
+rule:
+  id: "uk.def.site.ownership_access_risk"
+  version: "1.0.0"
+  title: "Site: ownership/control; access/HSE; risk alignment with cl.19/20"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","site","worksite","risk","insurance","call-off"]
+  triggers:
+    any:
+      - regex: "(?i)\\bSite\\b\\s+means"
+  checks:
+    - id: "owner_control_missing"
+      when:
+        any:
+          - not_regex: "(?i)owned|leased|licensed|under\\s+the\\s+control\\s+of\\s+the\\s+Company|Affiliates?"
+      finding:
+        message: "No clear ownership/lease/licence/control basis for the Site."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "State Site is owned/leased/licensed or otherwise under control of Company or its Affiliates."
+        score_delta: -15
+    - id: "access_hse_missing"
+      when:
+        any:
+          - not_regex: "(?i)access\\s+rights|right\\s+of\\s+way|easements?"
+          - not_regex: "(?i)HSE|health\\s+and\\s+safety|permit\\s+to\\s+work"
+      finding:
+        message: "Access rights/HSE regime at Site not articulated."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Add access rights (easements/pass regime) and HSE controls (permit-to-work/site rules)."
+        score_delta: -15
+    - id: "risk_alignment_missing"
+      when:
+        any:
+          - not_regex: "(?i)Clause\\s*19|Risk"
+          - not_regex: "(?i)Clause\\s*20|Insurance"
+      finding:
+        message: "No cross-reference to risk (cl.19) and insurance (cl.20)."
+        severity_level: "medium"
+        risk: "medium"
+        legal_basis: []
+        suggestion:
+          text: "Cross-reference Clause 19 (Risk) and Clause 20 (Insurance) for third-party property at Site."
+        score_delta: -10
+    - id: "calloff_worksites_link"
+      when:
+        all:
+          - regex: "(?i)Call[-\\s]?Off|Worksites?"
+          - not_regex: "(?i)listed\\s+in\\s+(the|each)\\s+Call[-\\s]?Off"
+      finding:
+        message: "Worksites list not tied to each Call-Off."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Require Worksites to be listed in each Call-Off."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: SiteAccessRiskGap
+    score: 80
+    problem: "Site ownership/control/access/HSE or risk/insurance links are unclear."
+    recommendation: "Define control basis, access & HSE, link to cl.19/20, and list Worksites per Call-Off."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Site","access","HSE","risk","insurance","Worksites"]
+metadata:
+  tags: ["site","hse","risk"]

--- a/core/rules/uk/definitions/s_to_w_block/02_specifications_versioning_variations.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/02_specifications_versioning_variations.yaml
@@ -1,0 +1,63 @@
+rule:
+  id: "uk.def.specs.versioning_and_variations"
+  version: "1.0.0"
+  title: "Specifications: version/DCC; no hidden updates; priority of stricter requirement"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","specifications","variation","codes","fitness"]
+  triggers:
+    any:
+      - regex: "(?i)Specifications?\\s+means"
+  checks:
+    - id: "dcc_version_missing"
+      when:
+        any:
+          - not_regex: "(?i)Document\\s+Control|DCC|revision|version"
+      finding:
+        message: "No DCC/reference/revision control for Specifications."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Reference DCC/Document Control and include revision/issue/date identifiers."
+        score_delta: -15
+    - id: "as_updated_without_variation"
+      when:
+        all:
+          - regex: "(?i)as\\s+updated\\s+from\\s+time\\s+to\\s+time"
+          - not_regex: "(?i)Variation|Clause\\s*14|Change\\s+Control"
+      finding:
+        message: "Dynamic updates to specifications without Variation/Change Control."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Require updates via Clause 14 Variation Order; clerical fixes only by notice."
+        score_delta: -20
+    - id: "no_fitness_priority_rule"
+      when:
+        all:
+          - regex: "(?i)Codes?\\s+and\\s+Standards|fitness\\s+for\\s+purpose"
+          - not_regex: "(?i)stricter\\s+requirement\\s+prevails|fitness\\s+takes\\s+priority"
+      finding:
+        message: "No priority rule between fitness-for-purpose and codes/standards."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "State that the stricter requirement prevails (MT Højgaard approach)."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: SpecsChangeControlGap
+    score: 80
+    problem: "Specs lack DCC/versioning; allow hidden updates; or miss priority rule."
+    recommendation: "Add DCC and VO gate; set stricter-of fitness/codes priority."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Specifications","DCC","Variation","fitness","codes"]
+metadata:
+  tags: ["specs","variation","dcc"]

--- a/core/rules/uk/definitions/s_to_w_block/03_subcontractor_flowdown_audit.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/03_subcontractor_flowdown_audit.yaml
@@ -1,0 +1,62 @@
+rule:
+  id: "uk.def.subcontractor.flowdown_audit"
+  version: "1.0.0"
+  title: "Subcontractor: tier coverage; flow-down (HSE/ABC/export/IP/NDA); audit/approval"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","subcontractor","compliance","audit","anti-bribery","export","ip"]
+  triggers:
+    any:
+      - regex: "(?i)Subcontractor\\s+means"
+  checks:
+    - id: "tiers_not_covered"
+      when:
+        not_regex: "(?i)all\\s+tiers|tier[-\\s]?n|sub[-\\s]?tiers?"
+      finding:
+        message: "Definition does not cover multi-tier subcontracting."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Extend to all tiers (tier-n) including suppliers of equipment/materials."
+        score_delta: -15
+    - id: "flowdown_gaps"
+      when:
+        any:
+          - not_regex: "(?i)health\\s+and\\s+safety|HSE"
+          - not_regex: "(?i)anti[-\\s]?bribery|UKBA|sanctions|export"
+          - not_regex: "(?i)Intellectual\\s+Property|confidentiality"
+          - not_regex: "(?i)audit|inspect"
+      finding:
+        message: "Missing flow-downs (HSE/anti-bribery/sanctions/export/IP/NDA) and/or audit rights."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Mandate flow-down of HSE, ABC, sanctions/export, IP/confidentiality and audit/access rights."
+        score_delta: -20
+    - id: "approval_missing"
+      when:
+        not_regex: "(?i)prior\\s+written\\s+approval|right\\s+to\\s+approve|critical\\s+subcontractors?"
+      finding:
+        message: "No prior approval process for critical subcontractors."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Introduce approval/blacklist/right to require replacement of critical subs."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: SubcontractorFlowDownGap
+    score: 80
+    problem: "Subcontractor definition lacks tier coverage/flow-downs/audit/approval."
+    recommendation: "Cover all tiers; add flow-down matrix, audit and approval mechanics."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Subcontractor","flow-down","audit","tiers"]
+metadata:
+  tags: ["subs","compliance","audit"]

--- a/core/rules/uk/definitions/s_to_w_block/04_supplied_software_scope_licence_escrow.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/04_supplied_software_scope_licence_escrow.yaml
@@ -1,0 +1,81 @@
+rule:
+  id: "uk.def.supplied_software.scope_licence_escrow"
+  version: "1.0.0"
+  title: "Supplied Software: full scope; broad licence; keys/docs/updates; escrow if critical"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","software","ip","licence","escrow"]
+  triggers:
+    any:
+      - regex: "(?i)Supplied\\s+Software\\s+means"
+  checks:
+    - id: "components_missing"
+      when:
+        any:
+          - not_regex: "(?i)executables?|embedded|utilities?|tools"
+          - not_regex: "(?i)keys|passwords|diagnostic|logs?"
+          - not_regex: "(?i)documentation|manuals?"
+          - not_regex: "(?i)updates|patch(es)?"
+      finding:
+        message: "Software scope omits executables/embedded/utilities, keys/passwords/diagnostics, docs or updates."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Enumerate executables/embedded/utilities, keys/passwords/diagnostics, documentation and updates/patches."
+        score_delta: -20
+    - id: "licence_too_narrow"
+      when:
+        any:
+          - not_regex: "(?i)modify|adapt|integrat|test|disaster\\s+recovery|backup"
+          - not_regex: "(?i)worldwide|perpetual|royalty[-\\s]?free"
+          - not_regex: "(?i)sub[-\\s]?licen[cs]e\\s+within\\s+the\\s+Company\\s+Group"
+      finding:
+        message: "Licence too narrow for operation/maintenance/integration/DR."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Grant worldwide, perpetual, royalty-free licence incl. modify/integrate/test/DR/backup; allow sub-licence within Company Group."
+        score_delta: -25
+    - id: "ipr_moral_db_rights"
+      when:
+        any:
+          - not_regex: "(?i)assignment\\s+in\\s+writing"
+          - not_regex: "(?i)(waiv.*moral\\s+rights|moral\\s+rights.*waiv)"
+          - not_regex: "(?i)database\\s+right"
+      finding:
+        message: "Missing assignment-in-writing / moral rights waiver / database right coverage."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Ensure clause 17 covers assignment in writing (CDPA s.90), waiver of moral rights, and database right."
+        score_delta: -20
+    - id: "escrow_missing"
+      when:
+        all:
+          - regex: "(?i)critical|mission\\s+critical|essential"
+          - not_regex: "(?i)escrow|source\\s+code\\s+escrow"
+      finding:
+        message: "Critical software without escrow arrangement."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Add source code escrow for critical software."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: SuppliedSoftwareLicenceGap
+    score: 80
+    problem: "Software scope/licence/IPR safeguards inadequate."
+    recommendation: "Broaden scope/licence; keys/docs/updates; IPR safeguards; escrow if critical."
+    law_reference: ["CDPA 1988 s.90","Database Regs 1997"]
+    category: "Definitions"
+    keywords: ["software","licence","escrow","keys","updates"]
+metadata:
+  tags: ["software","ip","escrow"]

--- a/core/rules/uk/definitions/s_to_w_block/05_tariff_code_classification.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/05_tariff_code_classification.yaml
@@ -1,0 +1,51 @@
+rule:
+  id: "uk.def.tariff_code.classification"
+  version: "1.0.0"
+  title: "Tariff Code: UK Trade Tariff/HS basis; evidence and fiscal effects"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","imports","tax","customs"]
+  triggers:
+    any:
+      - regex: "(?i)Tariff\\s+Code|Commodity\\s+Code"
+  checks:
+    - id: "code_or_hs_missing"
+      when:
+        any:
+          - not_regex: "(?i)\\b\\d{6,10}\\b"
+          - not_regex: "(?i)HS\\s*20\\d{2}|Harmonized\\s+System"
+      finding:
+        message: "Commodity code or HS basis/version not stated."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Provide commodity code and HS version as classification basis."
+        score_delta: -15
+    - id: "no_evidence_or_fiscal_effects"
+      when:
+        any:
+          - not_regex: "(?i)evidence|classification\\s+note|ruling"
+          - not_regex: "(?i)dut(y|ies)|VAT"
+      finding:
+        message: "No evidence of classification and/or missing duty/VAT implications."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Attach classification evidence/ruling and list duty/VAT impacts."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: TariffCodeClassificationGap
+    score: 80
+    problem: "Tariff code lacks HS basis, evidence or fiscal effects."
+    recommendation: "Add HS basis, evidence and duty/VAT implications; verify via UK Trade Tariff."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Tariff Code","Commodity Code","HS","VAT","duty"]
+metadata:
+  tags: ["customs","tariff"]

--- a/core/rules/uk/definitions/s_to_w_block/06_taxes_matrix_withholding_grossup.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/06_taxes_matrix_withholding_grossup.yaml
@@ -1,0 +1,62 @@
+rule:
+  id: "uk.def.taxes.matrix_withholding_grossup"
+  version: "1.0.0"
+  title: "Taxes: responsibility matrix; withholding/gross-up; IoR/Incoterms consistency"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","tax","payments","withholding","incoterms"]
+  triggers:
+    any:
+      - regex: "(?i)Taxes?\\s+means"
+  checks:
+    - id: "matrix_missing"
+      when:
+        not_regex: "(?i)responsibilit(y|ies)\\s+matrix|Contractor\\s+Group\\s+taxes"
+      finding:
+        message: "No clear allocation of Contractor Group taxes (payroll, NI, import/export duties/fees)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Add responsibility matrix: Contractor bears own payroll/social, import/export duties and fees."
+        score_delta: -15
+    - id: "withholding_or_grossup_missing"
+      when:
+        any:
+          - not_regex: "(?i)withholding"
+          - not_regex: "(?i)gross[-\\s]?up"
+      finding:
+        message: "Withholding or gross-up mechanics absent."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Add withholding/gross-up clause and DTA relief procedures."
+        score_delta: -15
+    - id: "ior_incoterms_conflict"
+      when:
+        all:
+          - regex: "(?i)Incoterms|DDP|DAP|IoR|Importer\\s+of\\s+Record"
+          - not_regex: "(?i)consistent|align|in\\s+line\\s+with\\s+IoR"
+      finding:
+        message: "Potential conflict between Taxes allocation and IoR/Incoterms responsibilities."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Align Taxes with IoR/EoR and chosen Incoterms for VAT/duties payer."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: TaxesAllocationGap
+    score: 80
+    problem: "Tax allocation/withholding/gross-up or IoR/Incoterms alignment unclear."
+    recommendation: "Add matrix and withholding/gross-up; align with IoR/Incoterms."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Taxes","withholding","gross-up","Incoterms","IoR"]
+metadata:
+  tags: ["tax","payments"]

--- a/core/rules/uk/definitions/s_to_w_block/07_third_party_crtpa_alignment.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/07_third_party_crtpa_alignment.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.def.third_party.crtpa_alignment"
+  version: "1.0.0"
+  title: "Third Party: exclude Company/Contractor Groups; align with CRTPA carve-outs"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","third party rights","crpta"]
+  triggers:
+    any:
+      - regex: "(?i)Third\\s+Party\\s+means"
+  checks:
+    - id: "groups_exclusion_missing"
+      when:
+        not_regex: "(?i)exclud(?:es|ing)\\s+the\\s+Company\\s+Group\\s+and\\s+the\\s+Contractor\\s+Group"
+      finding:
+        message: "Third Party definition does not exclude the parties’ Groups."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Explicitly exclude Company Group and Contractor Group."
+        score_delta: -15
+    - id: "crtpa_link_missing"
+      when:
+        not_regex: "(?i)Contracts\\s*\\(Rights\\s+of\\s+Third\\s+Parties\\)\\s*Act|CRTPA|Clause\\s*32"
+      finding:
+        message: "No alignment with CRTPA carve-outs."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Reference CRTPA clause/carve-outs to prevent unintended third-party rights."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: ThirdPartyScopeGap
+    score: 85
+    problem: "Third Party scope too wide or not aligned with CRTPA."
+    recommendation: "Exclude Groups and align with CRTPA carve-outs."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Third Party","CRTPA","Groups"]
+metadata:
+  tags: ["crpta","third-party"]

--- a/core/rules/uk/definitions/s_to_w_block/08_trade_tariff_source_recency.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/08_trade_tariff_source_recency.yaml
@@ -1,0 +1,51 @@
+rule:
+  id: "uk.def.trade_tariff.source_recency"
+  version: "1.0.0"
+  title: "Trade Tariff: official UK source; HS link; recency stamp and measures"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","imports","customs","tax"]
+  triggers:
+    any:
+      - regex: "(?i)Trade\\s+Tariff"
+  checks:
+    - id: "source_or_hs_missing"
+      when:
+        any:
+          - not_regex: "(?i)GOV\\.UK|UK\\s+Trade\\s+Tariff|CDS"
+          - not_regex: "(?i)HS|Harmonized\\s+System|WCO"
+      finding:
+        message: "Trade Tariff lacks official UK source or HS linkage."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Reference UK Trade Tariff service and HS/WCO basis."
+        score_delta: -15
+    - id: "recency_measures_missing"
+      when:
+        any:
+          - not_regex: "(?i)last\\s+checked|date"
+          - not_regex: "(?i)measures|dut(y|ies)|prohibitions|licences"
+      finding:
+        message: "No last-checked date or applicable measures stated."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Record last-checked date and list measures (duties, licences, restrictions)."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: TradeTariffRecencyGap
+    score: 80
+    problem: "Trade Tariff reference not anchored to official source/HS and recency/measures."
+    recommendation: "Add official source + HS link and recency/measures fields."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Trade Tariff","CDS","HS","measures"]
+metadata:
+  tags: ["customs","tariff","recency"]

--- a/core/rules/uk/definitions/s_to_w_block/09_tupe_eli_requirements.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/09_tupe_eli_requirements.yaml
@@ -1,0 +1,60 @@
+rule:
+  id: "uk.def.tupe.eli_requirements"
+  version: "1.0.0"
+  title: "TUPE: cite 2006 regs; Employee Liability Information (Reg.11) deadlines and content"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","tupe","personnel","data protection"]
+  triggers:
+    any:
+      - regex: "(?i)TUPE|Transfer\\s+of\\s+Undertakings\\s+\\(Protection\\s+of\\s+Employment\\)"
+  checks:
+    - id: "citation_missing"
+      when:
+        not_regex: "(?i)2006"
+      finding:
+        message: "TUPE reference does not cite the 2006 Regulations (as amended)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Refer to the Transfer of Undertakings (Protection of Employment) Regulations 2006 (as amended)."
+        score_delta: -10
+    - id: "eli_requirements_missing"
+      when:
+        any:
+          - not_regex: "(?i)Employee\\s+Liability\\s+Information|Reg\\.?\\s*11"
+          - not_regex: "(?i)\\b7\\s*days\\b|\\b14\\s*days\\b|deadline|snapshot"
+      finding:
+        message: "No ELI (Reg.11) snapshot/delivery deadlines/content."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Include ELI snapshot date and delivery by statutory deadlines with accuracy warranty."
+        score_delta: -15
+    - id: "dpa_data_transfer"
+      when:
+        not_regex: "(?i)Data\\s+Protection|lawful\\s+basis|anonymi[sz]e"
+      finding:
+        message: "No data protection safeguards around ELI transfer."
+        severity_level: "medium"
+        risk: "medium"
+        legal_basis: []
+        suggestion:
+          text: "Add lawful basis/anonymisation for ELI sharing."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: TUPEELIGap
+    score: 80
+    problem: "TUPE/ELI referencing and safeguards incomplete."
+    recommendation: "Cite 2006 regs; add ELI deadlines/content and DPA safeguards."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["TUPE","ELI Reg.11","DPA"]
+metadata:
+  tags: ["tupe","eli","privacy"]

--- a/core/rules/uk/definitions/s_to_w_block/10_variation_gate.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/10_variation_gate.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.def.variation.gate"
+  version: "1.0.0"
+  title: "Variation: any change to Work/Price/Schedule only via Variation Order (Clause 14)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","variation","change control"]
+  triggers:
+    any:
+      - regex: "(?i)Variation\\s+means"
+  checks:
+    - id: "vo_required_missing"
+      when:
+        all:
+          - regex: "(?i)change|amend|modify"
+          - not_regex: "(?i)Variation\\s+Order|Clause\\s*14"
+      finding:
+        message: "Variation defined without gating changes via a Variation Order."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "State that any change to Work/Price/Schedule only takes effect via a VO under Clause 14."
+        score_delta: -20
+    - id: "proceed_on_risk_not_banned"
+      when:
+        not_regex: "(?i)no\\s+proceed(ing)?\\s+without\\s+a\\s+signed\\s+VO"
+      finding:
+        message: "No explicit ban on proceeding without a signed VO."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Ban proceeding without a signed VO; emergency safety actions excepted."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: VariationGateGap
+    score: 80
+    problem: "Changes can bypass Clause 14 VO gate."
+    recommendation: "Enforce VO gate and ban proceed-without-VO."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Variation","VO","Clause 14"]
+metadata:
+  tags: ["variation","change-control"]

--- a/core/rules/uk/definitions/s_to_w_block/11_variation_order_contents.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/11_variation_order_contents.yaml
@@ -1,0 +1,52 @@
+rule:
+  id: "uk.def.variation.order_contents"
+  version: "1.0.0"
+  title: "Variation Order: content checklist (scope delta, TIA, price build-up, interfaces, LD/warranty impacts)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["variation","call-off","scope","price","schedule","risk"]
+  triggers:
+    any:
+      - regex: "(?i)Variation\\s+Order\\b"
+  checks:
+    - id: "contents_missing"
+      when:
+        any:
+          - not_regex: "(?i)scope\\s+change|delta"
+          - not_regex: "(?i)Time\\s+Impact\\s+Analysis|TIA"
+          - not_regex: "(?i)price\\s+build[-\\s]?up|rates"
+          - not_regex: "(?i)interfaces?"
+          - not_regex: "(?i)warrant(y|ies)|LDs?|liquidated\\s+damages"
+      finding:
+        message: "VO content incomplete (scope/TIA/price/interfaces/warranty/LD impacts)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Include scope delta, TIA, price build-up, interfaces, impacts on warranties/LDs."
+        score_delta: -20
+    - id: "precedence_update_missing"
+      when:
+        not_regex: "(?i)order\\s+of\\s+precedence|Clause\\s*2\\.2"
+      finding:
+        message: "No statement how VO integrates with order of precedence."
+        severity_level: "medium"
+        risk: "medium"
+        legal_basis: []
+        suggestion:
+          text: "Reference Clause 2.2 and update precedence if needed."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: VariationOrderContentGap
+    score: 80
+    problem: "VO lacks mandatory content or precedence integration."
+    recommendation: "Add checklist and precedence reference."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["VO","scope delta","TIA","price","LD","precedence"]
+metadata:
+  tags: ["variation","vo"]

--- a/core/rules/uk/definitions/s_to_w_block/12_variation_order_request_process.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/12_variation_order_request_process.yaml
@@ -1,0 +1,39 @@
+rule:
+  id: "uk.def.vor.process"
+  version: "1.0.0"
+  title: "Variation Order Request: initiator, timelines, evaluation; no proceed on risk"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["variation","process"]
+  triggers:
+    any:
+      - regex: "(?i)Variation\\s+Order\\s+Request|\\bVOR\\b"
+  checks:
+    - id: "process_elements_missing"
+      when:
+        any:
+          - not_regex: "(?i)initiat(or|ed)\\s+by"
+          - not_regex: "(?i)response|evaluation|timeline|\\b\\d+\\s*(days|business\\s+days)"
+          - not_regex: "(?i)(no\\s+proceed(ing)?\\s+without\\s+(a\\s+)?(signed\\s+)?VO|proceed(ing)?\\s+without\\s+(a\\s+)?(signed\\s+)?VO\\s+is\\s+prohibited)"
+      finding:
+        message: "VOR lacks initiator, response/evaluation timelines, or proceed-on-risk ban."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Define initiator, response/evaluation timelines and ban proceeding without VO."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: VORProcessGap
+    score: 80
+    problem: "VOR process incomplete."
+    recommendation: "Add initiator, timelines, and no-proceed safeguard."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["VOR","process","timeline","no proceed"]
+metadata:
+  tags: ["variation","vor"]

--- a/core/rules/uk/definitions/s_to_w_block/13_vat_registration_place_of_supply_zero_rating.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/13_vat_registration_place_of_supply_zero_rating.yaml
@@ -1,0 +1,62 @@
+rule:
+  id: "uk.def.vat.registration_place_of_supply_zero_rating"
+  version: "1.0.0"
+  title: "VAT: VAT Act 1994; registration/invoicing; place of supply; reverse charge/zero-rating evidence"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","tax","vat","invoicing","imports"]
+  triggers:
+    any:
+      - regex: "(?i)VAT\\s+means|Value\\s+Added\\s+Tax"
+  checks:
+    - id: "vat_act_missing"
+      when:
+        not_regex: "(?i)Value\\s+Added\\s+Tax\\s+Act\\s+1994"
+      finding:
+        message: "VAT Act 1994 not referenced."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Reference VAT Act 1994 for charge/rates/place of supply."
+        score_delta: -10
+    - id: "registration_invoicing_missing"
+      when:
+        any:
+          - not_regex: "(?i)VAT\\s+registration|VAT\\s+number"
+          - not_regex: "(?i)valid\\s+invoice|tax\\s+invoice"
+      finding:
+        message: "VAT registration or invoicing requirements missing."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Require VAT registration/number and valid tax invoices."
+        score_delta: -15
+    - id: "place_of_supply_or_reverse_zero_missing"
+      when:
+        any:
+          - not_regex: "(?i)place\\s+of\\s+supply|reverse\\s+charge"
+          - not_regex: "(?i)zero[-\\s]?rating|export\\s+evidence"
+      finding:
+        message: "Place of supply/reverse charge or zero-rating evidence not addressed."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Address place of supply/reverse charge and require export/zero-rating evidence."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: VATComplianceGap
+    score: 80
+    problem: "VAT framework incomplete."
+    recommendation: "Cite VAT Act 1994, require registration/invoices, place of supply/reverse charge and evidence for zero-rating."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["VAT Act 1994","reverse charge","place of supply","zero-rating"]
+metadata:
+  tags: ["vat","tax"]

--- a/core/rules/uk/definitions/s_to_w_block/14_work_scope_boundary_interfaces.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/14_work_scope_boundary_interfaces.yaml
@@ -1,0 +1,52 @@
+rule:
+  id: "uk.def.work.scope_boundary_interfaces"
+  version: "1.0.0"
+  title: "Work: broad scope; enforce boundaries (battery limits/interfaces/exclusions); link QA/LD/Variation"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","work","scope","qa","variation","ld"]
+  triggers:
+    any:
+      - regex: "(?i)Work\\s+means"
+  checks:
+    - id: "boundaries_missing"
+      when:
+        any:
+          - not_regex: "(?i)battery\\s+limits|boundar(y|ies)"
+          - not_regex: "(?i)interfaces?"
+          - not_regex: "(?i)exclusions?"
+      finding:
+        message: "Work lacks explicit boundaries/interfaces/exclusions to prevent scope creep."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Add battery limits, interfaces and exclusions; tie changes to VO."
+        score_delta: -20
+    - id: "qa_ld_links_missing"
+      when:
+        any:
+          - not_regex: "(?i)QA|quality\\s+plan|inspection"
+          - not_regex: "(?i)liquidated\\s+damages|LDs"
+      finding:
+        message: "No linkage to QA/inspection and LDs for schedule/performance."
+        severity_level: "medium"
+        risk: "medium"
+        legal_basis: []
+        suggestion:
+          text: "Reference QA/inspection regime and any LDs applicable in Call-Off."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: WorkBoundaryGap
+    score: 80
+    problem: "Work definition lacks boundaries/QA/LD links."
+    recommendation: "Define limits/interfaces/exclusions; link to QA and LD; route changes via VO."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Work","scope creep","interfaces","exclusions","QA","LD"]
+metadata:
+  tags: ["work","scope"]

--- a/core/rules/uk/definitions/s_to_w_block/15_worksite_inclusion_exclusions.yaml
+++ b/core/rules/uk/definitions/s_to_w_block/15_worksite_inclusion_exclusions.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.def.worksite.inclusion_exclusions"
+  version: "1.0.0"
+  title: "Worksite: includes execution locations; excludes manufacturing/pre-delivery plants; HSE/insurance"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["definitions","worksite","site","hse","insurance"]
+  triggers:
+    any:
+      - regex: "(?i)Worksite\\s+means"
+  checks:
+    - id: "exclusions_missing"
+      when:
+        not_regex: "(?i)excluding\\s+manufactur(ing)?|pre[-\\s]?delivery|factory|plant"
+      finding:
+        message: "Worksite definition does not exclude manufacturing/pre-delivery facilities."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Exclude manufacturing/pre-delivery plants unless expressly listed as Worksites."
+        score_delta: -15
+    - id: "hse_insurance_missing"
+      when:
+        any:
+          - not_regex: "(?i)HSE|site\\s+rules|permit\\s+to\\s+work"
+          - not_regex: "(?i)insurance\\s+appl(ies|y|icability)"
+      finding:
+        message: "No HSE or insurance applicability statements for Worksites."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: []
+        suggestion:
+          text: "Reference HSE/site rules and whether insurance applies at Worksites."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: WorksiteExclusionGap
+    score: 80
+    problem: "Worksite scope does not handle factory exclusions or HSE/insurance."
+    recommendation: "Exclude factories unless listed; add HSE/insurance applicability."
+    law_reference: []
+    category: "Definitions"
+    keywords: ["Worksite","factory exclusion","HSE","insurance"]
+metadata:
+  tags: ["worksite","hse","insurance"]

--- a/tests/rules/definitions/test_s_to_w_block.py
+++ b/tests/rules/definitions/test_s_to_w_block.py
@@ -1,0 +1,214 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+def AI(text, clause="definitions", doc="Master Agreement"):
+    return AnalysisInput(clause_type=clause, text=text,
+                         metadata={"jurisdiction":"UK","doc_type":doc})
+
+# 1) Site
+def test_site_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/01_site_ownership_access_risk.yaml")
+    t = "Site means any location."
+    out = run_rule(spec, AI(t, clause="site"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_site_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/01_site_ownership_access_risk.yaml")
+    t = ("Site means locations owned, leased, licensed or under the control of the Company or its Affiliates; "
+         "access rights (easements) and HSE permit-to-work apply; risk is aligned with Clause 19 and insurance with Clause 20; "
+         "Worksites are listed in each Call-Off.")
+    out = run_rule(spec, AI(t, clause="site"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 2) Specifications
+def test_specs_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/02_specifications_versioning_variations.yaml")
+    t = "Specifications means documents as updated from time to time."
+    out = run_rule(spec, AI(t, clause="specifications"))
+    assert out is not None and any("dynamic updates" in f.message.lower() or "dcc" in f.message.lower() for f in out.findings)
+
+def test_specs_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/02_specifications_versioning_variations.yaml")
+    t = ("Specifications are DCC-controlled (revision/date). Any update requires a Variation Order under Clause 14; "
+         "the stricter of fitness-for-purpose or codes/standards prevails.")
+    out = run_rule(spec, AI(t, clause="specifications"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 3) Subcontractor
+def test_subcontractor_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/03_subcontractor_flowdown_audit.yaml")
+    t = "Subcontractor means any direct subcontractor."
+    out = run_rule(spec, AI(t, clause="subcontractor"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_subcontractor_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/03_subcontractor_flowdown_audit.yaml")
+    t = ("Subcontractor means any party at all tiers (tier-n), including suppliers of equipment and materials; "
+         "flow-down includes HSE, anti-bribery/sanctions/export, IP/confidentiality and audit rights; critical subs require prior written approval.")
+    out = run_rule(spec, AI(t, clause="subcontractor"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 4) Supplied Software
+def test_supplied_software_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/04_supplied_software_scope_licence_escrow.yaml")
+    t = "Supplied Software means software licensed for use."
+    out = run_rule(spec, AI(t, clause="software"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_supplied_software_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/04_supplied_software_scope_licence_escrow.yaml")
+    t = ("Supplied Software includes executables, embedded components, utilities, keys/passwords/diagnostics, documentation and updates/patches; "
+         "licence is worldwide, perpetual and royalty-free, allowing modify/integrate/test/DR/backup and sub-licence within the Company Group; "
+         "clause 17 covers assignment in writing, waiver of moral rights and database right; critical software is subject to source code escrow.")
+    out = run_rule(spec, AI(t, clause="software"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 5) Tariff Code
+def test_tariff_code_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/05_tariff_code_classification.yaml")
+    t = "Tariff Code means the code for customs."
+    out = run_rule(spec, AI(t, clause="imports"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_tariff_code_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/05_tariff_code_classification.yaml")
+    t = "Commodity Code 8504403000 classified under HS 2022; classification evidence is available; duties and VAT implications are stated."
+    out = run_rule(spec, AI(t, clause="imports"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 6) Taxes
+def test_taxes_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/06_taxes_matrix_withholding_grossup.yaml")
+    t = "Taxes means taxes."
+    out = run_rule(spec, AI(t, clause="tax"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_taxes_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/06_taxes_matrix_withholding_grossup.yaml")
+    t = ("A responsibility matrix allocates Contractor Group taxes (payroll/NI/import/export duties/fees); "
+         "withholding and gross-up mechanics apply with DTA relief; Taxes align with IoR/EoR and chosen Incoterms (e.g., DDP).")
+    out = run_rule(spec, AI(t, clause="tax"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 7) Third Party
+def test_third_party_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/07_third_party_crtpa_alignment.yaml")
+    t = "Third Party means any person other than the parties."
+    out = run_rule(spec, AI(t, clause="third party rights"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_third_party_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/07_third_party_crtpa_alignment.yaml")
+    t = "Third Party excludes the Company Group and the Contractor Group and aligns with the CRTPA carve-outs (Clause 32)."
+    out = run_rule(spec, AI(t, clause="third party rights"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 8) Trade Tariff
+def test_trade_tariff_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/08_trade_tariff_source_recency.yaml")
+    t = "Trade Tariff means a tariff."
+    out = run_rule(spec, AI(t, clause="imports"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_trade_tariff_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/08_trade_tariff_source_recency.yaml")
+    t = "Trade Tariff refers to the UK Trade Tariff (GOV.UK/CDS) and the HS/WCO basis; last checked date is recorded and applicable measures are listed."
+    out = run_rule(spec, AI(t, clause="imports"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 9) TUPE
+def test_tupe_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/09_tupe_eli_requirements.yaml")
+    t = "TUPE applies."
+    out = run_rule(spec, AI(t, clause="tupe"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_tupe_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/09_tupe_eli_requirements.yaml")
+    t = ("Transfer of Undertakings (Protection of Employment) Regulations 2006 (as amended); "
+         "Employee Liability Information (Reg.11) snapshot and delivery deadlines apply with accuracy warranty and data protection safeguards.")
+    out = run_rule(spec, AI(t, clause="tupe"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 10) Variation
+def test_variation_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/10_variation_gate.yaml")
+    t = "Variation means any change."
+    out = run_rule(spec, AI(t, clause="variation"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_variation_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/10_variation_gate.yaml")
+    t = "Any change to Work/Price/Schedule only takes effect via a Variation Order under Clause 14; no proceeding without a signed VO."
+    out = run_rule(spec, AI(t, clause="variation"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 11) VO
+def test_vo_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/11_variation_order_contents.yaml")
+    t = "Variation Order may be issued."
+    out = run_rule(spec, AI(t, clause="variation"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_vo_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/11_variation_order_contents.yaml")
+    t = ("A Variation Order includes scope delta, Time Impact Analysis, price build-up, interfaces and effects on warranties/LDs, "
+         "and references Clause 2.2 for order of precedence.")
+    out = run_rule(spec, AI(t, clause="variation"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 12) VOR
+def test_vor_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/12_variation_order_request_process.yaml")
+    t = "A VOR may be sent."
+    out = run_rule(spec, AI(t, clause="variation"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_vor_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/12_variation_order_request_process.yaml")
+    t = "A Variation Order Request may be initiated by either party; response/evaluation timelines apply (10 Business Days); proceeding without a signed VO is prohibited."
+    out = run_rule(spec, AI(t, clause="variation"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 13) VAT
+def test_vat_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/13_vat_registration_place_of_supply_zero_rating.yaml")
+    t = "VAT means value added tax."
+    out = run_rule(spec, AI(t, clause="vat"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_vat_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/13_vat_registration_place_of_supply_zero_rating.yaml")
+    t = ("VAT refers to the Value Added Tax Act 1994; Contractor provides VAT registration/number and valid tax invoices; "
+         "place of supply/reverse charge rules may apply; evidence is required for zero-rating on export.")
+    out = run_rule(spec, AI(t, clause="vat"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 14) Work
+def test_work_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/14_work_scope_boundary_interfaces.yaml")
+    t = "Work means all that is reasonably incidental."
+    out = run_rule(spec, AI(t, clause="work"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_work_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/14_work_scope_boundary_interfaces.yaml")
+    t = ("Work includes explicit battery limits, interfaces and exclusions; QA/inspection regime applies and LDs may apply; "
+         "changes to Work are only via VO.")
+    out = run_rule(spec, AI(t, clause="work"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 15) Worksite
+def test_worksite_negative():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/15_worksite_inclusion_exclusions.yaml")
+    t = "Worksite means any place where work is done."
+    out = run_rule(spec, AI(t, clause="worksite"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_worksite_positive():
+    spec = load_rule("core/rules/uk/definitions/s_to_w_block/15_worksite_inclusion_exclusions.yaml")
+    t = ("Worksite includes locations of execution and excludes manufacturing/pre-delivery plants unless expressly listed; "
+         "HSE/site rules apply and insurance applicability is stated.")
+    out = run_rule(spec, AI(t, clause="worksite"))
+    assert out is None or len(getattr(out, "findings", [])) == 0


### PR DESCRIPTION
## Summary
- add 15 UK definition rules from Site through Worksite, covering ownership, specs versioning, subcontractor flow-down, software licensing, tariffs, taxes, third-party exclusions, TUPE, variations, VAT, and more
- add focused tests validating each rule's negative and positive scenarios

## Testing
- `pytest tests/rules/definitions/test_s_to_w_block.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baefa443648325b32ad0867ece18ae