### PR TITLE
Fix Analyze end-to-end: wire parseFindings, enable auto-annotation, add anchor fallback, align UI IDs, make tests green

### DIFF
--- a/tests/panel/test_anchor_fallbacks.py
+++ b/tests/panel/test_anchor_fallbacks.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+import textwrap
+
+JS = r"""
+const vm = require('vm');
+const fs = require('fs');
+const path = require('path');
+
+const bundlePath = path.resolve(process.cwd(), 'word_addin_dev', 'taskpane.bundle.js');
+let code = fs.readFileSync(bundlePath, 'utf-8');
+code = code.replace(/bootstrap\(\);\s*$/, '');
+
+const comments = [];
+const snippet = 'foo LongTokenExample bar';
+const token = 'LongTokenExample';
+
+const sandbox = {
+  window: { __lastAnalyzed: snippet },
+  document: { readyState: 'complete', getElementById(){return null;}, querySelector(){return null;}, addEventListener(){}, body: { dispatchEvent() {} } },
+  Word: {
+    run: async (fn) => {
+      const ctx = {
+        document: {
+          body: {
+            search: (txt) => ({
+              items: txt === snippet ? [] : [{ insertComment: (msg) => comments.push(msg) }],
+              load: () => {}
+            })
+          }
+        },
+        sync: async () => {}
+      };
+      await fn(ctx);
+    }
+  },
+  console
+};
+
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+
+(async () => {
+  await sandbox.annotateFindingsIntoWord([{ snippet, rule_id: 'r1', severity: 'high', start: 0 }]);
+  console.log(JSON.stringify(comments));
+})();
+"""
+
+def test_anchor_fallbacks(tmp_path):
+    result = subprocess.run(
+        ["node", "-e", textwrap.dedent(JS)],
+        capture_output=True, text=True, check=True
+    )
+    last_line = result.stdout.strip().splitlines()[-1]
+    data = json.loads(last_line)
+    assert len(data) == 1

--- a/tests/panel/test_autocomment_toggle.py
+++ b/tests/panel/test_autocomment_toggle.py
@@ -1,0 +1,81 @@
+import json
+import subprocess
+import textwrap
+
+JS = r"""
+const vm = require('vm');
+const fs = require('fs');
+const path = require('path');
+
+const bundlePath = path.resolve(process.cwd(), 'word_addin_dev', 'taskpane.bundle.js');
+let code = fs.readFileSync(bundlePath, 'utf-8');
+code = code.replace(/bootstrap\(\);\s*$/, '');
+
+let annotateCalled = 0;
+let analyzeCalled = 0;
+
+const btnAnalyze = {
+  handler: null,
+  addEventListener(ev, fn) { if (ev === 'click') this.handler = fn; },
+  removeAttribute() {},
+  classList: { remove() {} },
+  click() { this.handler && this.handler({ preventDefault(){} }); }
+};
+
+const checkbox = { checked: true };
+
+const elements = {
+  btnAnalyze,
+  results: { dispatchEvent() {} },
+  'cai-comment-on-analyze': checkbox
+};
+
+const document = {
+  querySelector(sel) { return sel === '#btnAnalyze' ? btnAnalyze : null; },
+  getElementById(id) { return elements[id] || null; },
+  body: { dispatchEvent() {} }
+};
+
+const sandbox = {
+  window: {},
+  document,
+  getWholeDocText: async () => 'A',
+  apiAnalyze: async () => {
+    analyzeCalled += 1;
+    return { json: { analysis: { findings: [{ snippet: 'A', rule_id: 'r1', severity: 'high' }] } }, resp: {} };
+  },
+  annotateFindingsIntoWord: async () => { annotateCalled += 1; },
+  notifyOk: () => {},
+  notifyErr: () => {},
+  notifyWarn: () => {},
+  applyMetaToBadges: () => {},
+  metaFromResponse: () => ({}),
+  console,
+  CustomEvent: function(type, init){ return { type, detail: (init && init.detail) || null }; },
+  parseFindings: (resp) => resp.analysis.findings
+};
+
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+
+sandbox.wireUI();
+btnAnalyze.click();
+setTimeout(() => {
+  const first = annotateCalled;
+  checkbox.checked = false;
+  btnAnalyze.click();
+  setTimeout(() => {
+    console.log(JSON.stringify({ first, second: annotateCalled }));
+  }, 0);
+}, 0);
+"""
+
+def test_autocomment_toggle(tmp_path):
+    result = subprocess.run(
+        ["node", "-e", textwrap.dedent(JS)],
+        capture_output=True, text=True, check=True
+    )
+    last_line = result.stdout.strip().splitlines()[-1]
+    data = json.loads(last_line)
+    assert data.get("first") == 1
+    assert data.get("second") == 1

--- a/tests/panel/test_risk_threshold_filter.py
+++ b/tests/panel/test_risk_threshold_filter.py
@@ -1,0 +1,79 @@
+import json
+import subprocess
+import textwrap
+
+JS = r"""
+const vm = require('vm');
+const fs = require('fs');
+const path = require('path');
+
+const bundlePath = path.resolve(process.cwd(), 'word_addin_dev', 'taskpane.bundle.js');
+let code = fs.readFileSync(bundlePath, 'utf-8');
+code = code.replace(/bootstrap\(\);\s*$/, '');
+
+let annotateCalled = 0;
+let receivedRuleIds = [];
+
+const btnAnalyze = {
+  handler: null,
+  addEventListener(ev, fn) { if (ev === 'click') this.handler = fn; },
+  removeAttribute() {},
+  classList: { remove() {} },
+  click() { this.handler && this.handler({ preventDefault(){} }); }
+};
+
+const select = { value: 'high' };
+const checkbox = { checked: true };
+
+const elements = {
+  btnAnalyze,
+  results: { dispatchEvent() {} },
+  'selectRiskThreshold': select,
+  'cai-comment-on-analyze': checkbox
+};
+
+const document = {
+  querySelector(sel) { return sel === '#btnAnalyze' ? btnAnalyze : null; },
+  getElementById(id) { return elements[id] || null; },
+  body: { dispatchEvent() {} }
+};
+
+const sandbox = {
+  window: {},
+  document,
+  getWholeDocText: async () => 'abc',
+  apiAnalyze: async () => ({ json: { analysis: { findings: [
+    { snippet: 'a', rule_id: 'low', severity: 'low' },
+    { snippet: 'b', rule_id: 'med', severity: 'medium' },
+    { snippet: 'c', rule_id: 'hi', severity: 'high' }
+  ] } }, resp: {} }),
+  annotateFindingsIntoWord: async (list) => { annotateCalled += 1; receivedRuleIds = list.map(f => f.rule_id); },
+  notifyOk: () => {},
+  notifyErr: () => {},
+  notifyWarn: () => {},
+  applyMetaToBadges: () => {},
+  metaFromResponse: () => ({}),
+  console,
+  CustomEvent: function(type, init){ return { type, detail: (init && init.detail) || null }; },
+  parseFindings: (resp) => resp.analysis.findings
+};
+
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+
+sandbox.wireUI();
+btnAnalyze.click();
+setTimeout(() => {
+  console.log(JSON.stringify({ annotateCalled, receivedRuleIds }));
+}, 0);
+"""
+
+def test_risk_threshold_filter(tmp_path):
+    result = subprocess.run(
+        ["node", "-e", textwrap.dedent(JS)],
+        capture_output=True, text=True, check=True
+    )
+    last_line = result.stdout.strip().splitlines()[-1]
+    data = json.loads(last_line)
+    assert data.get("annotateCalled") == 1
+    assert data.get("receivedRuleIds") == ["hi"]

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -38,6 +38,9 @@ export function parseFindings(resp: AnalyzeResponse): AnalyzeFinding[] {
   return Array.isArray(arr) ? arr.filter(Boolean) : [];
 }
 
+// (dev aid; harmless in prod)
+;(window as any).parseFindings = parseFindings;
+
 export function metaFromResponse(r: { headers: Headers; json?: any; status?: number }): Meta {
   const h = r.headers;
   const js = r.json || {};

--- a/word_addin_dev/taskpane.bundle.js
+++ b/word_addin_dev/taskpane.bundle.js
@@ -1,486 +1,652 @@
-// word_addin_dev/app/assets/api-client.ts
-function metaFromResponse(r) {
-  const h = r.headers;
-  const js = r.json || {};
-  const llm = js.llm || js;
-  return {
-    cid: h.get("x-cid"),
-    xcache: h.get("x-cache"),
-    latencyMs: h.get("x-latency-ms"),
-    schema: h.get("x-schema-version"),
-    provider: h.get("x-provider") || llm.provider || js.provider || null,
-    model: h.get("x-model") || llm.model || js.model || null,
-    llm_mode: h.get("x-llm-mode") || llm.mode || js.mode || null,
-    usage: h.get("x-usage-total"),
-    status: r.status != null ? String(r.status) : null
-  };
-}
-function applyMetaToBadges(m) {
-  const set = (id, v) => {
-    const el = document.getElementById(id);
-    if (el) el.textContent = v && v.length ? v : "\u2014";
-  };
-  set("status", m.status);
-  set("cid", m.cid);
-  set("xcache", m.xcache);
-  set("latency", m.latencyMs);
-  set("schema", m.schema);
-  set("provider", m.provider);
-  set("model", m.model);
-  set("mode", m.llm_mode);
-  set("usage", m.usage);
-}
-var DEFAULT_BASE = "https://localhost:9443";
-function base() {
-  try {
-    return (localStorage.getItem("backendUrl") || DEFAULT_BASE).replace(/\/+$/, "");
-  } catch {
-    return DEFAULT_BASE;
+(() => {
+  // app/assets/api-client.ts
+  function parseFindings(resp) {
+    const arr = resp?.analysis?.findings ?? resp?.findings ?? resp?.issues ?? [];
+    return Array.isArray(arr) ? arr.filter(Boolean) : [];
   }
-}
-async function req(path, { method = "GET", body = null, key = path } = {}) {
-  const r = await fetch(base() + path, {
-    method,
-    headers: { "content-type": "application/json" },
-    body: body ? JSON.stringify(body) : void 0,
-    credentials: "include"
-  });
-  const json = await r.json().catch(() => ({}));
-  const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
-  try {
-    applyMetaToBadges(meta);
-  } catch {
+  window.parseFindings = parseFindings;
+  function metaFromResponse(r) {
+    const h = r.headers;
+    const js = r.json || {};
+    const llm = js.llm || js;
+    return {
+      cid: h.get("x-cid"),
+      xcache: h.get("x-cache"),
+      latencyMs: h.get("x-latency-ms"),
+      schema: h.get("x-schema-version"),
+      provider: h.get("x-provider") || llm.provider || js.provider || null,
+      model: h.get("x-model") || llm.model || js.model || null,
+      llm_mode: h.get("x-llm-mode") || llm.mode || js.mode || null,
+      usage: h.get("x-usage-total"),
+      status: r.status != null ? String(r.status) : null
+    };
   }
-  try {
-    const w = window;
-    if (!w.__last) w.__last = {};
-    w.__last[key] = { status: r.status, req: { path, method, body }, json };
-  } catch {
+  function applyMetaToBadges(m) {
+    const set = (id, v) => {
+      const el = document.getElementById(id);
+      if (el) el.textContent = v && v.length ? v : "\u2014";
+    };
+    set("status", m.status);
+    set("cid", m.cid);
+    set("xcache", m.xcache);
+    set("latency", m.latencyMs);
+    set("schema", m.schema);
+    set("provider", m.provider);
+    set("model", m.model);
+    set("mode", m.llm_mode);
+    set("usage", m.usage);
   }
-  return { ok: r.ok, json, resp: r, meta };
-}
-async function apiHealth() {
-  return req("/health", { key: "health" });
-}
-async function apiAnalyze(text) {
-  return req("/api/analyze", { method: "POST", body: { text, mode: "live" }, key: "analyze" });
-}
-async function apiGptDraft(text, mode = "friendly", extra = {}) {
-  return req("/api/gpt-draft", { method: "POST", body: { text, mode, ...extra }, key: "gpt-draft" });
-}
-async function apiQaRecheck(text, rules = []) {
-  return req("/api/qa-recheck", { method: "POST", body: { text, rules }, key: "qa-recheck" });
-}
-
-// word_addin_dev/app/assets/notifier.ts
-function notifyOk(msg) {
-  try {
-    console.log("[OK]", msg);
-  } catch {
-  }
-}
-function notifyErr(msg) {
-  try {
-    console.error("[ERR]", msg);
-  } catch {
-  }
-}
-function notifyWarn(msg) {
-  try {
-    console.warn("[WARN]", msg);
-  } catch {
-  }
-}
-
-// word_addin_dev/app/assets/office.ts
-async function getWholeDocText() {
-  return await Word.run(async (ctx) => {
-    const body = ctx.document.body;
-    body.load("text");
-    await ctx.sync();
-    return (body.text || "").trim();
-  });
-}
-
-// word_addin_dev/app/assets/taskpane.ts
-var Q = {
-  proposed: 'textarea#proposedText, textarea[name="proposed"], textarea[data-role="proposed-text"]',
-  original: 'textarea#originalClause, textarea[name="original"], textarea[data-role="original-clause"]'
-};
-function slot(id, role) {
-  return document.querySelector(`[data-role="${role}"]`) || document.getElementById(id);
-}
-function renderResults(res) {
-  const clause = slot("resClauseType", "clause-type");
-  if (clause) clause.textContent = res?.clause_type || "\u2014";
-  const findingsArr = Array.isArray(res?.findings) ? res.findings : [];
-  const findingsList = slot("findingsList", "findings");
-  if (findingsList) {
-    findingsList.innerHTML = "";
-    findingsArr.forEach((f) => {
-      const li = document.createElement("li");
-      li.textContent = typeof f === "string" ? f : JSON.stringify(f);
-      findingsList.appendChild(li);
-    });
-  }
-  const recoArr = Array.isArray(res?.recommendations) ? res.recommendations : [];
-  const recoList = slot("recoList", "recommendations");
-  if (recoList) {
-    recoList.innerHTML = "";
-    recoArr.forEach((r) => {
-      const li = document.createElement("li");
-      li.textContent = typeof r === "string" ? r : JSON.stringify(r);
-      recoList.appendChild(li);
-    });
-  }
-  const count = slot("resFindingsCount", "findings-count");
-  if (count) count.textContent = String(findingsArr.length);
-  const pre = slot("rawJson", "raw-json");
-  if (pre) pre.textContent = JSON.stringify(res ?? {}, null, 2);
-}
-function wireResultsToggle() {
-  const toggle = slot("toggleRaw", "toggle-raw-json");
-  const pre = slot("rawJson", "raw-json");
-  if (toggle && pre) {
-    pre.style.display = "none";
-    toggle.addEventListener("click", () => {
-      pre.style.display = pre.style.display === "none" ? "block" : "none";
-    });
-  }
-}
-function setConnBadge(ok) {
-  const el = document.getElementById("connBadge");
-  if (el) el.textContent = `Conn: ${ok === null ? "\u2014" : ok ? "\u2713" : "\xD7"}`;
-}
-function setOfficeBadge(txt) {
-  const el = document.getElementById("officeBadge");
-  if (el) el.textContent = `Office: ${txt ?? "\u2014"}`;
-}
-function $(sel) {
-  return document.querySelector(sel);
-}
-function getSelectionAsync() {
-  return new Promise((resolve, reject) => {
+  var DEFAULT_BASE = "https://localhost:9443";
+  function base() {
     try {
-      Office.context.document.getSelectedDataAsync(Office.CoercionType.Text, (r) => {
-        if (r.status === Office.AsyncResultStatus.Succeeded) {
-          resolve((r.value || "").toString().trim());
-        } else {
-          reject(r.error);
-        }
-      });
-    } catch (e) {
-      reject(e);
+      return (localStorage.getItem("backendUrl") || DEFAULT_BASE).replace(/\/+$/, "");
+    } catch {
+      return DEFAULT_BASE;
     }
-  });
-}
-async function getSelectionContext(chars = 200) {
-  try {
+  }
+  async function req(path, { method = "GET", body = null, key = path } = {}) {
+    const r = await fetch(base() + path, {
+      method,
+      headers: { "content-type": "application/json" },
+      body: body ? JSON.stringify(body) : void 0,
+      credentials: "include"
+    });
+    const json = await r.json().catch(() => ({}));
+    const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
+    try {
+      applyMetaToBadges(meta);
+    } catch {
+    }
+    try {
+      const w = window;
+      if (!w.__last) w.__last = {};
+      w.__last[key] = { status: r.status, req: { path, method, body }, json };
+    } catch {
+    }
+    return { ok: r.ok, json, resp: r, meta };
+  }
+  async function apiHealth() {
+    return req("/health", { key: "health" });
+  }
+  async function apiAnalyze(text) {
+    return req("/api/analyze", { method: "POST", body: { text, mode: "live" }, key: "analyze" });
+  }
+  async function apiGptDraft(text, mode = "friendly", extra = {}) {
+    return req("/api/gpt-draft", { method: "POST", body: { text, mode, ...extra }, key: "gpt-draft" });
+  }
+  async function apiQaRecheck(text, rules = []) {
+    return req("/api/qa-recheck", { method: "POST", body: { text, rules }, key: "qa-recheck" });
+  }
+
+  // app/assets/notifier.ts
+  function notifyOk(msg) {
+    try {
+      console.log("[OK]", msg);
+    } catch {
+    }
+  }
+  function notifyErr(msg) {
+    try {
+      console.error("[ERR]", msg);
+    } catch {
+    }
+  }
+  function notifyWarn(msg) {
+    try {
+      console.warn("[WARN]", msg);
+    } catch {
+    }
+  }
+
+  // app/assets/office.ts
+  async function getWholeDocText() {
     return await Word.run(async (ctx) => {
-      const sel = ctx.document.getSelection();
       const body = ctx.document.body;
-      sel.load("text");
       body.load("text");
       await ctx.sync();
-      const full = body.text || "";
-      const s = sel.text || "";
-      const idx = full.indexOf(s);
-      if (idx === -1) return { before: "", after: "" };
-      return {
-        before: full.slice(Math.max(0, idx - chars), idx),
-        after: full.slice(idx + s.length, idx + s.length + chars)
-      };
+      return (body.text || "").trim();
     });
-  } catch (e) {
-    console.warn("context fail", e);
-    return { before: "", after: "" };
   }
-}
-async function onUseSelection() {
-  try {
-    const txt = await getSelectionAsync();
-    const el = document.getElementById("originalClause");
-    if (el) {
-      el.value = txt;
-      el.setAttribute("data-role", "source-loaded");
-    }
-  } catch (e) {
-    notifyWarn("Failed to load selection");
-    console.error(e);
+
+  // app/assets/taskpane.ts
+  var g = globalThis;
+  g.parseFindings = g.parseFindings || parseFindings;
+  g.apiAnalyze = g.apiAnalyze || apiAnalyze;
+  g.applyMetaToBadges = g.applyMetaToBadges || applyMetaToBadges;
+  g.metaFromResponse = g.metaFromResponse || metaFromResponse;
+  g.getWholeDocText = g.getWholeDocText || getWholeDocText;
+  var Q = {
+    proposed: 'textarea#proposedText, textarea[name="proposed"], textarea[data-role="proposed-text"]',
+    original: 'textarea#originalClause, textarea[name="original"], textarea[data-role="original-clause"]'
+  };
+  function slot(id, role) {
+    return document.querySelector(`[data-role="${role}"]`) || document.getElementById(id);
   }
-}
-async function onUseWholeDoc() {
-  const src = $(Q.original);
-  const raw = await getWholeDocText();
-  const text = normalizeText(raw || "");
-  if (src) {
-    src.value = text;
-    src.dispatchEvent(new Event("input", { bubbles: true }));
+  function normalizeText(s) {
+    if (!s) return "";
+    return s.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/[ \t]+/g, " ").trim();
   }
-  window.__lastAnalyzed = text;
-  window.toast?.("Whole doc loaded");
-}
-async function onGetAIDraft(ev) {
-  try {
-    const src = $(Q.original);
-    const dst = $(Q.proposed);
-    let text = (src?.value ?? "").trim();
-    if (!text) {
-      try {
-        text = await getSelectionAsync();
-        if (src) src.value = text;
-      } catch {
-      }
+  function getRiskThreshold() {
+    const sel = document.getElementById("selectRiskThreshold") || document.getElementById("riskThreshold");
+    const v = sel?.value?.toLowerCase();
+    return v === "low" || v === "medium" || v === "high" ? v : "medium";
+  }
+  function isAddCommentsOnAnalyzeEnabled() {
+    const cb = document.getElementById("cai-comment-on-analyze") || document.getElementById("chkAddCommentsOnAnalyze");
+    return cb ? !!cb.checked : true;
+  }
+  function severityRank(s) {
+    const m = (s || "").toLowerCase();
+    return m === "high" ? 3 : m === "medium" ? 2 : 1;
+  }
+  function filterByThreshold(list, thr) {
+    const min = severityRank(thr);
+    return (list || []).filter((f) => severityRank(f.severity) >= min);
+  }
+  function buildLegalComment(f) {
+    const sev = (f.severity || "info").toUpperCase();
+    const rid = f.rule_id || "rule";
+    const ct = f.clause_type ? ` (${f.clause_type})` : "";
+    const adv = f.advice ? ` \u2014 ${f.advice}` : "";
+    const law = f.law_reference ? ` | Law: ${f.law_reference}` : "";
+    const cit = Array.isArray(f.citations) && f.citations.length ? ` | Sources: ${f.citations.join(", ")}` : "";
+    const xrf = f.conflict_with ? ` | Conflicts: ${f.conflict_with}` : "";
+    return `[${sev}] ${rid}${ct}${adv}${law}${xrf}${cit}`;
+  }
+  function nthOccurrenceIndex(hay, needle, startPos) {
+    if (!needle) return 0;
+    let idx = -1, n = 0;
+    const bound = typeof startPos === "number" ? Math.max(0, startPos) : Number.MAX_SAFE_INTEGER;
+    while ((idx = hay.indexOf(needle, idx + 1)) !== -1 && idx < bound) n++;
+    return n;
+  }
+  function buildParagraphIndex(paragraphs) {
+    const starts = [];
+    const texts = [];
+    let pos = 0;
+    for (const p of paragraphs) {
+      const t = normalizeText(p);
+      starts.push(pos);
+      texts.push(t);
+      pos += t.length + 1;
     }
-    if (!text) {
-      notifyWarn("No source text");
-      return;
-    }
-    const modeSel = document.getElementById("cai-mode");
-    const mode = modeSel?.value || "friendly";
-    const ctx = await getSelectionContext(200);
-    const { ok, json, resp } = await apiGptDraft(
-      text,
-      mode,
-      { before_text: ctx.before, after_text: ctx.after }
-    );
-    if (!ok) {
-      notifyWarn("Draft failed");
-      return;
-    }
+    return { starts, texts };
+  }
+  async function mapFindingToRange(f) {
+    const last = window.__lastAnalyzed || "";
+    const base2 = normalizeText(last);
+    const snippet = normalizeText(f.snippet || "");
+    const occIdx = nthOccurrenceIndex(base2, snippet, f.start);
     try {
-      applyMetaToBadges(metaFromResponse(resp));
-    } catch {
-    }
-    const proposed = (json?.proposed_text ?? "").toString();
-    if (dst) {
-      if (!dst.id) dst.id = "proposedText";
-      if (!dst.name) dst.name = "proposed";
-      dst.dataset.role = "proposed-text";
-      dst.value = proposed;
-      dst.dispatchEvent(new Event("input", { bubbles: true }));
-      notifyOk("Draft ready");
-    } else {
-      notifyWarn("Proposed textarea not found");
-    }
-  } catch (e) {
-    notifyWarn("Draft error");
-    console.error(e);
-  }
-}
-async function doHealth() {
-  try {
-    const { ok, json, resp } = await apiHealth();
-    try {
-      applyMetaToBadges(metaFromResponse(resp));
-    } catch {
-    }
-    setConnBadge(ok);
-    notifyOk(`Health: ${json.status} (schema ${json.schema})`);
-  } catch (e) {
-    setConnBadge(false);
-    notifyWarn("Health failed");
-    console.error(e);
-  }
-}
-async function doAnalyze() {
-  try {
-    const cached = window.__lastAnalyzed;
-    const base = cached && cached.trim() ? cached : normalizeText(await getWholeDocText());
-    if (!base) {
-      notifyErr("\u0412 \u0434\u043E\u043A\u0443\u043C\u0435\u043D\u0442\u0435 \u043D\u0435\u0442 \u0442\u0435\u043A\u0441\u0442\u0430");
-      return;
-    }
-    window.__lastAnalyzed = base;
-    const { json, resp } = await apiAnalyze(base);
-    try {
-      applyMetaToBadges(metaFromResponse(resp));
-    } catch {}
-    renderResults(json);
-    try {
-      const findings = parseFindings(json);
-      if (Array.isArray(findings) && findings.length > 0) {
-        await annotateFindingsIntoWord(findings);
-      }
-    } catch (e) {
-      console.warn("auto-annotate after analyze failed", e);
-    }
-    (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.results", { detail: json }));
-    notifyOk("Analyze OK");
-  } catch (e) {
-    notifyWarn("Analyze failed");
-    console.error(e);
-  }
-}
-async function doQARecheck() {
-  const text = await getWholeDocText();
-  const { json, resp } = await apiQaRecheck(text, []);
-  try {
-    applyMetaToBadges(metaFromResponse(resp));
-  } catch {
-  }
-  (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
-  notifyOk("QA recheck OK");
-}
-function bindClick(sel, fn) {
-  const el = document.querySelector(sel);
-  if (!el) return;
-  el.addEventListener("click", (e) => {
-    e.preventDefault();
-    fn();
-  });
-  el.classList.remove("js-disable-while-busy");
-  el.removeAttribute("disabled");
-}
-async function onApplyTracked() {
-  try {
-    const dst = $(Q.proposed);
-    const proposed = (dst?.value || "").trim();
-    if (!proposed) {
-      notifyWarn("No draft to insert");
-      return;
-    }
-    await Word.run(async (ctx) => {
-      let range = ctx.document.getSelection();
-      ctx.document.trackRevisions = true;
-      range.insertText(proposed, "Replace");
-      try {
-        range.insertComment("AI draft");
-      } catch {
-      }
-      await ctx.sync();
-    });
-    notifyOk("Inserted into Word");
-  } catch (e) {
-    notifyWarn("Insert failed");
-    console.error(e);
-  }
-}
-async function onAcceptAll() {
-  try {
-    const dst = $(Q.proposed);
-    const proposed = (dst?.value || "").trim();
-    if (!proposed) {
-      window.toast?.("Nothing to accept");
-      return;
-    }
-    const cid = (document.getElementById("cid")?.textContent || "").trim();
-    const base2 = (() => {
-      try {
-        return (localStorage.getItem("backendUrl") || "https://localhost:9443").replace(/\/+$/, "");
-      } catch {
-        return "https://localhost:9443";
-      }
-    })();
-    const link = cid && cid !== "\u2014" ? `${base2}/api/trace/${cid}` : "AI draft";
-    await Word.run(async (ctx) => {
-      const range = ctx.document.getSelection();
-      ctx.document.trackRevisions = true;
-      range.insertText(proposed, "Replace");
-      try {
-        range.insertComment(link);
-      } catch {
-      }
-      await ctx.sync();
-    });
-    window.toast?.("Accepted into Word");
-    console.log("[OK] Accepted into Word");
-  } catch (e) {
-    window.toast?.("Accept failed");
-    console.error(e);
-  }
-}
-async function onRejectAll() {
-  try {
-    const dst = $(Q.proposed);
-    if (dst) {
-      dst.value = "";
-      dst.dispatchEvent(new Event("input", { bubbles: true }));
-    }
-    await Word.run(async (ctx) => {
-      const range = ctx.document.getSelection();
-      const revs = range.revisions;
-      revs.load("items");
-      await ctx.sync();
-      (revs.items || []).forEach((r) => {
-        try {
-          r.reject();
-        } catch {
-        }
+      return await Word.run(async (ctx) => {
+        const body = ctx.document.body;
+        const searchRes = body.search(snippet, { matchCase: false, matchWholeWord: false });
+        searchRes.load("items");
+        await ctx.sync();
+        const items = searchRes.items || [];
+        return items[Math.min(occIdx, Math.max(0, items.length - 1))] || null;
       });
-      await ctx.sync();
-    });
-    window.toast?.("Rejected");
-    console.log("[OK] Rejected");
-  } catch (e) {
-    window.toast?.("Reject failed");
-    console.error(e);
-  }
-}
-function wireUI() {
-  bindClick("#btnUseWholeDoc", onUseWholeDoc);
-  bindClick("#btnAnalyze", doAnalyze);
-  bindClick("#btnTest", doHealth);
-  bindClick("#btnQARecheck", doQARecheck);
-  document.getElementById("btnGetAIDraft")?.addEventListener("click", onGetAIDraft);
-  bindClick("#btnInsertIntoWord", onInsertIntoWord);
-  bindClick("#btnApplyTracked", onApplyTracked);
-  bindClick("#btnAcceptAll", onAcceptAll);
-  bindClick("#btnRejectAll", onRejectAll);
-  wireResultsToggle();
-  console.log("Panel UI wired");
-}
-async function onInsertIntoWord() {
-  try {
-    const dst = $(Q.proposed);
-    const txt = (dst?.value || "").trim();
-    if (!txt) {
-      notifyWarn("No draft to insert");
-      return;
+    } catch (e) {
+      console.warn("mapFindingToRange fail", e);
+      return null;
     }
-    if (window.Office && window.Word) {
+  }
+  async function annotateFindingsIntoWord(findings) {
+    const base2 = normalizeText(window.__lastAnalyzed || "");
+    for (const f of findings) {
+      const snippet = normalizeText(f.snippet || "");
+      if (!snippet) continue;
+      const occIdx = (() => {
+        if (typeof f.start !== "number" || !snippet) return 0;
+        let idx = -1, n = 0;
+        while ((idx = base2.indexOf(snippet, idx + 1)) !== -1 && idx < f.start) n++;
+        return n;
+      })();
+      try {
+        await Word.run(async (ctx) => {
+          const body = ctx.document.body;
+          const s1 = body.search(snippet, { matchCase: false, matchWholeWord: false });
+          s1.load("items");
+          await ctx.sync();
+          let target = s1.items?.[Math.min(occIdx, Math.max(0, (s1.items || []).length - 1))];
+          if (!target) {
+            const token = (() => {
+              const tokens = snippet.replace(/[^\p{L}\p{N} ]/gu, " ").split(" ").filter((x) => x.length >= 12);
+              if (tokens.length) return tokens.sort((a, b) => b.length - a.length)[0].slice(0, 64);
+              const i = Math.max(0, f.start ?? 0);
+              return base2.slice(i, i + 40);
+            })();
+            if (token && token.trim()) {
+              const s2 = body.search(token, { matchCase: false, matchWholeWord: false });
+              s2.load("items");
+              await ctx.sync();
+              target = s2.items?.[Math.min(occIdx, Math.max(0, (s2.items || []).length - 1))];
+            }
+          }
+          if (target) {
+            const msg = buildLegalComment(f);
+            target.insertComment(msg);
+          } else {
+            console.warn("[annotate] no match for snippet/anchor", { rid: f.rule_id, snippet: snippet.slice(0, 120) });
+          }
+          await ctx.sync();
+        });
+      } catch (e) {
+        console.warn("annotate error", e);
+      }
+    }
+  }
+  g.annotateFindingsIntoWord = g.annotateFindingsIntoWord || annotateFindingsIntoWord;
+  async function applyOpsTracked(ops) {
+    if (!ops || !ops.length) return;
+    const last = window.__lastAnalyzed || "";
+    await Word.run(async (ctx) => {
+      const body = ctx.document.body;
+      ctx.document.trackRevisions = true;
+      for (const op of ops) {
+        const snippet = last.slice(op.start, op.end);
+        const occIdx = (() => {
+          let idx = -1, n = 0;
+          while ((idx = last.indexOf(snippet, idx + 1)) !== -1 && idx < op.start) n++;
+          return n;
+        })();
+        const found = body.search(snippet, { matchCase: false, matchWholeWord: false });
+        found.load("items");
+        await ctx.sync();
+        const items = found.items || [];
+        const target = items[Math.min(occIdx, Math.max(0, items.length - 1))];
+        if (target) {
+          target.insertText(op.replacement, "Replace");
+          try {
+            target.insertComment("AI edit");
+          } catch {
+          }
+        } else {
+          console.warn("[applyOpsTracked] match not found", { snippet, occIdx });
+        }
+        await ctx.sync();
+      }
+    });
+  }
+  async function navComments(dir) {
+    try {
       await Word.run(async (ctx) => {
-        const range = ctx.document.getSelection();
-        range.insertText(txt, "Replace");
+        const comments = ctx.document.body.getComments();
+        comments.load("items");
+        await ctx.sync();
+        const list = comments.items;
+        if (!list.length) return;
+        const w = window;
+        w.__caiNavIdx = (w.__caiNavIdx ?? -1) + dir;
+        if (w.__caiNavIdx < 0) w.__caiNavIdx = list.length - 1;
+        if (w.__caiNavIdx >= list.length) w.__caiNavIdx = 0;
+        list[w.__caiNavIdx].getRange().select();
         await ctx.sync();
       });
-      notifyOk("Inserted into Word");
-    } else {
-      await navigator.clipboard.writeText(txt);
-      notifyWarn("Not in Office environment; result copied to clipboard");
+    } catch (e) {
+      console.warn("nav comment fail", e);
     }
-  } catch (e) {
+  }
+  function onPrevIssue() {
+    navComments(-1);
+  }
+  function onNextIssue() {
+    navComments(1);
+  }
+  function renderResults(res) {
+    const clause = slot("resClauseType", "clause-type");
+    if (clause) clause.textContent = res?.clause_type || "\u2014";
+    const findingsArr = parseFindings(res);
+    const findingsList = slot("findingsList", "findings");
+    if (findingsList) {
+      findingsList.innerHTML = "";
+      findingsArr.forEach((f) => {
+        const li = document.createElement("li");
+        li.textContent = typeof f === "string" ? f : JSON.stringify(f);
+        findingsList.appendChild(li);
+      });
+    }
+    const recoArr = Array.isArray(res?.recommendations) ? res.recommendations : [];
+    const recoList = slot("recoList", "recommendations");
+    if (recoList) {
+      recoList.innerHTML = "";
+      recoArr.forEach((r) => {
+        const li = document.createElement("li");
+        li.textContent = typeof r === "string" ? r : JSON.stringify(r);
+        recoList.appendChild(li);
+      });
+    }
+    const count = slot("resFindingsCount", "findings-count");
+    if (count) count.textContent = String(findingsArr.length);
+    const pre = slot("rawJson", "raw-json");
+    if (pre) pre.textContent = JSON.stringify(res ?? {}, null, 2);
+  }
+  function wireResultsToggle() {
+    const toggle = slot("toggleRaw", "toggle-raw-json");
+    const pre = slot("rawJson", "raw-json");
+    if (toggle && pre) {
+      pre.style.display = "none";
+      toggle.addEventListener("click", () => {
+        pre.style.display = pre.style.display === "none" ? "block" : "none";
+      });
+    }
+  }
+  function setConnBadge(ok) {
+    const el = document.getElementById("connBadge");
+    if (el) el.textContent = `Conn: ${ok === null ? "\u2014" : ok ? "\u2713" : "\xD7"}`;
+  }
+  function setOfficeBadge(txt) {
+    const el = document.getElementById("officeBadge");
+    if (el) el.textContent = `Office: ${txt ?? "\u2014"}`;
+  }
+  function $(sel) {
+    return document.querySelector(sel);
+  }
+  function getSelectionAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.document.getSelectedDataAsync(Office.CoercionType.Text, (r) => {
+          if (r.status === Office.AsyncResultStatus.Succeeded) {
+            resolve((r.value || "").toString().trim());
+          } else {
+            reject(r.error);
+          }
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+  async function getSelectionContext(chars = 200) {
     try {
-      await navigator.clipboard.writeText($(Q.proposed)?.value || "");
+      return await Word.run(async (ctx) => {
+        const sel = ctx.document.getSelection();
+        const body = ctx.document.body;
+        sel.load("text");
+        body.load("text");
+        await ctx.sync();
+        const full = body.text || "";
+        const s = sel.text || "";
+        const idx = full.indexOf(s);
+        if (idx === -1) return { before: "", after: "" };
+        return {
+          before: full.slice(Math.max(0, idx - chars), idx),
+          after: full.slice(idx + s.length, idx + s.length + chars)
+        };
+      });
+    } catch (e) {
+      console.warn("context fail", e);
+      return { before: "", after: "" };
+    }
+  }
+  async function onUseWholeDoc() {
+    const src = $(Q.original);
+    const raw = await getWholeDocText();
+    const text = normalizeText(raw || "");
+    if (src) {
+      src.value = text;
+      src.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+    window.__lastAnalyzed = text;
+    window.toast?.("Whole doc loaded");
+  }
+  async function onGetAIDraft(ev) {
+    try {
+      const src = $(Q.original);
+      const dst = $(Q.proposed);
+      let text = (src?.value ?? "").trim();
+      if (!text) {
+        try {
+          text = await getSelectionAsync();
+          if (src) src.value = text;
+        } catch {
+        }
+      }
+      if (!text) {
+        notifyWarn("No source text");
+        return;
+      }
+      const modeSel = document.getElementById("cai-mode");
+      const mode = modeSel?.value || "friendly";
+      const ctx = await getSelectionContext(200);
+      const { ok, json, resp } = await apiGptDraft(
+        text,
+        mode,
+        { before_text: ctx.before, after_text: ctx.after }
+      );
+      if (!ok) {
+        notifyWarn("Draft failed");
+        return;
+      }
+      try {
+        applyMetaToBadges(metaFromResponse(resp));
+      } catch {
+      }
+      const proposed = (json?.proposed_text ?? "").toString();
+      if (dst) {
+        if (!dst.id) dst.id = "proposedText";
+        if (!dst.name) dst.name = "proposed";
+        dst.dataset.role = "proposed-text";
+        dst.value = proposed;
+        dst.dispatchEvent(new Event("input", { bubbles: true }));
+        notifyOk("Draft ready");
+      } else {
+        notifyWarn("Proposed textarea not found");
+      }
+    } catch (e) {
+      notifyWarn("Draft error");
+      console.error(e);
+    }
+  }
+  async function doHealth() {
+    try {
+      const { ok, json, resp } = await apiHealth();
+      try {
+        applyMetaToBadges(metaFromResponse(resp));
+      } catch {
+      }
+      setConnBadge(ok);
+      notifyOk(`Health: ${json.status} (schema ${json.schema})`);
+    } catch (e) {
+      setConnBadge(false);
+      notifyWarn("Health failed");
+      console.error(e);
+    }
+  }
+  async function doAnalyze() {
+    try {
+      const cached = window.__lastAnalyzed;
+      const base2 = cached && cached.trim() ? cached : normalizeText(await globalThis.getWholeDocText());
+      if (!base2) {
+        notifyErr("\u0412 \u0434\u043E\u043A\u0443\u043C\u0435\u043D\u0442\u0435 \u043D\u0435\u0442 \u0442\u0435\u043A\u0441\u0442\u0430");
+        return;
+      }
+      window.__lastAnalyzed = base2;
+      const { json, resp } = await globalThis.apiAnalyze(base2);
+      try {
+        globalThis.applyMetaToBadges(globalThis.metaFromResponse(resp));
+      } catch {
+      }
+      renderResults(json);
+      try {
+        const all = globalThis.parseFindings(json);
+        const thr = getRiskThreshold();
+        const filtered = filterByThreshold(all, thr);
+        if (isAddCommentsOnAnalyzeEnabled() && filtered.length) {
+          await globalThis.annotateFindingsIntoWord(filtered);
+        }
+      } catch (e) {
+        console.warn("auto-annotate after analyze failed", e);
+      }
+      (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.results", { detail: json }));
+      notifyOk("Analyze OK");
+    } catch (e) {
+      notifyWarn("Analyze failed");
+      console.error(e);
+    }
+  }
+  async function doQARecheck() {
+    const text = await getWholeDocText();
+    const { json, resp } = await apiQaRecheck(text, []);
+    try {
+      applyMetaToBadges(metaFromResponse(resp));
     } catch {
     }
-    notifyWarn("Not in Office environment; result copied to clipboard");
-    console.error(e);
+    (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
+    notifyOk("QA recheck OK");
   }
-}
-async function bootstrap() {
-  if (document.readyState === "loading") {
-    await new Promise((res) => document.addEventListener("DOMContentLoaded", () => res(), { once: true }));
+  function bindClick(sel, fn) {
+    const el = document.querySelector(sel);
+    if (!el) return;
+    el.addEventListener("click", (e) => {
+      e.preventDefault();
+      fn();
+    });
+    el.classList.remove("js-disable-while-busy");
+    el.removeAttribute("disabled");
   }
-  wireUI();
-  try {
-    await doHealth();
-  } catch {
-  }
-  try {
-    if (window.Office?.onReady) {
-      const info = await window.Office.onReady();
-      setOfficeBadge(`${info?.host || "Word"} \u2713`);
+  async function onApplyTracked() {
+    try {
+      const last = window.__last || {};
+      const ops = last["gpt-draft"]?.json?.ops || last["suggest"]?.json?.ops || [];
+      if (!ops.length) {
+        notifyWarn("No ops to apply");
+        return;
+      }
+      await applyOpsTracked(ops);
+      notifyOk("Applied ops");
+    } catch (e) {
+      notifyWarn("Insert failed");
+      console.error(e);
     }
-  } catch {
-    setOfficeBadge(null);
   }
-}
-// Codex added helpers for nth occurrence targeting
-function normalizeText(s){return s? s.replace(/\r\n/g,"\n").replace(/\r/g,"\n").replace(/[ \t]+/g," ").trim():"";}
-function buildLegalComment(f){const sev=(f.severity||"info").toUpperCase();const rid=f.rule_id||"rule";const ct=f.clause_type?` (${f.clause_type})`:"";const adv=f.advice?` — ${f.advice}`:"";const law=f.law_reference?` | Law: ${f.law_reference}`:"";const cit=Array.isArray(f.citations)&&f.citations.length?` | Sources: ${f.citations.join(", ")}`:"";const xrf=f.conflict_with?` | Conflicts: ${f.conflict_with}`:"";return`[${sev}] ${rid}${ct}${adv}${law}${xrf}${cit}`;}
-function nthOccurrenceIndex(hay,needle,startPos){if(!needle)return 0;let idx=-1,n=0;const bound=typeof startPos==="number"?Math.max(0,startPos):Number.MAX_SAFE_INTEGER;while((idx=hay.indexOf(needle,idx+1))!==-1&&idx<bound)n++;return n;}
-async function mapFindingToRange(f){const last=window.__lastAnalyzed||"";const base=normalizeText(last);const snippet=normalizeText(f.snippet||"");const occIdx=nthOccurrenceIndex(base,snippet,f.start);try{return await Word.run(async ctx=>{const body=ctx.document.body;const searchRes=body.search(snippet,{matchCase:false,matchWholeWord:false});searchRes.load("items");await ctx.sync();const items=searchRes.items||[];return items[Math.min(occIdx,Math.max(0,items.length-1))]||null;});}catch(e){console.warn("mapFindingToRange fail",e);return null;}}
-async function annotateFindingsIntoWord(findings){const last=window.__lastAnalyzed||"";const base=normalizeText(last);for(const f of findings){const snippet=normalizeText(f.snippet||"");if(!snippet)continue;const occIdx=nthOccurrenceIndex(base,snippet,f.start);try{await Word.run(async ctx=>{const body=ctx.document.body;const searchRes=body.search(snippet,{matchCase:false,matchWholeWord:false});searchRes.load("items");await ctx.sync();const items=searchRes.items||[];const target=items[Math.min(occIdx,Math.max(0,items.length-1))];if(target){const msg=buildLegalComment(f);target.insertComment(msg);}else{console.warn("[annotate] snippet not found",{snippet,occIdx,total:items.length});}await ctx.sync();});}catch(e){console.warn("annotate error",e);}}}
-async function applyOpsTracked(ops){if(!ops||!ops.length)return;const last=window.__lastAnalyzed||"";await Word.run(async ctx=>{const body=ctx.document.body;ctx.document.trackRevisions=true;for(const op of ops){const snippet=last.slice(op.start,op.end);const occIdx=(()=>{let idx=-1,n=0;while((idx=last.indexOf(snippet,idx+1))!==-1&&idx<op.start)n++;return n;})();const found=body.search(snippet,{matchCase:false,matchWholeWord:false});found.load("items");await ctx.sync();const items=found.items||[];const target=items[Math.min(occIdx,Math.max(0,items.length-1))];if(target){target.insertText(op.replacement,"Replace");try{target.insertComment("AI edit");}catch{}}else{console.warn("[applyOpsTracked] match not found",{snippet,occIdx});}await ctx.sync();}});}
-bootstrap();
+  async function onAcceptAll() {
+    try {
+      const dst = $(Q.proposed);
+      const proposed = (dst?.value || "").trim();
+      if (!proposed) {
+        window.toast?.("Nothing to accept");
+        return;
+      }
+      const cid = (document.getElementById("cid")?.textContent || "").trim();
+      const base2 = (() => {
+        try {
+          return (localStorage.getItem("backendUrl") || "https://localhost:9443").replace(/\/+$/, "");
+        } catch {
+          return "https://localhost:9443";
+        }
+      })();
+      const link = cid && cid !== "\u2014" ? `${base2}/api/trace/${cid}` : "AI draft";
+      await Word.run(async (ctx) => {
+        const range = ctx.document.getSelection();
+        ctx.document.trackRevisions = true;
+        range.insertText(proposed, "Replace");
+        try {
+          range.insertComment(link);
+        } catch {
+        }
+        await ctx.sync();
+      });
+      window.toast?.("Accepted into Word");
+      console.log("[OK] Accepted into Word");
+    } catch (e) {
+      window.toast?.("Accept failed");
+      console.error(e);
+    }
+  }
+  async function onRejectAll() {
+    try {
+      const dst = $(Q.proposed);
+      if (dst) {
+        dst.value = "";
+        dst.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      await Word.run(async (ctx) => {
+        const range = ctx.document.getSelection();
+        const revs = range.revisions;
+        revs.load("items");
+        await ctx.sync();
+        (revs.items || []).forEach((r) => {
+          try {
+            r.reject();
+          } catch {
+          }
+        });
+        await ctx.sync();
+      });
+      window.toast?.("Rejected");
+      console.log("[OK] Rejected");
+    } catch (e) {
+      window.toast?.("Reject failed");
+      console.error(e);
+    }
+  }
+  function wireUI() {
+    bindClick("#btnUseWholeDoc", onUseWholeDoc);
+    bindClick("#btnAnalyze", doAnalyze);
+    bindClick("#btnTest", doHealth);
+    bindClick("#btnQARecheck", doQARecheck);
+    document.getElementById("btnGetAIDraft")?.addEventListener("click", onGetAIDraft);
+    bindClick("#btnInsertIntoWord", onInsertIntoWord);
+    bindClick("#btnApplyTracked", onApplyTracked);
+    bindClick("#btnAcceptAll", onAcceptAll);
+    bindClick("#btnRejectAll", onRejectAll);
+    bindClick("#btnPrevIssue", onPrevIssue);
+    bindClick("#btnNextIssue", onNextIssue);
+    bindClick("#btnAnnotate", () => {
+      const data = window.__last?.analyze?.json || {};
+      const findings = globalThis.parseFindings(data);
+      globalThis.annotateFindingsIntoWord(findings);
+    });
+    wireResultsToggle();
+    console.log("Panel UI wired");
+  }
+  g.wireUI = g.wireUI || wireUI;
+  async function onInsertIntoWord() {
+    try {
+      const dst = $(Q.proposed);
+      const txt = (dst?.value || "").trim();
+      if (!txt) {
+        notifyWarn("No draft to insert");
+        return;
+      }
+      if (window.Office && window.Word) {
+        await Word.run(async (ctx) => {
+          const range = ctx.document.getSelection();
+          range.insertText(txt, "Replace");
+          await ctx.sync();
+        });
+        notifyOk("Inserted into Word");
+      } else {
+        await navigator.clipboard.writeText(txt);
+        notifyWarn("Not in Office environment; result copied to clipboard");
+      }
+    } catch (e) {
+      try {
+        await navigator.clipboard.writeText($(Q.proposed)?.value || "");
+      } catch {
+      }
+      notifyWarn("Not in Office environment; result copied to clipboard");
+      console.error(e);
+    }
+  }
+  async function bootstrap() {
+    if (document.readyState === "loading") {
+      await new Promise((res) => document.addEventListener("DOMContentLoaded", () => res(), { once: true }));
+    }
+    wireUI();
+    try {
+      await doHealth();
+    } catch {
+    }
+    try {
+      if (window.Office?.onReady) {
+        const info = await window.Office.onReady();
+        setOfficeBadge(`${info?.host || "Word"} \u2713`);
+      }
+    } catch {
+      setOfficeBadge(null);
+    }
+  }
+  bootstrap();
+})();


### PR DESCRIPTION
## Summary
- export and globalize `parseFindings` to share parsed findings across code
- auto-annotate Analyze results with risk threshold and checkbox toggle, using robust anchor fallback for Word search
- add tests for auto-comment toggle, risk filtering, and anchoring fallback

## Testing
- `pytest -q tests/panel/test_whole_doc_analyze_smoke.py`
- `node -e "global.describe=(n,f)=>{f();}; global.it=(n,f)=>{f();}; require('./tests/panel/test_parse_findings.js'); console.log('ok');"`
- `pytest -q tests/panel/test_autocomment_toggle.py`
- `pytest -q tests/panel/test_risk_threshold_filter.py`
- `pytest -q tests/panel/test_anchor_fallbacks.py`
- `pytest -q tests/rules/recitals_and_clauses1/test_recitals_and_clauses1.py`
- `pytest -q tests/rules/definitions/test_b_block_and_calloff.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb285c0a808325b889ab4cea5a6d4d