### PR TITLE
Add UK interpretation rule set for section 2.2 and tests

### DIFF
--- a/core/rules/uk/interpretation/2_2_rules/01_xrefs_links.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/01_xrefs_links.yaml
@@ -1,0 +1,55 @@
+rule:
+  id: "uk.int.2_2_1a.xrefs_links_exist"
+  version: "1.0.0"
+  title: "Cross-references must exist and match 1.1 exhibits"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","definitions","recitals"]
+  triggers:
+    any:
+      - regex: "(?i)Preamble|Recitals?|Clause\\s+\\d|Exhibit\\s+[A-Z]"
+  checks:
+    - id: "broken_clause_ref"
+      when:
+        regex: "(?i)Clause\\s+(\\d{2,}(?:\\.\\d+)*)"
+      finding:
+        message: "Clause reference present; engine must verify it resolves."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Ensure Clause numbering/titles kept updated; fix any broken references."
+        score_delta: -15
+    - id: "exhibit_not_listed_in_1_1"
+      when:
+        regex: "(?i)Exhibit\\s+([A-Z])"
+      finding:
+        message: "Exhibit referenced; verify it exists in Clause 1.1 exhibit list."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add missing exhibit to 1.1 list or correct the reference."
+        score_delta: -15
+    - id: "modified_numbers_titles"
+      when:
+        regex: "(?i)Clause\\s*3\\.12[\\s\\S]*?(amend|number(ing)?|title)"
+      finding:
+        message: "If modified under cl.3.12, cross-references must reflect updated number/title."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Synchronise numbering/titles after cl.3.12 modifications."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CrossReferenceIntegrity
+    score: 85
+    problem: "Potential broken/unknown cross-references."
+    recommendation: "Validate against Clause 1.1 exhibit list and current numbering."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["cross-reference","exhibits","1.1 list","3.12"]
+metadata:
+  tags: ["xrefs","integrity"]

--- a/core/rules/uk/interpretation/2_2_rules/02_time_periods_basis.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/02_time_periods_basis.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.int.2_2_1b.time_basis_calendar_vs_business"
+  version: "1.0.0"
+  title: "Time basis clarity (calendar days vs Business Days; timezone per Notices)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","notices","payments"]
+  triggers:
+    any:
+      - regex: "(?i)\\b\\d+\\s+days?\\b"
+  checks:
+    - id: "calendar_vs_business_ambiguous"
+      when:
+        all:
+          - regex: "(?i)\\b\\d+\\s+days?\\b"
+          - not_regex: "(?i)Business\\s+Days?|calendar\\s+days?"
+      finding:
+        message: "Day periods used without specifying calendar vs Business Days."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Specify 'Business Days' or 'calendar days' and align timezone with Notices (Clause 29)."
+        score_delta: -15
+    - id: "timezone_missing"
+      when:
+        not_regex: "(?i)UK\\s*time|GMT|BST|time\\s*zone|Clause\\s*29"
+      finding:
+        message: "Timezone/Notices alignment not stated for time calculations."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Tie cut-offs to UK time and Notices clause."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: TimeBasisAmbiguity
+    score: 85
+    problem: "Ambiguity between calendar and Business Days; timezone unclear."
+    recommendation: "State time basis and align with Notices."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["time","business day","timezone","Notices"]
+metadata:
+  tags: ["time","business-day"]

--- a/core/rules/uk/interpretation/2_2_rules/03_number_gender.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/03_number_gender.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "uk.int.2_2_1c.number_gender_presumption"
+  version: "1.0.0"
+  title: "Presumption: singular includes plural; genders interchangeable unless defined otherwise"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation"]
+  triggers:
+    any:
+      - regex: "(?i)singular\\s+includes\\s+the\\s+plural|plural\\s+includes\\s+the\\s+singular"
+  checks:
+    - id: "local_definition_conflict"
+      when:
+        regex: "(?i)Personnel\\s+means|Invitees?\\s+means|Contractor\\s+Group\\s+means"
+      finding:
+        message: "Local definitions may narrow the presumption; ensure no contradiction."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Clarify that specific definitions override general presumption where necessary."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: NumberGenderConflict
+    score: 88
+    problem: "Potential conflict between general presumption and specific definitions."
+    recommendation: "Confirm precedence of specific defined terms where intended."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["singular","plural","gender","definitions"]
+metadata:
+  tags: ["interpretation"]

--- a/core/rules/uk/interpretation/2_2_rules/04_including_non_exhaustive.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/04_including_non_exhaustive.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "uk.int.2_2_1d.including_is_without_limitation"
+  version: "1.0.0"
+  title: "\"Including/in particular\" are illustrative, not limiting"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","specifications","scope"]
+  triggers:
+    any:
+      - regex: "(?i)including|in\\s+particular"
+  checks:
+    - id: "closed_list_risk"
+      when:
+        all:
+          - regex: "(?i)including\\s+([\\s\\S]{0,60})\\b(and|or)\\b\\s+\\w+\\.?$"
+          - not_regex: "(?i)without\\s+limitation|without\\s+limit"
+      finding:
+        message: "‘Including’ appears limiting; add ‘without limitation’ to avoid closed list."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Use ‘including, without limitation’ unless a closed list is intended."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: IncludingMayLimit
+    score: 88
+    problem: "‘Including’ may be read as limiting."
+    recommendation: "Add ‘without limitation’ or restructure list."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["including","non-exhaustive"]
+metadata:
+  tags: ["including"]

--- a/core/rules/uk/interpretation/2_2_rules/05_company_vs_Company.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/05_company_vs_Company.yaml
@@ -1,0 +1,38 @@
+rule:
+  id: "uk.int.2_2_1e.company_vs_Company_defined_term"
+  version: "1.0.0"
+  title: "Disambiguate generic 'company' vs defined 'Company'"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","definitions","parties"]
+  triggers:
+    any:
+      - regex: "(?i)\\bcompany\\b"
+  checks:
+    - id: "case_mixing"
+      when:
+        all:
+          - regex: "(?i)\\bcompany\\b"
+          - regex: "\\bCompany\\b"
+          - not_regex: "(?i)generic|lower\\s+case"
+      finding:
+        message: "Both ‘company’ and defined ‘Company’ used; ensure no ambiguity."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Use capitalised ‘Company’ for the defined party; keep lowercase only for generic sense."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: CompanyDisambiguation
+    score: 88
+    problem: "Potential ambiguity between generic and defined term."
+    recommendation: "Consistent capitalisation per defined terms."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["Company","company","defined term"]
+metadata:
+  tags: ["defined-terms"]

--- a/core/rules/uk/interpretation/2_2_rules/06_person_scope.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/06_person_scope.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "uk.int.2_2_1f.person_scope_broad"
+  version: "1.0.0"
+  title: "‘Person’ covers individuals, companies, bodies, authorities, associations"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","definitions"]
+  triggers:
+    any:
+      - regex: "(?i)person\\s+includes"
+  checks:
+    - id: "gov_auth_alignment"
+      when:
+        not_regex: "(?i)Governmental\\s+Authorit(y|ies)|regulator"
+      finding:
+        message: "Definition of ‘person’ should align with Governmental Authority and Third Party."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Ensure ‘person’ encompasses public bodies and aligns with Third Party carve-outs."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: PersonScopeMismatch
+    score: 88
+    problem: "Person scope may not align with related definitions."
+    recommendation: "Harmonise definitions."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["person","authority","third party"]
+metadata:
+  tags: ["definitions"]

--- a/core/rules/uk/interpretation/2_2_rules/07_dynamic_incorp_variation.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/07_dynamic_incorp_variation.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.int.2_2_1g.dynamic_incorp_requires_variation"
+  version: "1.0.0"
+  title: "Dynamic incorporation triggers Variation/compensation (no unilateral uplift)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","policies","standards","variation"]
+  triggers:
+    any:
+      - regex: "(?i)as\\s+(amended|updated)\\s+from\\s+time\\s+to\\s+time"
+  checks:
+    - id: "no_variation_trigger"
+      when:
+        not_regex: "(?i)Variation|Clause\\s*14|Change\\s+Control"
+      finding:
+        message: "Dynamic updates lack Variation/Change Control trigger."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Subject dynamic updates to Clause 14 Variation and equitable adjustments."
+        score_delta: -20
+    - id: "company_policies_unilateral"
+      when:
+        all:
+          - regex: "(?i)Company\\s+Policies|Standards"
+          - not_regex: "(?i)cost|time|adjust(ment|s)|compensation"
+      finding:
+        message: "Company policies updated unilaterally without cost/time adjustments."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add adjustment mechanism or limit updates to non-material changes."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: DynamicIncorpWithoutVO
+    score: 80
+    problem: "Uncontrolled dynamic updates may reallocate risk."
+    recommendation: "Gate via VO/Change Control with adjustments."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["as amended","policies","VO"]
+metadata:
+  tags: ["variation","policies"]

--- a/core/rules/uk/interpretation/2_2_rules/08_approvals_writing_reps.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/08_approvals_writing_reps.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "uk.int.2_2_1h.approvals_in_writing_by_reps"
+  version: "1.0.0"
+  title: "Approvals in writing by authorised Representatives; no silence=consent"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","approvals","representatives","notices"]
+  triggers:
+    any:
+      - regex: "(?i)Approval\\s+must\\s+be\\s+in\\s+writing"
+  checks:
+    - id: "rep_role_unspecified"
+      when:
+        not_regex: "(?i)Representative(s)?|authorised"
+      finding:
+        message: "Approver role not restricted to authorised Representatives."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Limit approvals to authorised Representatives per Clause 4."
+        score_delta: -10
+    - id: "silence_equals_approval"
+      when:
+        regex: "(?i)(deemed\\s+approved|silence(?!\\s+is\\s+not))"
+      finding:
+        message: "Deemed/silent approvals detected; risk of unintended consent."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Remove silence=approval; require explicit written approval."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: ApprovalAuthorityGap
+    score: 82
+    problem: "Approval authority or process unclear."
+    recommendation: "Restrict to authorised Reps; forbid silent approvals."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["approval","writing","Representatives"]
+metadata:
+  tags: ["approval","authority"]

--- a/core/rules/uk/interpretation/2_2_rules/09_writing_email_esign.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/09_writing_email_esign.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "uk.int.2_2_1i.writing_email_esign_alignment"
+  version: "1.0.0"
+  title: "‘Writing’ excludes email: ensure e-sign/portal carve-outs else process risk"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","notices","variation","approvals"]
+  triggers:
+    any:
+      - regex: "(?i)writing|written"
+  checks:
+    - id: "email_excluded_but_needed"
+      when:
+        all:
+          - regex: "(?i)email\\s+shall\\s+not\\s+constitute\\s+writing"
+          - not_regex: "(?i)e-?signature|portal|platform|DocuSign|Adobe\\s+Sign"
+      finding:
+        message: "Email excluded as 'writing' but no e-sign/portal pathway specified."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Allow e-sign platforms/secure portal for VO/approvals; keep Notices email rules in Clause 29."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: WritingProcessRisk
+    score: 80
+    problem: "Operational dead-ends for VO/approvals if email excluded."
+    recommendation: "Add e-sign/portal carve-outs and align with Notices."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["writing","email","e-sign","Notices"]
+metadata:
+  tags: ["esign","process"]

--- a/core/rules/uk/interpretation/2_2_rules/10_calloff_incorp_msa.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/10_calloff_incorp_msa.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "uk.int.2_2_1j.calloff_incorporates_msa"
+  version: "1.0.0"
+  title: "Each Call-Off incorporates MSA and states precedence per 2.2.4"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","Call-Off"]
+    clauses: ["interpretation","call-off","precedence"]
+  triggers:
+    any:
+      - regex: "(?i)Call[-\\s]?Off"
+  checks:
+    - id: "incorporation_missing"
+      when:
+        not_regex: "(?i)incorporat(ed|es)\\s+the\\s+MSA|this\\s+Agreement"
+      finding:
+        message: "Call-Off does not explicitly incorporate MSA terms."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State that Call-Off incorporates MSA conditions."
+        score_delta: -20
+    - id: "precedence_missing"
+      when:
+        not_regex: "(?i)precedence|Clause\\s*2\\.2\\.4|order\\s+of\\s+precedence"
+      finding:
+        message: "Call-Off lacks precedence statement."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add precedence per 2.2.4."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CallOffIncorporationGap
+    score: 80
+    problem: "Call-Off missing incorporation/precedence."
+    recommendation: "Add explicit incorporation and precedence."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["Call-Off","incorporation","precedence"]
+metadata:
+  tags: ["calloff","precedence"]

--- a/core/rules/uk/interpretation/2_2_rules/11_subcontracts_flowdown.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/11_subcontracts_flowdown.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.int.2_2_1k.subcontracts_flowdown_audit"
+  version: "1.0.0"
+  title: "‘Subcontracts’ includes services/materials/equipment; flow-down & audit rights"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","subcontracts","compliance","audit"]
+  triggers:
+    any:
+      - regex: "(?i)Subcontracts?\\s+means"
+  checks:
+    - id: "coverage_narrow"
+      when:
+        not_regex: "(?i)services?|materials?|equipment|Contractor\\s+Group\\s+Equipment"
+      finding:
+        message: "Subcontracts definition too narrow."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Include services, materials, equipment, Contractor Group Equipment."
+        score_delta: -15
+    - id: "flowdown_audit_missing"
+      when:
+        any:
+          - not_regex: "(?i)(flow[-\\s]?down|back[-\\s]?to[-\\s]?back)"
+          - not_regex: "(?i)audit|inspect"
+      finding:
+        message: "Flow-down/audit rights absent."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add mandatory flow-down and audit/access rights."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: SubcontractsFlowDownGap
+    score: 80
+    problem: "Subcontracts coverage/flow-down incomplete."
+    recommendation: "Broaden scope; include flow-down and audit."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["subcontracts","flow-down","audit"]
+metadata:
+  tags: ["subs","flowdown"]

--- a/core/rules/uk/interpretation/2_2_rules/12_headings_no_effect.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/12_headings_no_effect.yaml
@@ -1,0 +1,25 @@
+rule:
+  id: "uk.int.2_2_2.headings_no_effect"
+  version: "1.0.0"
+  title: "Headings are for convenience only and do not affect interpretation"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation"]
+  triggers:
+    any:
+      - regex: "(?i)headings?\\s+are\\s+for\\s+convenience"
+  checks: []
+  outcome:
+    status: pass
+    risk_level: low
+    severity: S4
+    issue_type: None
+    score: 100
+    problem: ""
+    recommendation: ""
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["headings","no effect"]
+metadata:
+  tags: ["headings"]

--- a/core/rules/uk/interpretation/2_2_rules/13_precedence_agreement_alpha.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/13_precedence_agreement_alpha.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "uk.int.2_2_3.precedence_agreement_alpha_risk"
+  version: "1.0.0"
+  title: "Agreement precedence: Clauses over Exhibits; alphabetical exhibits flagged as risk"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","precedence"]
+  triggers:
+    any:
+      - regex: "(?i)order\\s+of\\s+precedence|precedence"
+  checks:
+    - id: "alphabetical_exhibits_used"
+      when:
+        regex: "(?i)Exhibits?\\s+in\\s+alphabetical\\s+order"
+      finding:
+        message: "Alphabetical exhibit precedence is atypical and may cause accidental priority."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Replace with purpose-based precedence (Conditions > Scope/Specs > Standards/Codes > Templates)."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: PrecedenceAlphaRisk
+    score: 87
+    problem: "Alphabetical exhibit precedence can misallocate priority."
+    recommendation: "Adopt purpose-based precedence matrix."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["precedence","alphabetical","exhibits"]
+metadata:
+  tags: ["precedence"]

--- a/core/rules/uk/interpretation/2_2_rules/14_precedence_calloff.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/14_precedence_calloff.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.int.2_2_4.precedence_calloff"
+  version: "1.0.0"
+  title: "Call-Off precedence: (a) MSA Clauses (as modified 3.12) > (b) other Call-Off terms > (c) MSA Exhibits (alpha) > (d) Call-Off attachments > (e) POs/others"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off","Master Agreement","MSA"]
+    clauses: ["interpretation","call-off","precedence"]
+  triggers:
+    any:
+      - regex: "(?i)Call[-\\s]?Off"
+  checks:
+    - id: "modifies_msa_not_per_3_12"
+      when:
+        all:
+          - regex: "(?i)modify|amend|override"
+          - not_regex: "(?i)Clause\\s*3\\.12|expressly\\s+modif(y|ies)"
+      finding:
+        message: "Call-Off attempts to modify MSA without cl.3.12 compliance."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Require explicit 3.12 reference and pinpointed amendment."
+        score_delta: -20
+    - id: "po_terms_last_shot"
+      when:
+        regex: "(?i)(Supplier\\s+Terms\\s+apply|terms\\s+on\\s+PO\\s+apply)"
+      finding:
+        message: "PO/boilerplate terms attempt to override precedence (Tekdata risk)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State Supplier T&Cs are excluded; precedence follows 2.2.4."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CallOffPrecedenceBreach
+    score: 80
+    problem: "Call-Off modifies MSA improperly or lets PO terms win."
+    recommendation: "Enforce cl.3.12 and exclude Supplier T&Cs."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["Call-Off","precedence","Tekdata","3.12"]
+metadata:
+  tags: ["precedence","battle-of-forms"]

--- a/core/rules/uk/interpretation/2_2_rules/15_ambiguity_dr_checks.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/15_ambiguity_dr_checks.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "uk.int.2_2_5.ambiguity_pre_dr_checks"
+  version: "1.0.0"
+  title: "Before DR: check stringency rule (2.2.7) and correlative rule (2.2.6)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA"]
+    clauses: ["interpretation","dispute resolution","precedence"]
+  triggers:
+    any:
+      - regex: "(?i)dispute\\s+resolution|escalation"
+  checks:
+    - id: "no_pre_dr_checks"
+      when:
+        all:
+          - not_regex: "(?i)stricter|stringency|fitness"
+          - not_regex: "(?i)mutually\\s+explanatory|correlative"
+      finding:
+        message: "No attempt to apply 2.2.6/2.2.7 before DR."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Apply correlative and stricter-of rules prior to escalation."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: DRPremature
+    score: 88
+    problem: "Escalation without applying interpretation tie-breakers."
+    recommendation: "Apply 2.2.6 and 2.2.7 first."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["DR","ambiguity","tie-breakers"]
+metadata:
+  tags: ["dr","tie-breakers"]

--- a/core/rules/uk/interpretation/2_2_rules/16_correlative_scope_creep.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/16_correlative_scope_creep.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "uk.int.2_2_6.mutually_explanatory_scope_creep_guard"
+  version: "1.0.0"
+  title: "Correlative rule: no unpaid scope creep; route extras via VO"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","Call-Off"]
+    clauses: ["interpretation","scope","variation","specifications"]
+  triggers:
+    any:
+      - regex: "(?i)mutually\\s+explanatory|correlative"
+  checks:
+    - id: "battery_limits_missing"
+      when:
+        not_regex: "(?i)battery\\s+limits|interfaces|exclusions"
+      finding:
+        message: "No boundaries to restrain correlative expansion of Work."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Define limits/interfaces/exclusions; require VO for extras."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CorrelativeScopeCreep
+    score: 80
+    problem: "Correlative rule may inflate scope without VO."
+    recommendation: "Add boundaries and VO trigger."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["correlative","scope creep","VO"]
+metadata:
+  tags: ["scope","variation"]

--- a/core/rules/uk/interpretation/2_2_rules/17_stringency_fitness.yaml
+++ b/core/rules/uk/interpretation/2_2_rules/17_stringency_fitness.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "uk.int.2_2_7.stringency_fitness_priority"
+  version: "1.0.0"
+  title: "Stricter-of rule: fitness/target prevails over codes; VO if cost/time rises"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Master Agreement","MSA","Call-Off"]
+    clauses: ["interpretation","specifications","fitness","variation"]
+  triggers:
+    any:
+      - regex: "(?i)stricter|stringency|fitness\\s+for\\s+purpose"
+  checks:
+    - id: "vo_link_missing"
+      when:
+        all:
+          - regex: "(?i)stricter|fitness"
+          - not_regex: "(?i)Variation|Clause\\s*14|adjust(ment|s)|cost|time"
+      finding:
+        message: "Stricter-of rule present without VO/cost-time adjustment mechanism."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Link stricter-of to VO with cost/time adjustments."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: StringencyWithoutVO
+    score: 80
+    problem: "Stricter standard may impose extra cost/time without adjustment."
+    recommendation: "Bind to Clause 14 VO and adjustments."
+    law_reference: []
+    category: "Interpretation"
+    keywords: ["stringency","fitness","VO"]
+metadata:
+  tags: ["fitness","variation"]

--- a/tests/rules/interpretation/test_2_2_rules.py
+++ b/tests/rules/interpretation/test_2_2_rules.py
@@ -1,0 +1,223 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+def AI(text, clause="interpretation", doc="Master Agreement"):
+    return AnalysisInput(clause_type=clause, text=text,
+                         metadata={"jurisdiction":"UK","doc_type":doc})
+
+# 01 xrefs
+def test_xrefs_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/01_xrefs_links.yaml")
+    t = "See Exhibit Z and Clause 99.9."
+    out = run_rule(spec, AI(t))
+    assert out is not None and len(out.findings) >= 1
+
+def test_xrefs_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/01_xrefs_links.yaml")
+    t = "References to Recitals, Clauses and Exhibits listed in Clause 1.1 are updated per Clause 3.12."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 02 time basis
+def test_time_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/02_time_periods_basis.yaml")
+    t = "Notice must be served within 5 days."
+    out = run_rule(spec, AI(t, clause="notices"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_time_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/02_time_periods_basis.yaml")
+    t = "Notice must be served within 5 Business Days (UK time) and aligned with Clause 29."
+    out = run_rule(spec, AI(t, clause="notices"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 03 number/gender
+def test_number_gender_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/03_number_gender.yaml")
+    t = "Personnel means ... (narrow definition) ... singular includes plural."
+    out = run_rule(spec, AI(t))
+    assert out is not None and len(out.findings) >= 1
+
+def test_number_gender_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/03_number_gender.yaml")
+    t = "Singular includes the plural and vice versa; specific definitions override where stated."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 04 including
+def test_including_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/04_including_non_exhaustive.yaml")
+    t = "Including A and B."
+    out = run_rule(spec, AI(t, clause="specifications"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_including_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/04_including_non_exhaustive.yaml")
+    t = "Including, without limitation, A and B."
+    out = run_rule(spec, AI(t, clause="specifications"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 05 company vs Company
+def test_company_term_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/05_company_vs_Company.yaml")
+    t = "The company agrees... The Company shall also..."
+    out = run_rule(spec, AI(t, clause="parties"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_company_term_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/05_company_vs_Company.yaml")
+    t = "The Company (defined) agrees; references to a generic company are lower case only when not the defined Party."
+    out = run_rule(spec, AI(t, clause="parties"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 06 person scope
+def test_person_scope_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/06_person_scope.yaml")
+    t = "Person includes individuals and companies."
+    out = run_rule(spec, AI(t))
+    assert out is not None and len(out.findings) >= 1
+
+def test_person_scope_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/06_person_scope.yaml")
+    t = "Person includes individuals, companies, public authorities and associations; aligned with Governmental Authority and Third Party."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 07 dynamic incorporation
+def test_dynamic_incorp_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/07_dynamic_incorp_variation.yaml")
+    t = "Company Policies apply as updated from time to time."
+    out = run_rule(spec, AI(t, clause="policies"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_dynamic_incorp_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/07_dynamic_incorp_variation.yaml")
+    t = "Company Policies apply as updated from time to time subject to Clause 14 Variation and cost/time adjustments."
+    out = run_rule(spec, AI(t, clause="policies"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 08 approvals
+def test_approvals_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/08_approvals_writing_reps.yaml")
+    t = "Approval must be in writing; silence may be deemed approval."
+    out = run_rule(spec, AI(t, clause="approvals"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_approvals_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/08_approvals_writing_reps.yaml")
+    t = "Approval must be in writing by authorised Representatives; silence is not approval."
+    out = run_rule(spec, AI(t, clause="approvals"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 09 writing/email/e-sign
+def test_writing_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/09_writing_email_esign.yaml")
+    t = "Email shall not constitute writing."
+    out = run_rule(spec, AI(t))
+    assert out is not None and len(out.findings) >= 1
+
+def test_writing_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/09_writing_email_esign.yaml")
+    t = "Email shall not constitute writing; VO/approvals via DocuSign or secure portal; Notices follow Clause 29."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 10 call-off incorporates MSA
+def test_calloff_incorp_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/10_calloff_incorp_msa.yaml")
+    t = "Call-Off for services."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_calloff_incorp_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/10_calloff_incorp_msa.yaml")
+    t = "This Call-Off incorporates the MSA and states precedence per Clause 2.2.4."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 11 subcontracts
+def test_subcontracts_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/11_subcontracts_flowdown.yaml")
+    t = "Subcontracts means agreements with direct subcontractors."
+    out = run_rule(spec, AI(t, clause="subcontracts"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_subcontracts_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/11_subcontracts_flowdown.yaml")
+    t = "Subcontracts includes services, materials, equipment and Contractor Group Equipment with mandatory flow-down and audit rights."
+    out = run_rule(spec, AI(t, clause="subcontracts"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 12 headings no effect
+def test_headings_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/12_headings_no_effect.yaml")
+    t = "Headings are for convenience only and do not affect interpretation."
+    out = run_rule(spec, AI(t))
+    assert out is None
+
+# 13 precedence Agreement alpha
+def test_precedence_alpha_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/13_precedence_agreement_alpha.yaml")
+    t = "Order of precedence: Exhibits in alphabetical order."
+    out = run_rule(spec, AI(t, clause="precedence"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_precedence_alpha_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/13_precedence_agreement_alpha.yaml")
+    t = "Order of precedence: Clauses over Exhibits; purpose-based precedence applies."
+    out = run_rule(spec, AI(t, clause="precedence"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 14 precedence Call-Off
+def test_precedence_calloff_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/14_precedence_calloff.yaml")
+    t = "Supplier Terms apply to this PO."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_precedence_calloff_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/14_precedence_calloff.yaml")
+    t = "Any modification of the MSA must expressly modify Clause X under Clause 3.12; Supplier T&Cs are excluded; precedence follows 2.2.4."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 15 ambiguity → DR
+def test_ambiguity_dr_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/15_ambiguity_dr_checks.yaml")
+    t = "Escalate to Dispute Resolution."
+    out = run_rule(spec, AI(t, clause="dispute resolution"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_ambiguity_dr_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/15_ambiguity_dr_checks.yaml")
+    t = "Before Dispute Resolution, the Parties will apply the mutually explanatory and stricter-of rules."
+    out = run_rule(spec, AI(t, clause="dispute resolution"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 16 correlative
+def test_correlative_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/16_correlative_scope_creep.yaml")
+    t = "Documents are mutually explanatory."
+    out = run_rule(spec, AI(t, clause="interpretation"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_correlative_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/16_correlative_scope_creep.yaml")
+    t = "Documents are mutually explanatory; boundaries (battery limits, interfaces, exclusions) apply; extras require a Variation Order."
+    out = run_rule(spec, AI(t, clause="interpretation"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 17 stringency / fitness
+def test_stringency_negative():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/17_stringency_fitness.yaml")
+    t = "The stricter standard shall apply."
+    out = run_rule(spec, AI(t, clause="specifications"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_stringency_positive():
+    spec = load_rule("core/rules/uk/interpretation/2_2_rules/17_stringency_fitness.yaml")
+    t = "The stricter standard (including fitness-for-purpose) shall apply with cost/time adjustments via a Variation Order under Clause 14."
+    out = run_rule(spec, AI(t, clause="specifications"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+


### PR DESCRIPTION
## Summary
- implement UK interpretation rules 2.2.1(a)-2.2.7 covering cross references, time basis, definitions and precedence
- add pytest verifying behaviour across 33 scenarios

## Testing
- `pytest tests/rules/interpretation/test_2_2_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf34458588325ad8dd5d76e0364cf