### PR TITLE
Add UK Section 3 call-off and order rules

### DIFF
--- a/core/rules/uk/section3/01_po_excludes_supplier_terms.yaml
+++ b/core/rules/uk/section3/01_po_excludes_supplier_terms.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.s3.po.exclude_supplier_terms"
+  version: "1.0.0"
+  title: "PO/Call-Off must exclude Supplier T&Cs; precedence per 2.2.4 (Tekdata)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off","Master Agreement","MSA","PO"]
+    clauses: ["call-off","precedence","purchase order"]
+  triggers:
+    any:
+      - regex: "(?i)Supplier\\s+Terms\\s+apply|terms\\s+on\\s+(the\\s+)?back|subject\\s+to\\s+supplier\\s+terms"
+      - regex: "(?i)to\\s+the\\s+exclusion\\s+of\\s+all\\s+other\\s+terms"
+  checks:
+    - id: "supplier_terms_present"
+      when:
+        regex: "(?i)Supplier\\s+Terms\\s+apply|terms\\s+on\\s+(the\\s+)?back|subject\\s+to\\s+supplier\\s+terms"
+      finding:
+        message: "Supplier/boilerplate T&Cs attempt to apply (battle of forms risk)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: ["Tekdata v Amphenol (CA, 2009)"]
+        suggestion:
+          text: "Insert: 'This Call-Off/PO incorporates the MSA to the exclusion of all other terms; precedence per Clause 2.2.4.'"
+        score_delta: -20
+    - id: "msa_precedence_missing"
+      when:
+        not_regex: "(?i)exclusion\\s+of\\s+all\\s+other\\s+terms|precedence|Clause\\s*2\\.2\\.4"
+      finding:
+        message: "No explicit exclusion of Supplier T&Cs/precedence."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add explicit exclusion and precedence statement (2.2.4)."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: BattleOfFormsRisk
+    score: 80
+    problem: "Supplier T&Cs may override MSA."
+    recommendation: "Exclude Supplier T&Cs; enforce 2.2.4."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["battle of forms","PO","precedence","Tekdata"]
+metadata:
+  tags: ["po","precedence","tekdata"]

--- a/core/rules/uk/section3/02_start_work_acceptance_guard.yaml
+++ b/core/rules/uk/section3/02_start_work_acceptance_guard.yaml
@@ -1,0 +1,38 @@
+rule:
+  id: "uk.s3.order.start_as_acceptance_guard"
+  version: "1.0.0"
+  title: "Start of performance as acceptance requires core terms locked; otherwise block"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off","MSA"]
+    clauses: ["call-off","formation"]
+  triggers:
+    any:
+      - regex: "(?i)commencement\\s+of\\s+performance\\s+constitutes\\s+acceptance|start\\s+work\\s+constitutes\\s+acceptance"
+  checks:
+    - id: "core_terms_not_locked"
+      when:
+        any:
+          - not_regex: "(?i)price|milestones?|LD|scope|IP|HSE"
+          - not_regex: "(?i)no\\s+work\\s+shall\\s+commence\\s+without\\s+a\\s+written\\s+Order"
+      finding:
+        message: "Start-work acceptance with core terms unset (RTS risk)."
+        severity_level: "blocker"
+        risk: "high"
+        legal_basis: ["RTS v Müller (UKSC, 2010)"]
+        suggestion:
+          text: "Add 'No work starts without signed Order or written confirmation covering Price/SoW/LD/IP/HSE.'"
+        score_delta: -30
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S1
+    issue_type: StartWorkAcceptanceRisk
+    score: 60
+    problem: "Work-as-acceptance without locked core terms."
+    recommendation: "Prohibit start without written order or lock core terms."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["acceptance","formation","RTS"]
+metadata:
+  tags: ["formation","rts"]

--- a/core/rules/uk/section3/03_ld_only_remedy_gate.yaml
+++ b/core/rules/uk/section3/03_ld_only_remedy_gate.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "uk.s3.ld.only_remedy_gates"
+  version: "1.0.0"
+  title: "LD as exclusive remedy for delay only with conditions/caps/termination link"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off","MSA"]
+    clauses: ["delay","ld","remedies"]
+  triggers:
+    any:
+      - regex: "(?i)only\\s+remedy\\s+for\\s+delay"
+  checks:
+    - id: "no_cap_or_threshold"
+      when:
+        not_regex: "(?i)cap|max(imum)?\\s+LD|percentage\\s+of\\s+price"
+      finding:
+        message: "Exclusive LD without cap/threshold reference."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add LD cap and termination threshold."
+        score_delta: -15
+    - id: "no_conditions_ref"
+      when:
+        not_regex: "(?i)subject\\s+to\\s+Clause\\s*3\\.10\\.(3|4|5)|conditions\\s+set\\s+out\\s+in\\s+Clause\\s*3\\.10"
+      finding:
+        message: "Exclusive LD lacks reference to gating conditions."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Reference gating subclauses (3.10.3–.5)."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: LDExclusiveRemedyRisk
+    score: 80
+    problem: "Exclusive LD without clear gates/caps."
+    recommendation: "Add caps and gating references."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["LD","exclusive remedy","cap"]
+metadata:
+  tags: ["ld","remedies"]

--- a/core/rules/uk/section3/04_typo_numbering_blocker.yaml
+++ b/core/rules/uk/section3/04_typo_numbering_blocker.yaml
@@ -1,0 +1,40 @@
+rule:
+  id: "uk.s3.editorial.typos_numbering_block"
+  version: "1.0.0"
+  title: "Editorial defects (broken cross-ref/typos) must be fixed pre-issue"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["section3","ld","general"]
+  triggers:
+    any:
+      - regex: "(?i)Notwithstanding\\s+C\\s+Company"
+      - regex: "(?i)foregoing[\\s\\S]{0,40}of\\s+this\\s+Clause\\s+3\\.10\\.3"
+      - regex: "(?i)partrial\\s+shipment"
+  checks:
+    - id: "editorial_block"
+      when:
+        any:
+          - regex: "(?i)Notwithstanding\\s+C\\s+Company"
+          - regex: "(?i)foregoing[\\s\\S]{0,40}Clause\\s+3\\.10\\.3"
+          - regex: "(?i)partrial\\s+shipment"
+      finding:
+        message: "Editorial error (broken ref/typo) detected."
+        severity_level: "blocker"
+        risk: "high"
+        suggestion:
+          text: "Correct text and numbering before release."
+        score_delta: -40
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S1
+    issue_type: EditorialDefect
+    score: 50
+    problem: "Editorial defects in Section 3."
+    recommendation: "Fix before execution."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["typo","numbering","blocker"]
+metadata:
+  tags: ["editorial","blocker"]

--- a/core/rules/uk/section3/05_no_minimum_commitment.yaml
+++ b/core/rules/uk/section3/05_no_minimum_commitment.yaml
@@ -1,0 +1,36 @@
+rule:
+  id: "uk.s3.volume.no_min_commit"
+  version: "1.0.0"
+  title: "No guarantee of volume; detect hidden minimums"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["section3","volume","tender"]
+  triggers:
+    any:
+      - regex: "(?i)minimum\\s+(purchase|order|hours|commitment)|requirements\\s+contract"
+      - regex: "(?i)Nothing\\s+in\\s+this\\s+Agreement\\s+shall\\s+be\\s+construed\\s+as\\s+a\\s+guarantee"
+  checks:
+    - id: "hidden_minimum"
+      when:
+        regex: "(?i)minimum\\s+(purchase|order|hours|commitment)|requirements\\s+contract"
+      finding:
+        message: "Hidden minimum commitment contradicts 3.1."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Remove minimums or qualify via explicit framework exception."
+        score_delta: -20
+  outcome:
+    status: pass
+    risk_level: low
+    severity: S4
+    issue_type: None
+    score: 100
+    problem: ""
+    recommendation: ""
+    law_reference: []
+    category: "Section 3"
+    keywords: ["volume","minimum commitment"]
+metadata:
+  tags: ["volume"]

--- a/core/rules/uk/section3/06_non_exclusive.yaml
+++ b/core/rules/uk/section3/06_non_exclusive.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "uk.s3.exclusivity.non_exclusive"
+  version: "1.0.0"
+  title: "Non-exclusive relationship; detect de-facto exclusivity"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["section3","exclusivity"]
+  triggers:
+    any:
+      - regex: "(?i)exclusive\\s+supplier|right\\s+of\\s+first\\s+refusal|ROFR"
+  checks:
+    - id: "de_facto_exclusivity"
+      when:
+        regex: "(?i)exclusive\\s+supplier|right\\s+of\\s+first\\s+refusal|ROFR"
+      finding:
+        message: "De-facto exclusivity detected; conflicts with 3.2–3.3."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Remove exclusivity/ROFR or move to separate negotiated term."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: ExclusivityRisk
+    score: 88
+    problem: "Potential exclusivity."
+    recommendation: "Confirm non-exclusive status."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["exclusivity","ROFR"]
+metadata:
+  tags: ["exclusivity"]

--- a/core/rules/uk/section3/07_order_channels_alignment.yaml
+++ b/core/rules/uk/section3/07_order_channels_alignment.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "uk.s3.order.channels_align_29"
+  version: "1.0.0"
+  title: "Order acknowledgement channels must align with Notices/writing policy"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off","MSA"]
+    clauses: ["call-off","notices","interpretation"]
+  triggers:
+    any:
+      - regex: "(?i)written\\s+acknowledgement|acknowledgment|acknowledge\\s+in\\s+writing"
+  checks:
+    - id: "email_banned_no_portal"
+      when:
+        all:
+          - regex: "(?i)email\\s+shall\\s+not\\s+constitute\\s+writing"
+          - not_regex: "(?i)DocuSign|Adobe\\s+Sign|portal|e-?signature"
+      finding:
+        message: "Email excluded as 'writing' but no e-sign/portal path provided."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Permit e-signature platforms/portal for Order acks; keep Notices per Clause 29."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: ChannelMisalignment
+    score: 80
+    problem: "Operational dead-end for Order acks."
+    recommendation: "Allow e-sign/portal."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["writing","email","ack"]
+metadata:
+  tags: ["channels","notices"]

--- a/core/rules/uk/section3/08_calloff_contract_execution.yaml
+++ b/core/rules/uk/section3/08_calloff_contract_execution.yaml
@@ -1,0 +1,36 @@
+rule:
+  id: "uk.s3.calloff.contract_execution_authority"
+  version: "1.0.0"
+  title: "Call-Off Contract: executed by authorised signatories; no 'subject to board approval'"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off","MSA"]
+    clauses: ["call-off","execution","authority"]
+  triggers:
+    any:
+      - regex: "(?i)subject\\s+to\\s+board\\s+approval"
+      - regex: "(?i)authorised\\s+signatory"
+  checks:
+    - id: "board_approval_subject_to"
+      when:
+        regex: "(?i)subject\\s+to\\s+board\\s+approval"
+      finding:
+        message: "Conditional board approval undermines formation."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Remove 'subject to board approval'; have authorised signatories execute."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: ExecutionFormalityRisk
+    score: 88
+    problem: "Conditional approval language present."
+    recommendation: "Execute with proper authority."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["authority","execution"]
+metadata:
+  tags: ["execution","authority"]

--- a/core/rules/uk/section3/09_po_chain_per_entity.yaml
+++ b/core/rules/uk/section3/09_po_chain_per_entity.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "uk.s3.po.per_entity_responsibility"
+  version: "1.0.0"
+  title: "Each PO binds only the issuing Company; no joint liability across group"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["PO","Call-Off","MSA"]
+    clauses: ["call-off","purchase order"]
+  triggers:
+    any:
+      - regex: "(?i)joint(ly)?\\s+and\\s+severally\\s+liable|any\\s+Group\\s+entity\\s+shall\\s+be\\s+responsible"
+  checks:
+    - id: "joint_liability"
+      when:
+        regex: "(?i)joint(ly)?\\s+and\\s+severally\\s+liable|any\\s+Group\\s+entity\\s+shall\\s+be\\s+responsible"
+      finding:
+        message: "Cross-entity liability contradicts 3.5.2–3.5.7/3.6.2."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Clarify that Contractor looks only to the PO issuer."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CrossEntityLiability
+    score: 80
+    problem: "Joint liability creep."
+    recommendation: "Tie obligations to issuer only."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["PO","liability","issuer"]
+metadata:
+  tags: ["po","liability"]

--- a/core/rules/uk/section3/10_order_acceptance_triggers.yaml
+++ b/core/rules/uk/section3/10_order_acceptance_triggers.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.s3.order.acceptance_triggers_channels"
+  version: "1.0.0"
+  title: "Order acceptance via performance/signature/written confirmation must align with Clause 29"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off"]
+    clauses: ["call-off","acceptance","notices"]
+  triggers:
+    any:
+      - regex: "(?i)acceptance\\s+by\\s+performance|signature|written\\s+confirmation"
+  checks:
+    - id: "channels_misaligned"
+      when:
+        all:
+          - regex: "(?i)written\\s+confirmation"
+          - not_regex: "(?i)Clause\\s*29|Notices|e-?signature|portal"
+      finding:
+        message: "Written confirmation channel not aligned with Notices/writing policy."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Reference Clause 29 and allow e-signature/portal."
+        score_delta: -20
+    - id: "joint_liability_check"
+      when:
+        regex: "(?i)joint(ly)?\\s+and\\s+severally"
+      finding:
+        message: "Joint liability language conflicts with 3.6.2."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Confirm 'only own Order' liability."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: OrderAcceptanceProcessRisk
+    score: 80
+    problem: "Acceptance channels misaligned/joint liability risk."
+    recommendation: "Align channels; remove joint liability."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["acceptance","channels"]
+metadata:
+  tags: ["acceptance","channels"]

--- a/core/rules/uk/section3/11_calloff_minimum_contents.yaml
+++ b/core/rules/uk/section3/11_calloff_minimum_contents.yaml
@@ -1,0 +1,68 @@
+rule:
+  id: "uk.s3.calloff.minimum_contents"
+  version: "1.0.0"
+  title: "Call-Off must include parties, scope, price, schedule, MSA incorporation & exclusion of other T&Cs"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off"]
+    clauses: ["call-off"]
+  triggers:
+    any:
+      - regex: "(?i)Call[-\\s]?Off"
+  checks:
+    - id: "parties_missing"
+      when:
+        not_regex: "(?i)Company\\s+and\\s+Contractor"
+      finding:
+        message: "Parties not clearly defined."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Name Company and Contractor entities."
+        score_delta: -15
+    - id: "msa_incorp_missing"
+      when:
+        not_regex: "(?i)incorporat(es|ed)\\s+the\\s+MSA|this\\s+Agreement"
+      finding:
+        message: "MSA incorporation missing."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State incorporation of MSA."
+        score_delta: -15
+    - id: "exclude_other_terms_missing"
+      when:
+        not_regex: "(?i)exclusion\\s+of\\s+all\\s+other\\s+terms"
+      finding:
+        message: "Exclusion of other terms missing."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add exclusion clause."
+        score_delta: -15
+    - id: "scope_price_schedule_missing"
+      when:
+        any:
+          - not_regex: "(?i)Scope|SoW"
+          - not_regex: "(?i)Price|rates|lump\\s+sum"
+          - not_regex: "(?i)Schedule|milestones|key\\s+dates"
+      finding:
+        message: "Scope/Price/Schedule incomplete."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Provide SoW, pricing basis, and schedule/key dates."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CallOffContentGap
+    score: 78
+    problem: "Call-Off lacks mandatory elements."
+    recommendation: "Complete parties, MSA link, exclusion, SoW/price/schedule."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["contents","incorporation","exclusion"]
+metadata:
+  tags: ["calloff","contents"]

--- a/core/rules/uk/section3/12_reliance_vs_entire.yaml
+++ b/core/rules/uk/section3/12_reliance_vs_entire.yaml
@@ -1,0 +1,38 @@
+rule:
+  id: "uk.s3.reliance.entire_nonreliance_alignment"
+  version: "1.0.0"
+  title: "Reliance on tender statements aligned with entire agreement / non-reliance"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["reliance","entire","misrepresentation"]
+  triggers:
+    any:
+      - regex: "(?i)Company\\s+may\\s+rely\\s+on\\s+representations|tender|offer"
+      - regex: "(?i)entire\\s+agreement|non[-\\s]?reliance"
+  checks:
+    - id: "reliance_without_nonreliance"
+      when:
+        all:
+          - regex: "(?i)rely\\s+on\\s+representations"
+          - not_regex: "(?i)non[-\\s]?reliance|no\\s+representations"
+      finding:
+        message: "Reliance asserted without non-reliance/clarity (AXA risk)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add clear non-reliance wording or carve agreed reliance."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: RelianceClauseRisk
+    score: 85
+    problem: "Reliance vs entire agreement misaligned."
+    recommendation: "Align with explicit non-reliance or carve-outs."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["reliance","entire agreement"]
+metadata:
+  tags: ["reliance"]

--- a/core/rules/uk/section3/13_nom_mods_enforcement.yaml
+++ b/core/rules/uk/section3/13_nom_mods_enforcement.yaml
@@ -1,0 +1,55 @@
+rule:
+  id: "uk.s3.nom.mods_enforcement_3_12_3_13"
+  version: "1.0.0"
+  title: "Any modification of MSA in Call-Off must comply with 3.12; else null/void (3.13)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off","MSA"]
+    clauses: ["modification","nom"]
+  triggers:
+    any:
+      - regex: "(?i)modify|amend|override|var(y|iation)"
+  checks:
+    - id: "mod_not_in_body"
+      when:
+        not_regex: "(?i)in\\s+the\\s+body\\s+of\\s+this\\s+Call[-\\s]?Off"
+      finding:
+        message: "Modification not placed in Call-Off body."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Place modification text in Call-Off body."
+        score_delta: -15
+    - id: "no_clause_citation"
+      when:
+        not_regex: "(?i)expressly\\s+modif(y|ies)\\s+Clause\\s+\\d+(?:\\.\\d+)*"
+      finding:
+        message: "No explicit citation of modified Clause number/title."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Cite exact Clause/Exhibit and change."
+        score_delta: -20
+    - id: "nullity_warning"
+      when:
+        not_regex: "(?i)null\\s+and\\s+void|Clause\\s*3\\.13"
+      finding:
+        message: "3.13 nullity safeguard not referenced."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Reference 3.13 nullity for non-compliant changes."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: NOMBreachRisk
+    score: 80
+    problem: "Modification doesn’t meet 3.12 formalities."
+    recommendation: "Comply with 3.12; enforce 3.13 nullity."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["NOM","modification","null and void"]
+metadata:
+  tags: ["nom","modification"]

--- a/core/rules/uk/section3/14_ld_parameters_and_cases.yaml
+++ b/core/rules/uk/section3/14_ld_parameters_and_cases.yaml
@@ -1,0 +1,77 @@
+rule:
+  id: "uk.s3.ld.parameters_case_law"
+  version: "1.0.0"
+  title: "LD validity: rate, cap, accrual post-termination, sectional completion"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off","MSA"]
+    clauses: ["ld","schedule","termination"]
+  triggers:
+    any:
+      - regex: "(?i)liquidated\\s+damages|LDs?"
+  checks:
+    - id: "rate_missing"
+      when:
+        not_regex: "(?i)per\\s+day|per\\s+week|\\b%\\b|percent"
+      finding:
+        message: "LD rate missing/unclear."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Specify daily/weekly rate or %."
+        score_delta: -15
+    - id: "cap_missing"
+      when:
+        not_regex: "(?i)cap|max(imum)?\\s+LD|\\b%\\s+of\\s+Contract\\s+Price"
+      finding:
+        message: "LD cap missing."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Set LD cap."
+        score_delta: -15
+    - id: "post_termination_unspecified"
+      when:
+        not_regex: "(?i)post[-\\s]?termination|until\\s+termination|thereafter"
+      finding:
+        message: "LD accrual at/after termination not specified (Triple Point risk)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Clarify LD accrual relative to termination."
+        score_delta: -15
+    - id: "partial_possession_missing"
+      when:
+        all:
+          - regex: "(?i)section(al)?\\s+completion|partial\\s+possession"
+          - not_regex: "(?i)LD\\s+apply\\s+notwithstanding\\s+partial\\s+possession"
+      finding:
+        message: "Sectional/partial possession interaction with LD not addressed (Eco World)."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "State LD allocation for sections/partial possession."
+        score_delta: -10
+    - id: "penalty_indicator"
+      when:
+        regex: "(?i)punitive|penal|penalty\\s+charge"
+      finding:
+        message: "Penalty-style wording (Cavendish risk)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Reframe to protectable interest/genuine pre-estimate."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: LDParameterGap
+    score: 78
+    problem: "LD parameters incomplete/misaligned."
+    recommendation: "Specify rate, cap, post-termination, and sectional rules."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["LD","Triple Point","Cavendish","Eco World"]
+metadata:
+  tags: ["ld","case-law"]

--- a/core/rules/uk/section3/15_unacceptable_conditions.yaml
+++ b/core/rules/uk/section3/15_unacceptable_conditions.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "uk.s3.calloff.unacceptable_conditions_3_11"
+  version: "1.0.0"
+  title: "Reject conditional signatures/subject to negotiation/supplier Ts&Cs (3.11)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off"]
+    clauses: ["call-off","acceptance"]
+  triggers:
+    any:
+      - regex: "(?i)conditional\\s+signature|subject\\s+to\\s+negotiation|subject\\s+to\\s+supplier\\s+terms"
+  checks:
+    - id: "reject_condition"
+      when:
+        all:
+          - regex: "(?i)conditional\\s+signature|subject\\s+to\\s+negotiation|subject\\s+to\\s+supplier\\s+terms"
+          - not_regex: "(?i)no\\s+conditional\\s+signature"
+      finding:
+        message: "Unacceptable condition per 3.11."
+        severity_level: "blocker"
+        risk: "high"
+        suggestion:
+          text: "Remove conditional/subject-to wording; use 3.12 process."
+        score_delta: -30
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S1
+    issue_type: UnacceptableCondition
+    score: 60
+    problem: "Conditional/subject-to terms present."
+    recommendation: "Delete and re-issue."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["conditional","subject to","3.11"]
+metadata:
+  tags: ["3.11","blocker"]

--- a/core/rules/uk/section3/16_coventurers_agent_model.yaml
+++ b/core/rules/uk/section3/16_coventurers_agent_model.yaml
@@ -1,0 +1,55 @@
+rule:
+  id: "uk.s3.coventurers.agent_model_cap"
+  version: "1.0.0"
+  title: "Company acts as agent for Coventurers; aggregated cap; no direct rights; no direct comms"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["coventurers","liability","crpta"]
+  triggers:
+    any:
+      - regex: "(?i)Co-?venturers|joint\\s+operations|JV"
+  checks:
+    - id: "no_agent_model"
+      when:
+        not_regex: "(?i)acts\\s+as\\s+agent|in\\s+its\\s+own\\s+name\\s+for\\s+Co-?venturers"
+      finding:
+        message: "Agent model not stated."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State Company acts as agent; Contractor looks only to Company."
+        score_delta: -20
+    - id: "no_aggregate_cap"
+      when:
+        not_regex: "(?i)aggregate(d)?\\s+cap|cumulative\\s+limit"
+      finding:
+        message: "No aggregated cap for Company+Coventurers."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Set cumulative cap aligned with Clause 36."
+        score_delta: -15
+    - id: "direct_comms_allowed"
+      when:
+        regex: "(?i)direct\\s+communications\\s+with\\s+Co-?venturers"
+      finding:
+        message: "Direct comms with Co-venturers allowed — governance risk."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Prohibit direct comms absent Company consent."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CoventurerModelGap
+    score: 80
+    problem: "Agent model/cap/comms misaligned."
+    recommendation: "Enforce agent model; aggregate cap; block direct comms."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["coventurers","agent","cap"]
+metadata:
+  tags: ["coventurers"]

--- a/core/rules/uk/section3/17_foreign_terms_nullity.yaml
+++ b/core/rules/uk/section3/17_foreign_terms_nullity.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "uk.s3.nullity.foreign_terms_3_13"
+  version: "1.0.0"
+  title: "Foreign boilerplate terms in Call-Off are null/void unless compliant with 3.12"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["Call-Off"]
+    clauses: ["modification","precedence"]
+  triggers:
+    any:
+      - regex: "(?i)Supplier\\s+Terms\\s+apply|General\\s+Terms\\s+and\\s+Conditions\\s+of\\s+Sale"
+  checks:
+    - id: "nullity_enforce"
+      when:
+        all:
+          - regex: "(?i)Supplier\\s+Terms\\s+apply|General\\s+Terms"
+          - not_regex: "(?i)expressly\\s+modif(y|ies)\\s+Clause"
+      finding:
+        message: "Foreign T&Cs detected; null/void under 3.13."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Delete foreign T&Cs or reissue via 3.12 formal modification."
+        score_delta: -25
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: ForeignTermsNullity
+    score: 78
+    problem: "Foreign boilerplate conflicts with 3.12/3.13."
+    recommendation: "Purge or formalise via 3.12."
+    law_reference: []
+    category: "Section 3"
+    keywords: ["null and void","3.13","supplier terms"]
+metadata:
+  tags: ["nullity","foreign-terms"]

--- a/tests/rules/section3/test_section3_rules.py
+++ b/tests/rules/section3/test_section3_rules.py
@@ -1,0 +1,263 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+
+def AI(text, clause="section3", doc="MSA"):
+    return AnalysisInput(clause_type=clause, text=text,
+                         metadata={"jurisdiction":"UK","doc_type":doc})
+
+
+# 01 battle of forms
+def test_po_battle_forms_negative():
+    spec = load_rule("core/rules/uk/section3/01_po_excludes_supplier_terms.yaml")
+    t = "Supplier Terms apply; terms on the back of the PO shall apply."
+    out = run_rule(spec, AI(t, clause="purchase order", doc="PO"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_po_battle_forms_positive():
+    spec = load_rule("core/rules/uk/section3/01_po_excludes_supplier_terms.yaml")
+    t = "This Call-Off incorporates the MSA to the exclusion of all other terms; precedence per Clause 2.2.4."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 02 start-work acceptance
+def test_start_work_acceptance_negative():
+    spec = load_rule("core/rules/uk/section3/02_start_work_acceptance_guard.yaml")
+    t = "Commencement of performance constitutes acceptance."
+    out = run_rule(spec, AI(t, clause="formation"))
+    assert out is not None and any("RTS risk" in f.message for f in out.findings)
+
+
+def test_start_work_acceptance_positive():
+    spec = load_rule("core/rules/uk/section3/02_start_work_acceptance_guard.yaml")
+    t = "No work shall commence without a written Order specifying Price, SoW, LD, IP and HSE."
+    out = run_rule(spec, AI(t, clause="formation"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 03 LD only remedy gates
+def test_ld_only_remedy_negative():
+    spec = load_rule("core/rules/uk/section3/03_ld_only_remedy_gate.yaml")
+    t = "LD shall be the only remedy for delay."
+    out = run_rule(spec, AI(t, clause="ld"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_ld_only_remedy_positive():
+    spec = load_rule("core/rules/uk/section3/03_ld_only_remedy_gate.yaml")
+    t = "LD shall be the only remedy for delay, subject to Clause 3.10.3–3.10.5 and a maximum LD cap."
+    out = run_rule(spec, AI(t, clause="ld"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 04 editorial blocker
+def test_editorial_blocker_negative():
+    spec = load_rule("core/rules/uk/section3/04_typo_numbering_blocker.yaml")
+    t = "Notwithstanding C Company ... and the foregoing of this Clause 3.10.3 ... and partrial shipment ..."
+    out = run_rule(spec, AI(t))
+    assert out is not None and any("Editorial error" in f.message for f in out.findings)
+
+
+def test_editorial_blocker_positive():
+    spec = load_rule("core/rules/uk/section3/04_typo_numbering_blocker.yaml")
+    t = "No editorial errors remain."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 05 no minimum commitment
+def test_no_minimum_negative():
+    spec = load_rule("core/rules/uk/section3/05_no_minimum_commitment.yaml")
+    t = "Contractor shall purchase a minimum order of 1,000 hours per year."
+    out = run_rule(spec, AI(t))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_no_minimum_positive():
+    spec = load_rule("core/rules/uk/section3/05_no_minimum_commitment.yaml")
+    t = "Nothing in this Agreement shall be construed as a guarantee of volume."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 06 non exclusivity
+def test_non_exclusive_negative():
+    spec = load_rule("core/rules/uk/section3/06_non_exclusive.yaml")
+    t = "Contractor shall be the exclusive supplier and has a right of first refusal."
+    out = run_rule(spec, AI(t, clause="exclusivity"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_non_exclusive_positive():
+    spec = load_rule("core/rules/uk/section3/06_non_exclusive.yaml")
+    t = "The relationship is non-exclusive."
+    out = run_rule(spec, AI(t, clause="exclusivity"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 07 order channels align
+def test_order_channels_negative():
+    spec = load_rule("core/rules/uk/section3/07_order_channels_alignment.yaml")
+    t = "Email shall not constitute writing. Supplier to send written acknowledgement."
+    out = run_rule(spec, AI(t, clause="notices", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_order_channels_positive():
+    spec = load_rule("core/rules/uk/section3/07_order_channels_alignment.yaml")
+    t = "Written acknowledgement via DocuSign portal; Notices per Clause 29."
+    out = run_rule(spec, AI(t, clause="notices", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 08 call-off contract execution
+def test_contract_execution_negative():
+    spec = load_rule("core/rules/uk/section3/08_calloff_contract_execution.yaml")
+    t = "This Call-Off is subject to board approval."
+    out = run_rule(spec, AI(t, clause="execution", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_contract_execution_positive():
+    spec = load_rule("core/rules/uk/section3/08_calloff_contract_execution.yaml")
+    t = "Executed by authorised signatories."
+    out = run_rule(spec, AI(t, clause="execution", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 09 po per-entity responsibility
+def test_po_per_entity_negative():
+    spec = load_rule("core/rules/uk/section3/09_po_chain_per_entity.yaml")
+    t = "Any Group entity shall be responsible and jointly and severally liable."
+    out = run_rule(spec, AI(t, clause="purchase order", doc="PO"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_po_per_entity_positive():
+    spec = load_rule("core/rules/uk/section3/09_po_chain_per_entity.yaml")
+    t = "Contractor looks only to the issuing Company under each PO."
+    out = run_rule(spec, AI(t, clause="purchase order", doc="PO"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 10 order acceptance triggers
+def test_order_acceptance_negative():
+    spec = load_rule("core/rules/uk/section3/10_order_acceptance_triggers.yaml")
+    t = "Acceptance by written confirmation."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_order_acceptance_positive():
+    spec = load_rule("core/rules/uk/section3/10_order_acceptance_triggers.yaml")
+    t = "Acceptance by written confirmation in accordance with Clause 29 or via e-signature portal."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 11 call-off minimum contents
+def test_calloff_minimum_negative():
+    spec = load_rule("core/rules/uk/section3/11_calloff_minimum_contents.yaml")
+    t = "Call-Off for services."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_calloff_minimum_positive():
+    spec = load_rule("core/rules/uk/section3/11_calloff_minimum_contents.yaml")
+    t = "Call-Off: Company and Contractor; incorporates the MSA to the exclusion of all other terms; Scope; Price; Schedule with key dates."
+    out = run_rule(spec, AI(t, clause="call-off", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 12 reliance vs entire/non-reliance
+def test_reliance_negative():
+    spec = load_rule("core/rules/uk/section3/12_reliance_vs_entire.yaml")
+    t = "Company may rely on representations in the tender."
+    out = run_rule(spec, AI(t, clause="reliance"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_reliance_positive():
+    spec = load_rule("core/rules/uk/section3/12_reliance_vs_entire.yaml")
+    t = "Entire agreement with explicit non-reliance; agreed reliance carve-out where specified."
+    out = run_rule(spec, AI(t, clause="reliance"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 13 NOM mods enforcement
+def test_nom_negative():
+    spec = load_rule("core/rules/uk/section3/13_nom_mods_enforcement.yaml")
+    t = "The Supplier Terms apply and modify the Agreement."
+    out = run_rule(spec, AI(t, clause="modification", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_nom_positive():
+    spec = load_rule("core/rules/uk/section3/13_nom_mods_enforcement.yaml")
+    t = "In the body of this Call-Off, we expressly modify Clause 3.10.4 as agreed; non-compliant changes are null and void under Clause 3.13."
+    out = run_rule(spec, AI(t, clause="modification", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 14 LD parameters & cases
+def test_ld_params_negative():
+    spec = load_rule("core/rules/uk/section3/14_ld_parameters_and_cases.yaml")
+    t = "Liquidated damages shall apply."
+    out = run_rule(spec, AI(t, clause="ld"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_ld_params_positive():
+    spec = load_rule("core/rules/uk/section3/14_ld_parameters_and_cases.yaml")
+    t = "LD: per day rate, cap as % of Contract Price, accrual until termination; LD apply notwithstanding partial possession."
+    out = run_rule(spec, AI(t, clause="ld"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 15 unacceptable conditions 3.11
+def test_unacceptable_conditions_negative():
+    spec = load_rule("core/rules/uk/section3/15_unacceptable_conditions.yaml")
+    t = "This Call-Off is subject to negotiation and supplier terms."
+    out = run_rule(spec, AI(t, clause="acceptance", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_unacceptable_conditions_positive():
+    spec = load_rule("core/rules/uk/section3/15_unacceptable_conditions.yaml")
+    t = "No conditional signature; terms are final."
+    out = run_rule(spec, AI(t, clause="acceptance", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 16 coventurers agent model
+def test_coventurers_negative():
+    spec = load_rule("core/rules/uk/section3/16_coventurers_agent_model.yaml")
+    t = "Direct communications with Co-venturers are permitted."
+    out = run_rule(spec, AI(t, clause="coventurers"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_coventurers_positive():
+    spec = load_rule("core/rules/uk/section3/16_coventurers_agent_model.yaml")
+    t = "Company acts as agent for Co-venturers; communications pass via Company; aggregated cap applies."
+    out = run_rule(spec, AI(t, clause="coventurers"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+
+# 17 foreign terms nullity 3.13
+def test_foreign_terms_nullity_negative():
+    spec = load_rule("core/rules/uk/section3/17_foreign_terms_nullity.yaml")
+    t = "General Terms and Conditions of Sale shall apply."
+    out = run_rule(spec, AI(t, clause="precedence", doc="Call-Off"))
+    assert out is not None and len(out.findings) >= 1
+
+
+def test_foreign_terms_nullity_positive():
+    spec = load_rule("core/rules/uk/section3/17_foreign_terms_nullity.yaml")
+    t = "Any conflicting Supplier Terms are null and void unless expressly modifying Clause X under 3.12."
+    out = run_rule(spec, AI(t, clause="precedence", doc="Call-Off"))
+    assert out is None or len(getattr(out, "findings", [])) == 0


### PR DESCRIPTION
## Summary
- add 17 Section 3 UK rules covering battle of forms, start work acceptance, LD parameters, call-off contents, and more
- introduce Section 3 pytest suite validating positive/negative scenarios

## Testing
- `pytest tests/rules/section3/test_section3_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf80273c88325b6adf8157d9e01c3