### PR TITLE
Add clause 4 representative rules and tests

### DIFF
--- a/core/rules/uk/section4/01_cr_appointment_and_scope.yaml
+++ b/core/rules/uk/section4/01_cr_appointment_and_scope.yaml
@@ -1,0 +1,46 @@
+rule:
+  id: "uk.s4.cr.appointment_and_scope"
+  version: "1.0.0"
+  title: "CR appointed in writing; may issue operational instructions; not a Variation"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["representatives","clause 4"]
+  triggers:
+    any:
+      - regex: "(?i)Company\\s+Representative\\s*\\(|\\bCR\\b"
+  checks:
+    - id: "cr_not_named"
+      when:
+        not_regex: "(?i)Company\\s+Representative.+(name|named|appointed|designation)"
+      finding:
+        message: "CR not expressly named/appointed in writing for the Call-Off."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: ["Best practice NEC/FIDIC: instructions only via appointed role"]
+        suggestion:
+          text: "Name the CR (name/title) and attach appointment evidence effective for this Call-Off."
+        score_delta: -20
+    - id: "instruction_vs_variation_guard_missing"
+      when:
+        not_regex: "(?i)Instruction\\s+does\\s+not\\s+constitute\\s+a\\s+Variation|changes\\s+to\\s+Scope/Price/Schedule\\s+require\\s+VO|Clause\\s*14"
+      finding:
+        message: "No guard: CR instructions must not act as Variations."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Insert guard: operational instruction ≠ Variation; any impact to Scope/Price/Schedule -> VO per Clause 14."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CRAppointmentOrScopeGap
+    score: 80
+    problem: "CR not properly appointed and/or instruction≠variation guard missing."
+    recommendation: "Appoint CR in writing; add guard to route impacts via VO (Cl.14)."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["CR","appointment","instructions","variation guard"]
+metadata:
+  tags: ["cr","appointment","variation-guard"]

--- a/core/rules/uk/section4/02_cr_nom_shield.yaml
+++ b/core/rules/uk/section4/02_cr_nom_shield.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.s4.cr.nom_shield"
+  version: "1.0.0"
+  title: "CR cannot amend/waive MSA/Call-Off; NOM enforced"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["representatives","modification","clause 4","clause 3.12","clause 3.13"]
+  triggers:
+    any:
+      - regex: "(?i)Company\\s+Representative\\s+may\\s+(amend|modify|waive)"
+      - regex: "(?i)oral\\s+modification|email\\s+modification|verbal\\s+agreement"
+  checks:
+    - id: "cr_modifies_msa"
+      when:
+        regex: "(?i)CR\\s+may\\s+(amend|modify|waive)|Company\\s+Representative\\s+may\\s+(amend|modify|waive)"
+      finding:
+        message: "CR purported power to amend/waive contradicts NOM (3.12/3.13)."
+        severity_level: "blocker"
+        risk: "high"
+        legal_basis: ["Rock v MWB (UKSC, 2018)"]
+        suggestion:
+          text: "Delete/limit: modifications only via Clause 3.12; non-compliant changes null/void (3.13)."
+        score_delta: -30
+    - id: "off_channel_mod"
+      when:
+        regex: "(?i)oral\\s+modification|email\\s+modification|agreed\\s+in\\s+meeting\\s+minutes"
+      finding:
+        message: "Off-channel modification route detected; reinforce NOM."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State explicitly: no oral/email modifications; minutes are non-binding; VO required."
+        score_delta: -20
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S1
+    issue_type: NOMBreachRisk
+    score: 60
+    problem: "CR modification/waiver powers or off-channel modifications."
+    recommendation: "Enforce NOM (3.12/3.13); remove CR amendment powers."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["NOM","Rock v MWB","waiver","modification"]
+metadata:
+  tags: ["nom","rock"]

--- a/core/rules/uk/section4/03_apparent_authority_controls.yaml
+++ b/core/rules/uk/section4/03_apparent_authority_controls.yaml
@@ -1,0 +1,49 @@
+rule:
+  id: "uk.s4.cr.apparent_authority_controls"
+  version: "1.0.0"
+  title: "Mitigate ostensible authority: minutes disclaimer, instruction register, VO routing"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off","Minutes"]
+    clauses: ["representatives","governance"]
+  triggers:
+    any:
+      - regex: "(?i)minutes\\s+of\\s+meeting|MoM|agreed\\s+in\\s+meeting"
+      - regex: "(?i)instruction\\s+register|delegation\\s+register"
+  checks:
+    - id: "no_minutes_disclaimer"
+      when:
+        all:
+          - regex: "(?i)minutes"
+          - not_regex: "(?i)Minutes\\s+are\\s+non\\-binding|do\\s+not\\s+constitute\\s+Variation"
+      finding:
+        message: "Meeting minutes lack disclaimer (non-binding / not a Variation)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: ["Freeman & Lockyer (ostensible authority)"]
+        suggestion:
+          text: "Add minutes disclaimer: not binding; instructions with impact require VO."
+        score_delta: -15
+    - id: "no_instruction_register"
+      when:
+        not_regex: "(?i)Instruction\\s+Register"
+      finding:
+        message: "No Instruction Register reference to track CR/CTR directions."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Maintain Instruction Register with date/issuer/scope/VO link."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: ApparentAuthorityRisk
+    score: 86
+    problem: "Weak ostensible authority mitigations."
+    recommendation: "Insert minutes disclaimer and instruction register linkage."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["ostensible authority","minutes","register"]
+metadata:
+  tags: ["apparent-authority","minutes","register"]

--- a/core/rules/uk/section4/04_ctr_appointment_and_limits.yaml
+++ b/core/rules/uk/section4/04_ctr_appointment_and_limits.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "uk.s4.ctr.appointment_and_limits"
+  version: "1.0.0"
+  title: "CTR appointed; operational scope only; cannot amend MSA"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["representatives","clause 4"]
+  triggers:
+    any:
+      - regex: "(?i)Contractor\\s+Representative\\s*\\(|\\bCTR\\b"
+  checks:
+    - id: "ctr_not_named"
+      when:
+        not_regex: "(?i)Contractor\\s+Representative.+(name|named|appointed|designation)"
+      finding:
+        message: "CTR not expressly named/appointed in writing."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Name the CTR and attach appointment evidence."
+        score_delta: -20
+    - id: "ctr_may_modify"
+      when:
+        regex: "(?i)CTR\\s+may\\s+(amend|modify|waive)"
+      finding:
+        message: "CTR purported to amend/waive contract."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "State CTR has no power to amend; modifications via 3.12 only."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: CTRAppointmentOrScopeGap
+    score: 80
+    problem: "CTR appointment/scope gaps."
+    recommendation: "Appoint CTR; limit to operational instructions."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["CTR","appointment","scope limits"]
+metadata:
+  tags: ["ctr","appointment"]

--- a/core/rules/uk/section4/05_delegation_and_substitution.yaml
+++ b/core/rules/uk/section4/05_delegation_and_substitution.yaml
@@ -1,0 +1,57 @@
+rule:
+  id: "uk.s4.delegation.notice_and_register"
+  version: "1.0.0"
+  title: "Delegation/substitution by notice with scope & dates; maintain Delegation Register"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off","Notice"]
+    clauses: ["representatives","delegation","clause 4"]
+  triggers:
+    any:
+      - regex: "(?i)delegate|delegation|substitute|alternate\\s+representative"
+  checks:
+    - id: "no_notice_for_delegation"
+      when:
+        not_regex: "(?i)by\\s+notice|notice\\s+to\\s+the\\s+other\\s+party"
+      finding:
+        message: "Delegation/substitution without notice."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Require delegation by notice, stating scope and effective dates."
+        score_delta: -20
+    - id: "no_scope_or_dates"
+      when:
+        any:
+          - not_regex: "(?i)scope\\s+of\\s+authority"
+          - not_regex: "(?i)effective\\s+from|until|start\\s+date|end\\s+date"
+      finding:
+        message: "Delegation lacks scope and/or dates."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Define delegate’s scope, start/end dates."
+        score_delta: -15
+    - id: "no_delegation_register"
+      when:
+        not_regex: "(?i)Delegation\\s+Register"
+      finding:
+        message: "No Delegation Register reference."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Maintain Delegation Register mapping who/scope/dates."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: DelegationFormalitiesGap
+    score: 78
+    problem: "Delegation lacks notice/scope/dates/register."
+    recommendation: "Add formalities and register."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["delegation","notice","register"]
+metadata:
+  tags: ["delegation","register"]

--- a/core/rules/uk/section4/06_ctr_change_consent_sla.yaml
+++ b/core/rules/uk/section4/06_ctr_change_consent_sla.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "uk.s4.ctr.change_consent_sla"
+  version: "1.0.0"
+  title: "CTR change requires Company consent; deemed approval SLA recommended"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off","Notice"]
+    clauses: ["representatives","clause 4"]
+  triggers:
+    any:
+      - regex: "(?i)change\\s+of\\s+CTR|replace\\s+the\\s+Contractor\\s+Representative"
+  checks:
+    - id: "no_company_consent"
+      when:
+        not_regex: "(?i)Company'?s?\\s+consent.*not\\s+unreasonably\\s+(withheld|delayed)"
+      finding:
+        message: "CTR change lacks Company consent reasonableness."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Add consent standard: not unreasonably withheld/delayed."
+        score_delta: -10
+    - id: "no_deemed_approval"
+      when:
+        not_regex: "(?i)deemed\\s+approved\\s+after\\s+\\d+\\s+Business\\s+Days"
+      finding:
+        message: "No deemed approval SLA—risk of resource leverage."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Add deemed approval after 5 Business Days silence."
+        score_delta: -8
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: CTRChangeProcessGap
+    score: 88
+    problem: "CTR change lacks consent/SLA safeguards."
+    recommendation: "Insert reasonableness + deemed approval."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["CTR change","consent","SLA"]
+metadata:
+  tags: ["ctr","consent","sla"]

--- a/core/rules/uk/section4/07_notice_channels_alignment.yaml
+++ b/core/rules/uk/section4/07_notice_channels_alignment.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.s4.reps.notice_channels_alignment"
+  version: "1.0.0"
+  title: "CR/CTR sending/receiving notices must align with Clause 29 and writing policy"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off","Notice"]
+    clauses: ["representatives","notices","clause 29","interpretation 2.2.1(i)"]
+  triggers:
+    any:
+      - regex: "(?i)send\\s+or\\s+receive\\s+notices|notice\\s+address|acknowledgement\\s+in\\s+writing"
+  checks:
+    - id: "email_banned_no_alt"
+      when:
+        all:
+          - regex: "(?i)email\\s+shall\\s+not\\s+constitute\\s+writing"
+          - not_regex: "(?i)e-?signature|portal|DocuSign|Adobe\\s+Sign|platform"
+      finding:
+        message: "Email excluded as 'writing' but no e-sign/portal path defined."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Whitelist e-sign/portal for CR/CTR notices; keep formal Notices per Clause 29."
+        score_delta: -20
+    - id: "no_clause29_ref"
+      when:
+        not_regex: "(?i)Clause\\s*29|Notices"
+      finding:
+        message: "No cross-reference to Clause 29 for channels."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Reference Clause 29 for valid channels and addresses."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: NoticeChannelMisalignment
+    score: 80
+    problem: "Notice channels for reps misaligned."
+    recommendation: "Align with Clause 29 and allow e-sign/portal."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["notices","writing","channels"]
+metadata:
+  tags: ["notices","channels"]

--- a/core/rules/uk/section4/08_instruction_triggers_vo.yaml
+++ b/core/rules/uk/section4/08_instruction_triggers_vo.yaml
@@ -1,0 +1,38 @@
+rule:
+  id: "uk.s4.instructions.trigger_vo"
+  version: "1.0.0"
+  title: "Any CR/CTR instruction impacting Scope/Price/Schedule/LD must route to VO (Clause 14)"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off","Instruction"]
+    clauses: ["representatives","variations","clause 14"]
+  triggers:
+    any:
+      - regex: "(?i)instruct|instruction|direction"
+  checks:
+    - id: "impact_no_vo"
+      when:
+        all:
+          - regex: "(?i)(Scope|Price|Schedule|LD)"
+          - not_regex: "(?i)Variation\\s+Order|VO|Clause\\s*14"
+      finding:
+        message: "Instruction with impact but no VO routing (NEC/FIDIC practice)."
+        severity_level: "major"
+        risk: "high"
+        legal_basis: ["NEC4 compensation events; FIDIC 13.x Variations"]
+        suggestion:
+          text: "Add: any impact instruction requires VOR/VO per Clause 14."
+        score_delta: -20
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: HiddenVariationRisk
+    score: 80
+    problem: "Impactful instruction lacks VO routing."
+    recommendation: "Mandate VOR/VO for impacts."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["instruction","VO","variation"]
+metadata:
+  tags: ["variation","nec","fidic"]

--- a/core/rules/uk/section4/09_stop_work_authority.yaml
+++ b/core/rules/uk/section4/09_stop_work_authority.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "uk.s4.hse.stop_work_authority"
+  version: "1.0.0"
+  title: "Stop-Work Authority policy present; no retaliation"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off","HSE Policy"]
+    clauses: ["representatives","HSE","safety"]
+  triggers:
+    any:
+      - regex: "(?i)Stop\\s*Work\\s*Authority|SWA|right\\s+to\\s+stop\\s+work"
+  checks:
+    - id: "no_swa_policy"
+      when:
+        not_regex: "(?i)Stop\\s*Work\\s*Authority|SWA"
+      finding:
+        message: "No Stop-Work Authority provision referenced."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Insert SWA: any worker may stop unsafe work; CR/CTR must respect; no retaliation."
+        score_delta: -10
+    - id: "no_no_retaliation"
+      when:
+        all:
+          - regex: "(?i)Stop\\s*Work"
+          - not_regex: "(?i)no\\s+retaliation|non\\-retaliation"
+      finding:
+        message: "SWA present but no explicit non-retaliation."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Add non-retaliation protection for SWA."
+        score_delta: -8
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: HSERuleGap
+    score: 88
+    problem: "SWA/non-retaliation gaps."
+    recommendation: "Add SWA + non-retaliation."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["HSE","Stop Work","non-retaliation"]
+metadata:
+  tags: ["hse","swa"]

--- a/core/rules/uk/section4/10_chain_of_command_clarity.yaml
+++ b/core/rules/uk/section4/10_chain_of_command_clarity.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "uk.s4.governance.chain_of_command"
+  version: "1.0.0"
+  title: "Clear chain of command; conflicting directions blocked"
+  scope:
+    jurisdiction: ["UK"]
+    doc_types: ["MSA","Call-Off"]
+    clauses: ["representatives","governance"]
+  triggers:
+    any:
+      - regex: "(?i)conflicting\\s+instructions|two\\s+masters|dual\\s+reporting"
+  checks:
+    - id: "conflicting_directions"
+      when:
+        regex: "(?i)conflicting\\s+instructions|dual\\s+reporting|two\\s+masters"
+      finding:
+        message: "Conflicting directions detected; escalate to CR/CTR for resolution."
+        severity_level: "blocker"
+        risk: "high"
+        suggestion:
+          text: "Confirm single line authority via CR↔CTR; escalate conflicts; document resolution."
+        score_delta: -25
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S1
+    issue_type: ConflictingDirections
+    score: 60
+    problem: "Conflicting directions risk safety/contract control."
+    recommendation: "Enforce single chain via CR/CTR; block execution until resolved."
+    law_reference: []
+    category: "Section 4"
+    keywords: ["chain of command","conflict"]
+metadata:
+  tags: ["governance","conflicts"]

--- a/tests/rules/section4/test_section4_rules.py
+++ b/tests/rules/section4/test_section4_rules.py
@@ -1,0 +1,138 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+def AI(text, clause="representatives", doc="MSA"):
+    return AnalysisInput(clause_type=clause, text=text,
+                         metadata={"jurisdiction":"UK","doc_type":doc})
+
+# 01 CR appointment & guard
+def test_cr_appointment_negative():
+    spec = load_rule("core/rules/uk/section4/01_cr_appointment_and_scope.yaml")
+    t = "Company Representative (CR) may issue instructions."
+    out = run_rule(spec, AI(t))
+    assert out is not None and any("CR not expressly named" in f.message for f in out.findings)
+
+def test_cr_appointment_positive():
+    spec = load_rule("core/rules/uk/section4/01_cr_appointment_and_scope.yaml")
+    t = ("Company Representative is named and appointed in writing."
+         " Instruction does not constitute a Variation; changes to Scope/Price/Schedule require VO per Clause 14.")
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 02 CR NOM shield
+def test_cr_nom_negative():
+    spec = load_rule("core/rules/uk/section4/02_cr_nom_shield.yaml")
+    t = "The CR may amend or waive terms agreed; oral modification via email minutes."
+    out = run_rule(spec, AI(t, clause="modification"))
+    assert out is not None and any("NOM (3.12/3.13)" in f.message or "Off-channel" in f.message for f in out.findings)
+
+def test_cr_nom_positive():
+    spec = load_rule("core/rules/uk/section4/02_cr_nom_shield.yaml")
+    t = "Modifications only via Clause 3.12; non-compliant changes are null and void under Clause 3.13."
+    out = run_rule(spec, AI(t, clause="modification"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 03 Apparent authority controls
+def test_apparent_authority_negative():
+    spec = load_rule("core/rules/uk/section4/03_apparent_authority_controls.yaml")
+    t = "Minutes of meeting: parties agreed to change schedule."
+    out = run_rule(spec, AI(t, doc="Minutes"))
+    assert out is not None and any("Minutes lack disclaimer" in f.message or "No Instruction Register" in f.message for f in out.findings)
+
+def test_apparent_authority_positive():
+    spec = load_rule("core/rules/uk/section4/03_apparent_authority_controls.yaml")
+    t = "Minutes are non-binding and do not constitute a Variation. Instruction Register maintained."
+    out = run_rule(spec, AI(t, doc="Minutes"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 04 CTR appointment & limits
+def test_ctr_appointment_negative():
+    spec = load_rule("core/rules/uk/section4/04_ctr_appointment_and_limits.yaml")
+    t = "CTR may modify terms."
+    out = run_rule(spec, AI(t))
+    assert out is not None and any("CTR not expressly named" in f.message or "CTR purported to amend" in f.message for f in out.findings)
+
+def test_ctr_appointment_positive():
+    spec = load_rule("core/rules/uk/section4/04_ctr_appointment_and_limits.yaml")
+    t = "Contractor Representative is named and appointed; CTR has no power to amend MSA."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 05 Delegation/ substitution
+def test_delegation_negative():
+    spec = load_rule("core/rules/uk/section4/05_delegation_and_substitution.yaml")
+    t = "We delegate authority to John."
+    out = run_rule(spec, AI(t, clause="delegation", doc="Notice"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_delegation_positive():
+    spec = load_rule("core/rules/uk/section4/05_delegation_and_substitution.yaml")
+    t = "Delegation by notice stating scope of authority and effective from 01 Jan to 31 Mar. Delegation Register updated."
+    out = run_rule(spec, AI(t, clause="delegation", doc="Notice"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 06 CTR change consent & SLA
+def test_ctr_change_negative():
+    spec = load_rule("core/rules/uk/section4/06_ctr_change_consent_sla.yaml")
+    t = "Replace the Contractor Representative."
+    out = run_rule(spec, AI(t))
+    assert out is not None and len(out.findings) >= 1
+
+def test_ctr_change_positive():
+    spec = load_rule("core/rules/uk/section4/06_ctr_change_consent_sla.yaml")
+    t = "CTR change requires Company consent (not unreasonably withheld); deemed approved after 5 Business Days."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 07 Notice channels alignment
+def test_notice_channels_negative():
+    spec = load_rule("core/rules/uk/section4/07_notice_channels_alignment.yaml")
+    t = "Email shall not constitute writing. CR will acknowledge in writing."
+    out = run_rule(spec, AI(t, clause="notices"))
+    assert out is not None and any("no e-sign/portal path" in f.message or "Clause 29" in f.suggestion.text for f in out.findings)
+
+def test_notice_channels_positive():
+    spec = load_rule("core/rules/uk/section4/07_notice_channels_alignment.yaml")
+    t = "Acknowledgement via DocuSign portal; Notices per Clause 29."
+    out = run_rule(spec, AI(t, clause="notices"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 08 Instruction -> VO
+def test_instruction_vo_negative():
+    spec = load_rule("core/rules/uk/section4/08_instruction_triggers_vo.yaml")
+    t = "CR instructs change that affects Price and Schedule."
+    out = run_rule(spec, AI(t, clause="variations"))
+    assert out is not None and any("no VO routing" in f.message for f in out.findings)
+
+def test_instruction_vo_positive():
+    spec = load_rule("core/rules/uk/section4/08_instruction_triggers_vo.yaml")
+    t = "Any instruction impacting Scope/Price/Schedule/LD requires VOR/VO per Clause 14."
+    out = run_rule(spec, AI(t, clause="variations"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 09 Stop Work Authority
+def test_swa_negative():
+    spec = load_rule("core/rules/uk/section4/09_stop_work_authority.yaml")
+    t = "Safety rules apply."
+    out = run_rule(spec, AI(t, clause="HSE", doc="HSE Policy"))
+    assert out is not None and len(out.findings) >= 1
+
+def test_swa_positive():
+    spec = load_rule("core/rules/uk/section4/09_stop_work_authority.yaml")
+    t = "Stop Work Authority is in place; no retaliation for exercising SWA."
+    out = run_rule(spec, AI(t, clause="HSE", doc="HSE Policy"))
+    assert out is None or len(getattr(out, "findings", [])) == 0
+
+# 10 Chain of command clarity
+def test_chain_of_command_negative():
+    spec = load_rule("core/rules/uk/section4/10_chain_of_command_clarity.yaml")
+    t = "Dual reporting lines may apply; conflicting instructions can be followed."
+    out = run_rule(spec, AI(t))
+    assert out is not None and any("Conflicting directions" in f.message for f in out.findings)
+
+def test_chain_of_command_positive():
+    spec = load_rule("core/rules/uk/section4/10_chain_of_command_clarity.yaml")
+    t = "Single chain of command via CR↔CTR; conflicts escalated to CR for resolution."
+    out = run_rule(spec, AI(t))
+    assert out is None or len(getattr(out, "findings", [])) == 0


### PR DESCRIPTION
## Summary
- add deterministic YAML rules for UK clause 4 representatives including appointments, delegation, notice channels, and variation routing
- cover CR/CTR authority limits, NOM enforcement, and stop-work safeguards
- add comprehensive pytest suite for section4 rules

## Testing
- `pytest tests/rules/section4/test_section4_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafe267e588325bd193391b4efd917