### PR TITLE
Add universal performance rules and tests

### DIFF
--- a/core/rules/universal/performance/01_standard_rsc_vs_ffp.yaml
+++ b/core/rules/universal/performance/01_standard_rsc_vs_ffp.yaml
@@ -1,0 +1,50 @@
+rule:
+  id: "universal.performance.rsc_vs_ffp_priority"
+  version: "1.0.0"
+  title: "Reasonable skill and care vs fitness for purpose — stricter requirement prevails"
+  scope:
+    jurisdiction: ["UK","Any"]
+    doc_types: ["Any"]
+    clauses: ["performance","services","work"]
+  triggers:
+    any:
+      - regex: "(?i)reasonable\\s+skill\\s+and\\s+care|RSC|fitness\\s+for\\s+purpose|fit\\s+for\\s+purpose|KPI|performance\\s+standard"
+  checks:
+    - id: "no_rsc_and_no_ffp"
+      when:
+        all:
+          - not_regex: "(?i)reasonable\\s+skill\\s+and\\s+care|RSC"
+          - not_regex: "(?i)fitness\\s+for\\s+purpose|fit\\s+for\\s+purpose"
+      finding:
+        message: "No explicit standard of care or fitness requirement."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add RSC for services and specify fitness/output KPIs where applicable. Declare priority: specific output/fitness overrides general RSC."
+        score_delta: -25
+    - id: "conflict_no_priority_rule"
+      when:
+        all:
+          - regex: "(?i)reasonable\\s+skill\\s+and\\s+care"
+          - regex: "(?i)fitness\\s+for\\s+purpose|output\\s+parameter|KPI"
+          - not_regex: "(?i)(in\\s+case\\s+of\\s+|if\\s+)(a\\s+)?conflict.*(fitness|specific|stricter).*shall\\s+prevail"
+      finding:
+        message: "RSC + fitness present but no explicit priority rule."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "State: if conflict, stricter/specific fitness or output KPIs prevail."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: ServiceStandardAmbiguity
+    score: 80
+    problem: "Missing/ambiguous performance standard."
+    recommendation: "Add RSC and explicit priority for stricter fitness/output."
+    law_reference: []
+    category: "Performance"
+    keywords: ["RSC","fitness","priority"]
+metadata:
+  tags: ["standard","priority"]

--- a/core/rules/universal/performance/02_resources_sufficiency.yaml
+++ b/core/rules/universal/performance/02_resources_sufficiency.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "universal.performance.resources_sufficiency"
+  version: "1.0.0"
+  title: "Contractor to provide all resources; capacity planning where relevant"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["performance","resources"]
+  triggers:
+    any:
+      - regex: "(?i)resources|personnel|equipment|materials|capacity"
+  checks:
+    - id: "no_all_resources_commitment"
+      when:
+        not_regex: "(?i)provide\\s+all\\s+necessary\\s+(resources|personnel|equipment|materials)"
+      finding:
+        message: "No explicit obligation to provide all necessary resources."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Add obligation to provide all resources (people, tools, materials) at contractor’s cost unless stated otherwise."
+        score_delta: -15
+    - id: "no_capacity_plan_for_it"
+      when:
+        all:
+          - regex: "(?i)\\b(SaaS|IT|hosting|DR|RTO|RPO|availability)\\b"
+          - not_regex: "(?i)capacity\\s+plan|failover|RTO|RPO"
+      finding:
+        message: "Capacity/DR not addressed for IT/SaaS context."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Include capacity/failover with RTO/RPO metrics if service is IT/SaaS."
+        score_delta: -10
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: ResourceGap
+    score: 86
+    problem: "Resource/capacity commitments unclear."
+    recommendation: "Add full resources + capacity/DR where relevant."
+    law_reference: []
+    category: "Performance"
+    keywords: ["resources","capacity","DR"]
+metadata:
+  tags: ["resources"]

--- a/core/rules/universal/performance/03_cooperate_eot.yaml
+++ b/core/rules/universal/performance/03_cooperate_eot.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "universal.performance.cooperate_eot"
+  version: "1.0.0"
+  title: "Cooperate with others; include EOT mechanism for employer/third-party delay"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["performance","cooperation","schedule"]
+  triggers:
+    any:
+      - regex: "(?i)cooperate|coordination|third\\-party|interface|delay|extension\\s+of\\s+time|EOT"
+  checks:
+    - id: "no_cooperate_clause"
+      when:
+        not_regex: "(?i)cooperate|co-operation|coordinate"
+      finding:
+        message: "No duty to cooperate/coordinate with other parties."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Add duty to cooperate and an interface matrix."
+        score_delta: -12
+    - id: "no_eot_for_employer_delay"
+      when:
+        all:
+          - regex: "(?i)delay|late|hindrance|prevention"
+          - not_regex: "(?i)extension\\s+of\\s+time|EOT|time\\s+relief"
+      finding:
+        message: "No Extension of Time mechanism for employer/third-party delay (prevention principle risk)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add EOT for delays caused by employer or other contractors."
+        score_delta: -20
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: PreventionPrincipleRisk
+    score: 72
+    problem: "No cooperate/EOT protections."
+    recommendation: "Add cooperate + EOT for employer-caused delays."
+    law_reference: []
+    category: "Performance"
+    keywords: ["EOT","cooperate"]
+metadata:
+  tags: ["eot","cooperation"]

--- a/core/rules/universal/performance/04_permits_rtw.yaml
+++ b/core/rules/universal/performance/04_permits_rtw.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.permits_rtw"
+  version: "1.0.0"
+  title: "Permits/Authorisations matrix; right-to-work checks"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["permits","authorisations","immigration","performance"]
+  triggers:
+    any:
+      - regex: "(?i)permit|authorisation|authorization|licen[cs]e|visa|right\\-to\\-work|RTW"
+  checks:
+    - id: "no_permit_matrix"
+      when:
+        not_regex: "(?i)permit(s)?\\s+matrix|responsibility\\s+matrix|who\\s+obtains"
+      finding:
+        message: "No clear responsibility/timeframe for permits/licences."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add permit responsibility matrix (who/what/by when) and obligation to provide copies on request."
+        score_delta: -18
+    - id: "no_rtw_checks"
+      when:
+        not_regex: "(?i)right\\-to\\-work|immigration\\s+checks|sponsorship"
+      finding:
+        message: "No right-to-work / immigration compliance obligation."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Require RTW/immigration checks for all personnel before site access."
+        score_delta: -18
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: PermitImmigrationGap
+    score: 70
+    problem: "Permits/RTW control missing."
+    recommendation: "Add permit matrix + RTW checks."
+    law_reference: []
+    category: "Performance"
+    keywords: ["permits","RTW","immigration"]
+metadata:
+  tags: ["permits","rtw"]

--- a/core/rules/universal/performance/05_document_control_handover.yaml
+++ b/core/rules/universal/performance/05_document_control_handover.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.document_control_handover"
+  version: "1.0.0"
+  title: "Latest revisions in use; complete handover docs as condition of completion"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["document control","handover","performance"]
+  triggers:
+    any:
+      - regex: "(?i)revision|latest\\s+issue|document\\s+control|handover|as\\-built|O\\&M|manual"
+  checks:
+    - id: "no_latest_revision_rule"
+      when:
+        not_regex: "(?i)(latest\\s+(approved\\s+)?(revision|issue)\\b|work\\s+only\\s+on\\s+latest\\s+(approved\\s+)?(revision|issue)|no\\s+work\\s+on\\s+outdated\\s+documents)"
+      finding:
+        message: "No rule to ensure latest revisions are in use."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add: work only on latest approved revision; otherwise stop-work until updated."
+        score_delta: -20
+    - id: "handover_not_condition"
+      when:
+        not_regex: "(?i)completion\\s+subject\\s+to\\s+delivery\\s+of\\s+.*(handover|as\\-built|O\\&M)"
+      finding:
+        message: "Handover documentation not a condition to completion."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Make full handover pack a condition precedent to completion/acceptance."
+        score_delta: -12
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: DocumentControlGap
+    score: 72
+    problem: "No latest-revision rule and/or handover condition."
+    recommendation: "Add latest-revision control and handover as CP."
+    law_reference: []
+    category: "Performance"
+    keywords: ["document control","handover"]
+metadata:
+  tags: ["doc-control","handover"]

--- a/core/rules/universal/performance/06_materials_management.yaml
+++ b/core/rules/universal/performance/06_materials_management.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.materials_management"
+  version: "1.0.0"
+  title: "Materials management, non-conforming quarantine, CPI custody & risk"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["materials","warehouse","CPI"]
+  triggers:
+    any:
+      - regex: "(?i)materials|warehouse|inventory|non\\-conforming|quarantine|Company\\s+Provided"
+  checks:
+    - id: "no_mm_procedure"
+      when:
+        not_regex: "(?i)materials\\s+management\\s+procedure|MMP|WMS"
+      finding:
+        message: "No materials management/warehouse procedure."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Submit MMP/WMS incl. OS&D, quarantine, surplus/scrap flow."
+        score_delta: -12
+    - id: "no_cpi_liability"
+      when:
+        not_regex: "(?i)Company\\s+Provided\\s+(Items|Equipment).+custody|risk|loss|damage"
+      finding:
+        message: "No liability/custody terms for Company-Provided Items."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Define CPI custody, risk allocation and loss/damage responsibilities."
+        score_delta: -18
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: MaterialsControlGap
+    score: 80
+    problem: "Weak materials/CPI controls."
+    recommendation: "Add MMP/WMS and CPI custody/risk."
+    law_reference: []
+    category: "Performance"
+    keywords: ["materials","CPI","warehouse"]
+metadata:
+  tags: ["materials","cpi"]

--- a/core/rules/universal/performance/07_reporting_early_warning.yaml
+++ b/core/rules/universal/performance/07_reporting_early_warning.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.reporting_early_warning"
+  version: "1.0.0"
+  title: "Progress reporting cadence; early-warning events; shared risk register"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["reporting","risk","performance"]
+  triggers:
+    any:
+      - regex: "(?i)report|progress|early\\s+warning|risk\\s+register"
+  checks:
+    - id: "no_reporting_freq"
+      when:
+        not_regex: "(?i)weekly|biweekly|monthly\\s+progress\\s+report"
+      finding:
+        message: "No defined progress reporting frequency."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Define weekly/biweekly/monthly reporting cadence."
+        score_delta: -8
+    - id: "no_early_warning"
+      when:
+        not_regex: "(?i)early[-\\s]+warning|prompt\\s+notice\\s+of\\s+risk"
+      finding:
+        message: "No early-warning obligation."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Add early-warning triggers and shared risk register."
+        score_delta: -12
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: ReportingWeakness
+    score: 86
+    problem: "Reporting/early-warning not defined."
+    recommendation: "Add cadence, early-warning, risk register."
+    law_reference: []
+    category: "Performance"
+    keywords: ["reporting","early warning","risk register"]
+metadata:
+  tags: ["reporting"]

--- a/core/rules/universal/performance/08_schedule_recovery.yaml
+++ b/core/rules/universal/performance/08_schedule_recovery.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "universal.performance.schedule_recovery"
+  version: "1.0.0"
+  title: "Key dates; recovery plan on slippage; measures at contractor cost where agreed"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["schedule","recovery","performance"]
+  triggers:
+    any:
+      - regex: "(?i)key\\s+dates|milestone|slippage|recovery\\s+plan|accelerat"
+  checks:
+    - id: "no_key_dates"
+      when:
+        not_regex: "(?i)key\\s+dates|milestone|completion\\s+date"
+      finding:
+        message: "No key dates/milestones defined."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Define key dates/milestones tied to progress and LD (if any)."
+        score_delta: -18
+    - id: "no_recovery_plan"
+      when:
+        all:
+          - regex: "(?i)delay|slip|behind\\s+schedule"
+          - not_regex: "(?i)recovery\\s+plan|catch\\-up\\s+plan"
+      finding:
+        message: "No recovery plan obligation on delay."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Require recovery plan within X Business Days; additional resources at contractor cost if delay is contractor-caused."
+        score_delta: -15
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: ScheduleControlGap
+    score: 74
+    problem: "No key dates and/or recovery path."
+    recommendation: "Add milestones + recovery plan obligations."
+    law_reference: []
+    category: "Performance"
+    keywords: ["schedule","recovery"]
+metadata:
+  tags: ["schedule","recovery"]

--- a/core/rules/universal/performance/09_site_ptw_partial_occupation.yaml
+++ b/core/rules/universal/performance/09_site_ptw_partial_occupation.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.site_ptw_partial_occupation"
+  version: "1.0.0"
+  title: "Minimise interference; permit-to-work; partial occupation is not acceptance"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["site","worksite","HSE","acceptance"]
+  triggers:
+    any:
+      - regex: "(?i)site|worksite|permit\\-to\\-work|PTW|partial\\s+occupation|possession"
+  checks:
+    - id: "no_ptw_rule"
+      when:
+        not_regex: "(?i)permit\\-to\\-work|PTW"
+      finding:
+        message: "No permit-to-work requirement for site activities."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add PTW rule and compliance with site safety regime."
+        score_delta: -18
+    - id: "no_partial_occupation_clause"
+      when:
+        not_regex: "(?i)partial\\s+(occupation|possession)\\s+shall\\s+not\\s+constitute\\s+acceptance"
+      finding:
+        message: "No clause that partial occupation is not acceptance."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Clarify partial occupation/possession ≠ acceptance."
+        score_delta: -10
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: SiteControlGap
+    score: 72
+    problem: "Missing PTW and/or partial occupation clarification."
+    recommendation: "Add PTW and non-acceptance statement."
+    law_reference: []
+    category: "Performance"
+    keywords: ["PTW","partial occupation","HSE"]
+metadata:
+  tags: ["site","ptw"]

--- a/core/rules/universal/performance/10_working_hours_overtime.yaml
+++ b/core/rules/universal/performance/10_working_hours_overtime.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.working_hours_overtime"
+  version: "1.0.0"
+  title: "Working hours policy; overtime only with written approval; cost allocation"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["working hours","overtime","performance"]
+  triggers:
+    any:
+      - regex: "(?i)working\\s+hours|overtime|out\\-of\\-hours"
+  checks:
+    - id: "no_overtime_approval"
+      when:
+        not_regex: "(?i)overtime\\s+requires\\s+(prior\\s+)?written\\s+approval"
+      finding:
+        message: "No rule that overtime requires prior written approval."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Add prior written approval and who bears the cost."
+        score_delta: -10
+    - id: "no_cost_allocation"
+      when:
+        not_regex: "(?i)(overtime\\s+)?costs?\\s+(borne\\s+by|borne|at)\\s+(the\\s+contractor|contractor’s)"
+      finding:
+        message: "No clear cost allocation for overtime."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "State cost allocation (default: contractor if it remedies own delay)."
+        score_delta: -8
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: OvertimeAmbiguity
+    score: 88
+    problem: "Overtime approvals/costs unclear."
+    recommendation: "Add approval + cost rules."
+    law_reference: []
+    category: "Performance"
+    keywords: ["overtime","hours"]
+metadata:
+  tags: ["overtime"]

--- a/core/rules/universal/performance/11_goods_software_incoterms.yaml
+++ b/core/rules/universal/performance/11_goods_software_incoterms.yaml
@@ -1,0 +1,59 @@
+rule:
+  id: "universal.performance.goods_software_incoterms"
+  version: "1.0.0"
+  title: "Deliver software keys/licences & shipping docs; valid Incoterm with named place"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["goods","software","delivery","incoterms"]
+  triggers:
+    any:
+      - regex: "(?i)software|licen[cs]e|key|password|packing\\s+list|bill\\s+of\\s+lading|air\\s+waybill|incoterms|DDP|DAP|FCA|EXW"
+  checks:
+    - id: "no_software_keys"
+      when:
+        all:
+          - regex: "(?i)software|embedded"
+          - not_regex: "(?i)keys?|password|activation|licen[cs]e"
+      finding:
+        message: "Software-dependent goods but no keys/licences/passwords obligation."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Require delivery of keys/passwords/licences and O&M/manuals."
+        score_delta: -18
+    - id: "no_packing_docs"
+      when:
+        not_regex: "(?i)packing\\s+list|delivery\\s+note|certificate|manual"
+      finding:
+        message: "Shipping/packing documentation not specified."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "List required docs (packing list with PO, certificates, manuals)."
+        score_delta: -10
+    - id: "bad_incoterm"
+      when:
+        any:
+          - regex: "(?i)(DDP|DAP|FCA|EXW)(?![^\\n]*Named\\s+Place)"
+          - regex: "(?i)Incoterm(s)?(?!.*(DDP|DAP|FCA|EXW))"
+      finding:
+        message: "Incoterm missing or lacks Named Place."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Specify Incoterm 2020 with Named Place (e.g., DAP London DC, UK)."
+        score_delta: -18
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: DeliverySpecGap
+    score: 72
+    problem: "Keys/docs/incoterms incomplete."
+    recommendation: "Add software keys/docs and valid Incoterm with Named Place."
+    law_reference: []
+    category: "Performance"
+    keywords: ["software","incoterms","packing list"]
+metadata:
+  tags: ["goods","software","incoterms"]

--- a/core/rules/universal/performance/12_inspection_acceptance_window.yaml
+++ b/core/rules/universal/performance/12_inspection_acceptance_window.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.inspection_acceptance_window"
+  version: "1.0.0"
+  title: "Define inspection window and rejection mechanism; avoid deemed acceptance"
+  scope:
+    jurisdiction: ["UK","Any"]
+    doc_types: ["Any"]
+    clauses: ["inspection","acceptance","goods","deliverables"]
+  triggers:
+    any:
+      - regex: "(?i)inspect|inspection|acceptance|reject|deemed"
+  checks:
+    - id: "no_inspection_window"
+      when:
+        not_regex: "(?i)inspection\\s+window\\s+of\\s+\\d+\\s+(Business\\s+)?Days|within\\s+\\d+\\s+(Business\\s+)?Days\\s+of\\s+delivery"
+      finding:
+        message: "No concrete inspection window."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Set inspection window (e.g., 10 Business Days) and rejection mechanics."
+        score_delta: -15
+    - id: "no_reject_mechanism"
+      when:
+        not_regex: "(?i)reject|non\\-conforming|remedy|replace|repair"
+      finding:
+        message: "No rejection/remedy mechanism."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add reject notice procedure with supplier remedy/replace/repair."
+        score_delta: -18
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: AcceptanceRisk
+    score: 70
+    problem: "Inspection window/remedy not defined."
+    recommendation: "Define window and rejection/remedy steps."
+    law_reference: []
+    category: "Performance"
+    keywords: ["inspection","acceptance"]
+metadata:
+  tags: ["acceptance"]

--- a/core/rules/universal/performance/13_rental_equipment.yaml
+++ b/core/rules/universal/performance/13_rental_equipment.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.rental_equipment"
+  version: "1.0.0"
+  title: "Rental equipment: manuals, maintenance, risk & insurance"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["rental","equipment","hire"]
+  triggers:
+    any:
+      - regex: "(?i)rent|hire|leased\\s+equipment"
+  checks:
+    - id: "no_rental_docs"
+      when:
+        not_regex: "(?i)manual|maintenance|service\\s+records|instructions"
+      finding:
+        message: "Rental lacks manuals/maintenance instructions."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "Require manuals/maintenance instructions and service logs."
+        score_delta: -10
+    - id: "no_risk_insurance"
+      when:
+        not_regex: "(?i)risk\\s+of\\s+loss|insurance|liability"
+      finding:
+        message: "No risk/insurance allocation for rental equipment."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Allocate risk and minimum insurance for rented assets."
+        score_delta: -18
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: RentalGap
+    score: 80
+    problem: "Rental docs or risk allocation missing."
+    recommendation: "Add manuals/maintenance and risk/insurance terms."
+    law_reference: []
+    category: "Performance"
+    keywords: ["rental","insurance"]
+metadata:
+  tags: ["rental"]

--- a/core/rules/universal/performance/14_instructions_variation_gate.yaml
+++ b/core/rules/universal/performance/14_instructions_variation_gate.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "universal.performance.instructions_variation_gate"
+  version: "1.0.0"
+  title: "Customer instructions focus on result; any impact routes to Variation/Change"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["instructions","variation","change control"]
+  triggers:
+    any:
+      - regex: "(?i)instruction|direction|method|means|variation|change\\s+order|VO|VOR"
+  checks:
+    - id: "means_control"
+      when:
+        regex: "(?i)Customer\\s+may\\s+direct\\s+methods|means\\s+and\\s+methods"
+      finding:
+        message: "Customer attempts to control means/methods (risk of implied responsibility/variation)."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Limit to result; any impact to Scope/Price/Schedule -> formal Variation/Change."
+        score_delta: -15
+    - id: "impact_no_change_gate"
+      when:
+        all:
+          - regex: "(?i)(Scope|Price|Schedule|LD)"
+          - not_regex: "(?i)Variation|Change\\s+Order|VO|VOR"
+      finding:
+        message: "Instruction with impact but no Variation/Change gate."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Mandate VO/Change Order for any impact to scope/price/schedule/LD."
+        score_delta: -20
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: HiddenVariationRisk
+    score: 72
+    problem: "Means control and/or no change gate."
+    recommendation: "Limit to result; add Variation/Change routing."
+    law_reference: []
+    category: "Performance"
+    keywords: ["instructions","variation","change"]
+metadata:
+  tags: ["variation","instructions"]

--- a/core/rules/universal/performance/15_exhibits_policies_conflicts.yaml
+++ b/core/rules/universal/performance/15_exhibits_policies_conflicts.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.performance.exhibits_policies_conflicts"
+  version: "1.0.0"
+  title: "All referenced exhibits/policies applicable; resolve conflicts by precedence"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["policies","exhibits","precedence"]
+  triggers:
+    any:
+      - regex: "(?i)policy|policies|exhibit|appendix|annex|order\\s+of\\s+precedence"
+  checks:
+    - id: "no_list_of_applicables"
+      when:
+        not_regex: "(?i)(applicable\\s+[^\\n]+\\s+include|the\\s+following\\s+apply)"
+      finding:
+        message: "No explicit list of applicable exhibits/policies."
+        severity_level: "medium"
+        risk: "medium"
+        suggestion:
+          text: "List applicable exhibits/policies for the order."
+        score_delta: -10
+    - id: "no_precedence_rule"
+      when:
+        not_regex: "(?i)order\\s+of\\s+precedence|shall\\s+prevail"
+      finding:
+        message: "No precedence rule to resolve conflicts."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add precedence rule (e.g., Conditions > Scope/Specs > Standards/Policies > Forms)."
+        score_delta: -18
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: PrecedenceGap
+    score: 74
+    problem: "Applicability/precedence unclear."
+    recommendation: "Add explicit list and precedence rule."
+    law_reference: []
+    category: "Performance"
+    keywords: ["policies","precedence"]
+metadata:
+  tags: ["precedence","exhibits"]

--- a/tests/rules/performance/test_performance_rules.py
+++ b/tests/rules/performance/test_performance_rules.py
@@ -1,0 +1,203 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+def AI(text, clause="performance", doc="Agreement"):
+    return AnalysisInput(clause_type=clause, text=text,
+                         metadata={"jurisdiction":"UK","doc_type":doc})
+
+# 01 RSC vs FfP
+def test_rsc_ffp_negative():
+    spec = load_rule("core/rules/universal/performance/01_standard_rsc_vs_ffp.yaml")
+    t = "Services shall be provided."
+    out = run_rule(spec, AI(t))
+    assert out and any("No explicit standard" in f.message or "priority" in getattr(f, "message","") for f in out.findings)
+
+def test_rsc_ffp_positive():
+    spec = load_rule("core/rules/universal/performance/01_standard_rsc_vs_ffp.yaml")
+    t = ("Contractor shall exercise reasonable skill and care. "
+         "If conflict, stricter fitness/output KPIs shall prevail.")
+    out = run_rule(spec, AI(t))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 02 Resources
+def test_resources_negative():
+    spec = load_rule("core/rules/universal/performance/02_resources_sufficiency.yaml")
+    t = "Contractor will perform work."
+    out = run_rule(spec, AI(t, clause="resources"))
+    assert out and any("resources" in f.message.lower() for f in out.findings)
+
+def test_resources_positive():
+    spec = load_rule("core/rules/universal/performance/02_resources_sufficiency.yaml")
+    t = "Contractor shall provide all necessary resources (personnel, equipment, materials) at its cost."
+    out = run_rule(spec, AI(t, clause="resources"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 03 Cooperate & EOT
+def test_cooperate_eot_negative():
+    spec = load_rule("core/rules/universal/performance/03_cooperate_eot.yaml")
+    t = "There may be delay caused by others."
+    out = run_rule(spec, AI(t, clause="schedule"))
+    assert out and any("cooperate" in f.message.lower() or "Extension of Time" in f.message for f in out.findings)
+
+def test_cooperate_eot_positive():
+    spec = load_rule("core/rules/universal/performance/03_cooperate_eot.yaml")
+    t = "Contractor shall cooperate and coordinate; delays by employer/others give Extension of Time."
+    out = run_rule(spec, AI(t, clause="schedule"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 04 Permits/RTW
+def test_permits_rtw_negative():
+    spec = load_rule("core/rules/universal/performance/04_permits_rtw.yaml")
+    t = "All personnel will be engaged."
+    out = run_rule(spec, AI(t, clause="permits"))
+    assert out and len(out.findings) >= 1
+
+def test_permits_rtw_positive():
+    spec = load_rule("core/rules/universal/performance/04_permits_rtw.yaml")
+    t = "Permit responsibility matrix defines who/what/by when; right-to-work checks required before site access."
+    out = run_rule(spec, AI(t, clause="permits"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 05 Document control / handover
+def test_doc_control_negative():
+    spec = load_rule("core/rules/universal/performance/05_document_control_handover.yaml")
+    t = "Documents will be provided."
+    out = run_rule(spec, AI(t, clause="document control"))
+    assert out and any("latest" in f.message.lower() or "handover" in f.message.lower() for f in out.findings)
+
+def test_doc_control_positive():
+    spec = load_rule("core/rules/universal/performance/05_document_control_handover.yaml")
+    t = "Work only on latest approved revision; completion subject to delivery of full handover pack."
+    out = run_rule(spec, AI(t, clause="document control"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 06 Materials / CPI
+def test_materials_negative():
+    spec = load_rule("core/rules/universal/performance/06_materials_management.yaml")
+    t = "We will store materials."
+    out = run_rule(spec, AI(t, clause="materials"))
+    assert out and len(out.findings) >= 1
+
+def test_materials_positive():
+    spec = load_rule("core/rules/universal/performance/06_materials_management.yaml")
+    t = "Materials Management Procedure (WMS) in place incl. quarantine; Company Provided Items in contractor custody with risk allocation."
+    out = run_rule(spec, AI(t, clause="materials"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 07 Reporting / Early warning
+def test_reporting_negative():
+    spec = load_rule("core/rules/universal/performance/07_reporting_early_warning.yaml")
+    t = "Reports will be provided as needed."
+    out = run_rule(spec, AI(t, clause="reporting"))
+    assert out and len(out.findings) >= 1
+
+def test_reporting_positive():
+    spec = load_rule("core/rules/universal/performance/07_reporting_early_warning.yaml")
+    t = "Weekly progress reports; early-warning obligation; shared risk register."
+    out = run_rule(spec, AI(t, clause="reporting"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 08 Schedule / Recovery
+def test_schedule_negative():
+    spec = load_rule("core/rules/universal/performance/08_schedule_recovery.yaml")
+    t = "Contractor will try to meet dates; there may be slippage."
+    out = run_rule(spec, AI(t, clause="schedule"))
+    assert out and any("key dates" in f.message.lower() or "recovery" in f.message.lower() for f in out.findings)
+
+def test_schedule_positive():
+    spec = load_rule("core/rules/universal/performance/08_schedule_recovery.yaml")
+    t = "Key dates/milestones defined; on delay contractor submits recovery plan within 5 Business Days."
+    out = run_rule(spec, AI(t, clause="schedule"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 09 Site / PTW / Partial occupation
+def test_site_negative():
+    spec = load_rule("core/rules/universal/performance/09_site_ptw_partial_occupation.yaml")
+    t = "We will access the site; client may take partial possession."
+    out = run_rule(spec, AI(t, clause="site"))
+    assert out and len(out.findings) >= 1
+
+def test_site_positive():
+    spec = load_rule("core/rules/universal/performance/09_site_ptw_partial_occupation.yaml")
+    t = "Permit-to-Work applies; partial occupation shall not constitute acceptance."
+    out = run_rule(spec, AI(t, clause="site"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 10 Working hours & overtime
+def test_overtime_negative():
+    spec = load_rule("core/rules/universal/performance/10_working_hours_overtime.yaml")
+    t = "Overtime may be worked."
+    out = run_rule(spec, AI(t, clause="working hours"))
+    assert out and len(out.findings) >= 1
+
+def test_overtime_positive():
+    spec = load_rule("core/rules/universal/performance/10_working_hours_overtime.yaml")
+    t = "Overtime requires prior written approval; costs borne by the contractor when due to contractor delay."
+    out = run_rule(spec, AI(t, clause="working hours"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 11 Goods/software/Incoterms
+def test_goods_negative():
+    spec = load_rule("core/rules/universal/performance/11_goods_software_incoterms.yaml")
+    t = "Goods include embedded software."
+    out = run_rule(spec, AI(t, clause="goods"))
+    assert out and any("keys" in f.message.lower() or "incoterm" in f.message.lower() for f in out.findings)
+
+def test_goods_positive():
+    spec = load_rule("core/rules/universal/performance/11_goods_software_incoterms.yaml")
+    t = "Deliver keys/passwords/licences and packing list; Incoterm 2020 DAP Named Place London DC, UK."
+    out = run_rule(spec, AI(t, clause="goods"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 12 Inspection/acceptance window
+def test_acceptance_negative():
+    spec = load_rule("core/rules/universal/performance/12_inspection_acceptance_window.yaml")
+    t = "Buyer may inspect."
+    out = run_rule(spec, AI(t, clause="acceptance"))
+    assert out and len(out.findings) >= 1
+
+def test_acceptance_positive():
+    spec = load_rule("core/rules/universal/performance/12_inspection_acceptance_window.yaml")
+    t = "Inspection window of 10 Business Days from delivery; buyer may reject non-conforming items for repair/replace."
+    out = run_rule(spec, AI(t, clause="acceptance"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 13 Rental equipment
+def test_rental_negative():
+    spec = load_rule("core/rules/universal/performance/13_rental_equipment.yaml")
+    t = "Rented equipment will be provided."
+    out = run_rule(spec, AI(t, clause="rental"))
+    assert out and len(out.findings) >= 1
+
+def test_rental_positive():
+    spec = load_rule("core/rules/universal/performance/13_rental_equipment.yaml")
+    t = "Provide manuals and maintenance instructions; risk of loss and insurance allocation defined."
+    out = run_rule(spec, AI(t, clause="rental"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 14 Instructions / Variation gate
+def test_instructions_negative():
+    spec = load_rule("core/rules/universal/performance/14_instructions_variation_gate.yaml")
+    t = "Customer may direct methods; impacts schedule."
+    out = run_rule(spec, AI(t, clause="instructions"))
+    assert out and len(out.findings) >= 1
+
+def test_instructions_positive():
+    spec = load_rule("core/rules/universal/performance/14_instructions_variation_gate.yaml")
+    t = "Customer instructions focus on result; any impact to Scope/Price/Schedule requires a formal Change/Variation Order."
+    out = run_rule(spec, AI(t, clause="instructions"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 15 Exhibits/policies precedence
+def test_policies_negative():
+    spec = load_rule("core/rules/universal/performance/15_exhibits_policies_conflicts.yaml")
+    t = "Policies may apply."
+    out = run_rule(spec, AI(t, clause="policies"))
+    assert out and len(out.findings) >= 1
+
+def test_policies_positive():
+    spec = load_rule("core/rules/universal/performance/15_exhibits_policies_conflicts.yaml")
+    t = "Applicable policies/exhibits include A/B/C; order of precedence: Conditions > Scope/Specs > Standards/Policies > Forms."
+    out = run_rule(spec, AI(t, clause="policies"))
+    assert not out or len(getattr(out, "findings", [])) == 0


### PR DESCRIPTION
## Summary
- add 15 universal performance rules covering service standards, resources, cooperation, permits, document control, materials, reporting, schedule, site access, overtime, delivery specs, acceptance windows, rentals, instructions, and policy precedence
- add comprehensive test suite for performance rules

## Testing
- `pytest tests/rules/performance/test_performance_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb01c301048325bab9d07802f4e47a