### PR TITLE
Add universal inform rules with tests

### DIFF
--- a/core/engine/runner.py
+++ b/core/engine/runner.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 import yaml
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from core.schemas import AnalysisInput
 
@@ -17,6 +17,12 @@ from core.schemas import AnalysisInput
 class Finding:
     """Simplified finding used in tests."""
     message: str
+    suggestion: Optional["Suggestion"] = None
+
+
+@dataclass
+class Suggestion:
+    text: str = ""
 
 
 @dataclass
@@ -72,7 +78,11 @@ def run_rule(spec: Dict[str, Any], inp: AnalysisInput) -> RuleResult | None:
             f_spec = check.get("finding", {})
             msg = f_spec.get("message", "")
             risk = f_spec.get("risk", "low")
-            findings.append(Finding(message=msg))
+            s_spec = f_spec.get("suggestion")
+            suggestion = None
+            if isinstance(s_spec, dict):
+                suggestion = Suggestion(text=s_spec.get("text", ""))
+            findings.append(Finding(message=msg, suggestion=suggestion))
             if _RISK_ORDER.get(risk, 0) > _RISK_ORDER.get(max_risk, 0):
                 max_risk = risk
 

--- a/core/rules/universal/inform/01_deemed_scope_clarity.yaml
+++ b/core/rules/universal/inform/01_deemed_scope_clarity.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "universal.inform.deemed_scope_clarity"
+  version: "1.0.0"
+  title: "Deemed knowledge: scope must be clearly defined and referenced"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["pre-contract diligence","inform itself","scope","performance"]
+  triggers:
+    any:
+      - regex: "(?i)deemed\\s+to\\s+have\\s+(satisfied|informed)\\s+itself|contractor\\s+has\\s+informed\\s+itself"
+  checks:
+    - id: "no_scope_reference"
+      when:
+        not_regex: "(?i)(Scope|Statement\\s+of\\s+Work|Specifications|Employer|Customer\\s+Requirements)"
+      finding:
+        message: "Deemed knowledge present but scope documents not referenced explicitly."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Reference the exact scope/SoW/Specs set to avoid unintended fitness obligations."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: DeemedKnowledgeAmbiguity
+    score: 86
+    problem: "‘Deemed’ wording without crisp scope references."
+    recommendation: "Point the ‘deemed’ clause to named scope/SoW/Specs."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["deemed knowledge","scope","SoW"]
+metadata:
+  tags: ["deemed","scope"]

--- a/core/rules/universal/inform/02_deemed_laws_change.yaml
+++ b/core/rules/universal/inform/02_deemed_laws_change.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "universal.inform.deemed_laws_change"
+  version: "1.0.0"
+  title: "Deemed knowledge of laws must exclude Change in Law"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["inform itself","law compliance","change in law"]
+  triggers:
+    any:
+      - regex: "(?i)deemed\\s+to\\s+be\\s+aware\\s+of\\s+all\\s+applicable\\s+laws|knows\\s+all\\s+laws"
+  checks:
+    - id: "no_change_in_law_exception"
+      when:
+        not_regex: "(?i)Change\\s+in\\s+Law|variation|adjustment\\s+for\\s+law\\s+changes"
+      finding:
+        message: "Deemed awareness of all laws but no Change in Law relief."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add Change in Law clause routing to Variation/time/price adjustment."
+        score_delta: -20
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: ChangeInLawRisk
+    score: 72
+    problem: "No relief for law changes."
+    recommendation: "Provide Change in Law mechanism (VO/time/price)."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["Change in Law","deemed laws"]
+metadata:
+  tags: ["law","change"]

--- a/core/rules/universal/inform/03_deemed_pricing_voeot.yaml
+++ b/core/rules/universal/inform/03_deemed_pricing_voeot.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "universal.inform.deemed_pricing_voeot"
+  version: "1.0.0"
+  title: "Deemed sufficiency of rates/prices cannot block VO/EOT for new circumstances"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["pricing","inform itself","variations","EOT"]
+  triggers:
+    any:
+      - regex: "(?i)sufficient\\s+(rates|prices)|adequacy\\s+of\\s+pricing"
+  checks:
+    - id: "blocks_variation"
+      when:
+        regex: "(?i)no\\s+(adjustment|increase|extension)[^\\n]*in\\s+any\\s+circumstances"
+      finding:
+        message: "Pricing ‘sufficiency’ blocks all adjustment/extension."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Carve-out: bona fide Variations/EOT, Change in Law, Employer-caused delay."
+        score_delta: -20
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: PricingRigidity
+    score: 74
+    problem: "Absolute bar to adjustments."
+    recommendation: "Permit VO/EOT/Change in Law relief."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["pricing","VO","EOT"]
+metadata:
+  tags: ["pricing"]

--- a/core/rules/universal/inform/04_employer_info_nonreliance.yaml
+++ b/core/rules/universal/inform/04_employer_info_nonreliance.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "universal.inform.employer_info_nonreliance"
+  version: "1.0.0"
+  title: "Provided information disclaimers require fair non-reliance basis and fraud carve-out"
+  scope:
+    jurisdiction: ["UK","Any"]
+    doc_types: ["Any"]
+    clauses: ["information","non-reliance","misrepresentation"]
+  triggers:
+    any:
+      - regex: "(?i)(Customer|Employer|Company)\\s+Provided\\s+Information|provided\\s+by\\s+(Customer|Employer|Company)"
+  checks:
+    - id: "disclaimer_without_basis"
+      when:
+        all:
+          - regex: "(?i)no\\s+warranty|no\\s+representation"
+          - not_regex: "(?i)basis\\s+of\\s+contract|non\\-reliance|acknowledge\\s+not\\s+relied"
+      finding:
+        message: "Disclaimer present but no clear basis/non-reliance wording."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Add basis/non-reliance language consistent with reasonableness tests."
+        score_delta: -15
+    - id: "no_fraud_gross_carveout"
+      when:
+        not_regex: "(?i)(fraud|fraudulent|negligent)\\s+(misrepresentation|misstatement)|fraud\\s+carve\\-out"
+      finding:
+        message: "No carve-out for fraud/negligent misrep."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Insert explicit carve-out for fraud/negligent misrepresentation."
+        score_delta: -18
+  outcome:
+    status: warn
+    risk_level: high
+    severity: S2
+    issue_type: MisrepRisk
+    score: 78
+    problem: "Info disclaimers weak without fair non-reliance/fraud carve-out."
+    recommendation: "Add basis/non-reliance + fraud/negligence carve-out."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["non-reliance","misrepresentation"]
+metadata:
+  tags: ["nonreliance","disclaimer"]

--- a/core/rules/universal/inform/05_discrepancy_notice_timebar.yaml
+++ b/core/rules/universal/inform/05_discrepancy_notice_timebar.yaml
@@ -1,0 +1,47 @@
+rule:
+  id: "universal.inform.discrepancy_notice_timebar"
+  version: "1.0.0"
+  title: "Scrutinise and notify discrepancies within a clear, fair window; state time-bar"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["inform itself","notice","discrepancies","time bar"]
+  triggers:
+    any:
+      - regex: "(?i)(discrepanc|inconsisten|error)\\s+notice|notify\\s+.*(discrepanc|error)"
+  checks:
+    - id: "no_window"
+      when:
+        not_regex: "(?i)within\\s+\\d+\\s+(Business\\s+)?Days|\\d+\\s+day\\s+notice"
+      finding:
+        message: "No concrete notice window for discrepancies."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Set an explicit window (e.g., 10 Business Days from discovery/receipt)."
+        score_delta: -12
+    - id: "unclear_timebar"
+      when:
+        all:
+          - regex: "(?i)time\\-bar|lose\\s+entitlement|waiver"
+          - not_regex: "(?i)(Contract\\s+Manager|Project\\s+Manager|addressed\\s+to|issue|impact|evidence|discovery|receipt)"
+      finding:
+        message: "Time-bar mentioned but mechanics are unclear (trigger/addressee/content)."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Define trigger (receipt/discovery), addressee, required content and delivery channel."
+        score_delta: -18
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: TimeBarUnclear
+    score: 72
+    problem: "Ambiguous discrepancy notice/time-bar."
+    recommendation: "Define fair window and clear mechanics."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["notice","time-bar"]
+metadata:
+  tags: ["notice","timebar"]

--- a/core/rules/universal/inform/06_employer_corrects_variation.yaml
+++ b/core/rules/universal/inform/06_employer_corrects_variation.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.inform.employer_corrects_variation"
+  version: "1.0.0"
+  title: "Customer corrects its document errors; impacts go via Variation/EOT"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["discrepancies","variation","EOT"]
+  triggers:
+    any:
+      - regex: "(?i)Customer|Employer|Company.*(error|discrepanc|inconsisten)"
+  checks:
+    - id: "no_correction_obligation"
+      when:
+        not_regex: "(?i)shall\\s+(correct|clarify|instruct)[^\\n]*errors"
+      finding:
+        message: "No obligation on Customer to correct/clarify its errors."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Add explicit obligation to correct and instruct."
+        score_delta: -12
+    - id: "no_change_routing"
+      when:
+        not_regex: "(?i)(Variation|Change\\s+Order|VO|EOT)"
+      finding:
+        message: "No Variation/EOT routing when correction affects scope/time/price."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Route impacts through formal Variation/EOT."
+        score_delta: -18
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: CorrectionProcessGap
+    score: 74
+    problem: "No correction + change routing."
+    recommendation: "Mandate correction + VO/EOT routing."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["errors","variation","EOT"]
+metadata:
+  tags: ["variation"]

--- a/core/rules/universal/inform/07_implied_scope_limit.yaml
+++ b/core/rules/universal/inform/07_implied_scope_limit.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "universal.inform.implied_scope_limit"
+  version: "1.0.0"
+  title: "‘Necessary to perform’ implied scope limited to incidental work; otherwise Variation"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["scope","variation","performance"]
+  triggers:
+    any:
+      - regex: "(?i)all\\s+things\\s+necessary|everything\\s+required\\s+to\\s+perform"
+  checks:
+    - id: "unlimited_implied_scope"
+      when:
+        not_regex: "(?i)incidental|minor|not\\s+material|Variation"
+      finding:
+        message: "Implied scope appears unlimited."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Limit to incidental/minor tasks; material additions require Variation."
+        score_delta: -20
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: ScopeCreepRisk
+    score: 72
+    problem: "Unlimited implied scope."
+    recommendation: "Limit and gate via Variation."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["scope creep","implied scope"]
+metadata:
+  tags: ["scope"]

--- a/core/rules/universal/inform/08_physical_conditions_unforeseen.yaml
+++ b/core/rules/universal/inform/08_physical_conditions_unforeseen.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "universal.inform.physical_conditions_unforeseen"
+  version: "1.0.0"
+  title: "Physical conditions: foreseeability test and relief for unforeseen conditions"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["site conditions","physical conditions","risk","EOT","variation"]
+  triggers:
+    any:
+      - regex: "(?i)physical\\s+conditions|site\\s+conditions|ground\\s+conditions"
+  checks:
+    - id: "all_risk_contractor"
+      when:
+        all:
+          - regex: "(?i)contractor\\s+bears\\s+all\\s+risk"
+          - not_regex: "(?i)unforeseen|unforeseeable|latent|EOT|Variation"
+      finding:
+        message: "All physical condition risk on contractor with no unforeseen relief."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Add relief for unforeseen/latent physical conditions (VO/EOT) and a foreseeability test."
+        score_delta: -22
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: UnforeseenConditionsRisk
+    score: 70
+    problem: "No relief for unforeseen conditions."
+    recommendation: "Add foreseeability test + VO/EOT relief."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["physical conditions","unforeseen"]
+metadata:
+  tags: ["site","conditions"]

--- a/core/rules/universal/inform/09_resources_breakdown_carveouts.yaml
+++ b/core/rules/universal/inform/09_resources_breakdown_carveouts.yaml
@@ -1,0 +1,37 @@
+rule:
+  id: "universal.inform.resources_breakdown_carveouts"
+  version: "1.0.0"
+  title: "Resource availability and equipment breakdown risks with fair carve-outs"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["resources","equipment","risk","force majeure"]
+  triggers:
+    any:
+      - regex: "(?i)availability\\s+of\\s+personnel|equipment\\s+breakdown|failure\\s+of\\s+equipment"
+  checks:
+    - id: "no_employer_delay_relief"
+      when:
+        all:
+          - regex: "(?i)contractor\\s+responsible\\s+for\\s+all\\s+availability|all\\s+breakdowns"
+          - not_regex: "(?i)Employer|Customer\\s+caused|EOT|Variation"
+      finding:
+        message: "No relief for employer-caused access/interference or mandated delays."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Add relief for employer/authority interference and FM; align with EOT."
+        score_delta: -15
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: ResourceRiskImbalance
+    score: 82
+    problem: "Resource/breakdown risk allocated without carve-outs."
+    recommendation: "Add employer/FM carve-outs + EOT."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["resources","breakdown","EOT"]
+metadata:
+  tags: ["resources"]

--- a/core/rules/universal/inform/10_transport_employer_items.yaml
+++ b/core/rules/universal/inform/10_transport_employer_items.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "universal.inform.transport_employer_items"
+  version: "1.0.0"
+  title: "Transport of Customer-provided items: risk transfer point and Incoterms alignment"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["logistics","risk","company provided items"]
+  triggers:
+    any:
+      - regex: "(?i)(Company|Customer|Employer)\\s+Provided\\s+(Items|Equipment)|CPI"
+  checks:
+    - id: "no_risk_transfer_point"
+      when:
+        not_regex: "(?i)risk\\s+passes\\s+at\\s+(handover|collection|FOB|DAP|DDP)"
+      finding:
+        message: "No clear risk transfer point for transport of employer items."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Define risk transfer point and align with Incoterms 2020 if applicable."
+        score_delta: -12
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: S3
+    issue_type: TransportRiskGap
+    score: 86
+    problem: "Unclear risk transfer on CPI transport."
+    recommendation: "Define risk point; align with Incoterms."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["CPI","Incoterms","risk"]
+metadata:
+  tags: ["logistics","cpi"]

--- a/core/rules/universal/inform/11_notice_formalities.yaml
+++ b/core/rules/universal/inform/11_notice_formalities.yaml
@@ -1,0 +1,45 @@
+rule:
+  id: "universal.inform.notice_formalities"
+  version: "1.0.0"
+  title: "Notices about discrepancies/claims: channel, addressee, required content"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["notice","communication","time bar"]
+  triggers:
+    any:
+      - regex: "(?i)notice|written\\s+notice|notify"
+  checks:
+    - id: "no_channel"
+      when:
+        not_regex: "(?i)(email|portal|courier|registered\\s+post|e\\-signature|PDF)"
+      finding:
+        message: "Notice channel not specified."
+        severity_level: "major"
+        risk: "medium"
+        suggestion:
+          text: "Specify accepted channels (e-signed PDF/portal/email/courier)."
+        score_delta: -12
+    - id: "no_addressee_content"
+      when:
+        not_regex: "(?i)addressed\\s+to|attn\\.|must\\s+state|include\\s+details"
+      finding:
+        message: "Addressee or required content for notice is missing."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Define addressee/title and required fields (issue, impact, evidence, requested instruction)."
+        score_delta: -18
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: NoticeMechanicsGap
+    score: 72
+    problem: "Notice mechanics incomplete."
+    recommendation: "Define channel, addressee and content."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["notice","mechanics"]
+metadata:
+  tags: ["notice"]

--- a/core/rules/universal/inform/12_stop_work_on_conflict.yaml
+++ b/core/rules/universal/inform/12_stop_work_on_conflict.yaml
@@ -1,0 +1,35 @@
+rule:
+  id: "universal.inform.stop_work_on_conflict"
+  version: "1.0.0"
+  title: "If discrepancy jeopardises safety or legal compliance, stop-work until instruction"
+  scope:
+    jurisdiction: ["Any"]
+    doc_types: ["Any"]
+    clauses: ["HSE","compliance","discrepancies","instructions"]
+  triggers:
+    any:
+      - regex: "(?i)safety|legal\\s+compliance|stop\\-work|permit\\-to\\-work|PTW"
+  checks:
+    - id: "no_stop_work_right"
+      when:
+        not_regex: "(?i)may\\s+suspend|stop\\-work|halt\\s+work\\s+until\\s+instructions"
+      finding:
+        message: "No explicit right/duty to stop-work or suspend in safety/legal conflict."
+        severity_level: "major"
+        risk: "high"
+        suggestion:
+          text: "Insert stop-work authority and non-retaliation; resume after written instruction."
+        score_delta: -20
+  outcome:
+    status: fail
+    risk_level: high
+    severity: S2
+    issue_type: SafetyStopWorkGap
+    score: 70
+    problem: "No stop-work authority for HSE/legal conflicts."
+    recommendation: "Add stop-work right/duty + restart conditions."
+    law_reference: []
+    category: "Inform & Diligence"
+    keywords: ["HSE","stop work","compliance"]
+metadata:
+  tags: ["safety","ptw"]

--- a/tests/rules/inform/test_inform_rules.py
+++ b/tests/rules/inform/test_inform_rules.py
@@ -1,0 +1,165 @@
+import pytest
+from core.engine.runner import run_rule, load_rule
+from core.schemas import AnalysisInput
+
+def AI(text, clause="inform", doc="Agreement"):
+    return AnalysisInput(clause_type=clause, text=text,
+                         metadata={"jurisdiction":"UK","doc_type":doc})
+
+# 01 Deemed scope clarity
+def test_deemed_scope_negative():
+    spec = load_rule("core/rules/universal/inform/01_deemed_scope_clarity.yaml")
+    t = "The Contractor is deemed to have informed itself."
+    out = run_rule(spec, AI(t, clause="inform"))
+    assert out and any("scope documents" in f.message for f in out.findings)
+
+def test_deemed_scope_positive():
+    spec = load_rule("core/rules/universal/inform/01_deemed_scope_clarity.yaml")
+    t = "The Contractor is deemed to have informed itself of the Scope, Statement of Work and Specifications."
+    out = run_rule(spec, AI(t, clause="inform"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 02 Deemed laws / Change in Law
+def test_deemed_laws_negative():
+    spec = load_rule("core/rules/universal/inform/02_deemed_laws_change.yaml")
+    t = "The Contractor is deemed to be aware of all applicable laws."
+    out = run_rule(spec, AI(t, clause="inform"))
+    assert out and any("Change in Law" in f.suggestion.text for f in out.findings)
+
+def test_deemed_laws_positive():
+    spec = load_rule("core/rules/universal/inform/02_deemed_laws_change.yaml")
+    t = "The Contractor is deemed aware of laws; Change in Law adjustments shall be made via Variation/time/price."
+    out = run_rule(spec, AI(t, clause="inform"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 03 Deemed pricing / VO-EOT
+def test_deemed_pricing_negative():
+    spec = load_rule("core/rules/universal/inform/03_deemed_pricing_voeot.yaml")
+    t = "Rates are sufficient with no adjustment or extension in any circumstances."
+    out = run_rule(spec, AI(t, clause="pricing"))
+    assert out and any("blocks all adjustment" in f.message for f in out.findings)
+
+def test_deemed_pricing_positive():
+    spec = load_rule("core/rules/universal/inform/03_deemed_pricing_voeot.yaml")
+    t = "Rates are sufficient, save for bona fide Variations, Change in Law and Employer-caused delay (EOT)."
+    out = run_rule(spec, AI(t, clause="pricing"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 04 Employer info / non-reliance
+def test_employer_info_negative():
+    spec = load_rule("core/rules/universal/inform/04_employer_info_nonreliance.yaml")
+    t = "Information provided by Customer carries no warranty."
+    out = run_rule(spec, AI(t, clause="information"))
+    assert out and len(out.findings) >= 1
+
+def test_employer_info_positive():
+    spec = load_rule("core/rules/universal/inform/04_employer_info_nonreliance.yaml")
+    t = ("Customer Provided Information: no warranty; parties agree basis/non-reliance; "
+         "fraud/negligent misrepresentation expressly carved-out.")
+    out = run_rule(spec, AI(t, clause="information"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 05 Discrepancy notice / time-bar
+def test_discrepancy_notice_negative():
+    spec = load_rule("core/rules/universal/inform/05_discrepancy_notice_timebar.yaml")
+    t = "Contractor shall notify discrepancies promptly; claims may be time-barred."
+    out = run_rule(spec, AI(t, clause="notice"))
+    assert out and any("concrete notice window" in f.message or "mechanics are unclear" in f.message for f in out.findings)
+
+def test_discrepancy_notice_positive():
+    spec = load_rule("core/rules/universal/inform/05_discrepancy_notice_timebar.yaml")
+    t = ("Notify discrepancies within 10 Business Days of discovery by written notice to the Contract Manager, "
+         "stating issue/impact/evidence; failure results in time-bar.")
+    out = run_rule(spec, AI(t, clause="notice"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 06 Employer corrects / Variation routing
+def test_employer_corrects_negative():
+    spec = load_rule("core/rules/universal/inform/06_employer_corrects_variation.yaml")
+    t = "Errors may be addressed by the Contractor."
+    out = run_rule(spec, AI(t, clause="discrepancies"))
+    assert out and any("No obligation on Customer" in f.message or "No Variation/EOT routing" in f.message for f in out.findings)
+
+def test_employer_corrects_positive():
+    spec = load_rule("core/rules/universal/inform/06_employer_corrects_variation.yaml")
+    t = "Customer shall correct its document errors and any impact shall be processed via Variation/EOT."
+    out = run_rule(spec, AI(t, clause="discrepancies"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 07 Implied scope limit
+def test_implied_scope_negative():
+    spec = load_rule("core/rules/universal/inform/07_implied_scope_limit.yaml")
+    t = "Contractor shall do all things necessary to perform the Works."
+    out = run_rule(spec, AI(t, clause="scope"))
+    assert out and any("Implied scope appears unlimited" in f.message for f in out.findings)
+
+def test_implied_scope_positive():
+    spec = load_rule("core/rules/universal/inform/07_implied_scope_limit.yaml")
+    t = "Contractor shall perform incidental tasks necessary to perform; material additions require Variation."
+    out = run_rule(spec, AI(t, clause="scope"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 08 Physical conditions unforeseen relief
+def test_physical_conditions_negative():
+    spec = load_rule("core/rules/universal/inform/08_physical_conditions_unforeseen.yaml")
+    t = "Contractor bears all risk of physical conditions."
+    out = run_rule(spec, AI(t, clause="site conditions"))
+    assert out and any("unforeseen" in f.suggestion.text.lower() for f in out.findings)
+
+def test_physical_conditions_positive():
+    spec = load_rule("core/rules/universal/inform/08_physical_conditions_unforeseen.yaml")
+    t = "Contractor bears risk of normal conditions; unforeseen/latent conditions give EOT and Variation."
+    out = run_rule(spec, AI(t, clause="site conditions"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 09 Resources & breakdown carve-outs
+def test_resources_breakdown_negative():
+    spec = load_rule("core/rules/universal/inform/09_resources_breakdown_carveouts.yaml")
+    t = "Contractor is responsible for all availability and all breakdowns."
+    out = run_rule(spec, AI(t, clause="resources"))
+    assert out and len(out.findings) >= 1
+
+def test_resources_breakdown_positive():
+    spec = load_rule("core/rules/universal/inform/09_resources_breakdown_carveouts.yaml")
+    t = "Contractor responsible for availability/breakdowns, save for Employer interference/authority shutdowns (EOT applies)."
+    out = run_rule(spec, AI(t, clause="resources"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 10 Transport of employer items
+def test_transport_cpi_negative():
+    spec = load_rule("core/rules/universal/inform/10_transport_employer_items.yaml")
+    t = "Company Provided Items may be transported by Contractor."
+    out = run_rule(spec, AI(t, clause="logistics"))
+    assert out and any("risk transfer point" in f.message for f in out.findings)
+
+def test_transport_cpi_positive():
+    spec = load_rule("core/rules/universal/inform/10_transport_employer_items.yaml")
+    t = "Risk passes at collection (DAP Named Place); aligns with Incoterms 2020."
+    out = run_rule(spec, AI(t, clause="logistics"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 11 Notice mechanics
+def test_notice_mechanics_negative():
+    spec = load_rule("core/rules/universal/inform/11_notice_formalities.yaml")
+    t = "A written notice must be given."
+    out = run_rule(spec, AI(t, clause="notice"))
+    assert out and len(out.findings) >= 1
+
+def test_notice_mechanics_positive():
+    spec = load_rule("core/rules/universal/inform/11_notice_formalities.yaml")
+    t = "Notice by e-signed PDF or portal to Contract Manager (Attn.), stating issue/impact/evidence/requested instruction."
+    out = run_rule(spec, AI(t, clause="notice"))
+    assert not out or len(getattr(out, "findings", [])) == 0
+
+# 12 Stop-work safety/legal
+def test_stop_work_negative():
+    spec = load_rule("core/rules/universal/inform/12_stop_work_on_conflict.yaml")
+    t = "Parties will comply with safety rules."
+    out = run_rule(spec, AI(t, clause="HSE"))
+    assert out and any("stop-work" in f.message or "suspend" in f.message.lower() for f in out.findings)
+
+def test_stop_work_positive():
+    spec = load_rule("core/rules/universal/inform/12_stop_work_on_conflict.yaml")
+    t = "If safety/legal conflict arises, Contractor may stop-work until written instruction; no retaliation."
+    out = run_rule(spec, AI(t, clause="HSE"))
+    assert not out or len(getattr(out, "findings", [])) == 0


### PR DESCRIPTION
## Summary
- add 12 universal "inform" YAML rules covering deemed scope, change in law, pricing, notices and stop-work rights
- extend rule runner to expose suggestion text for findings
- add comprehensive pytest suite for inform rules

## Testing
- `pytest tests/rules/inform/test_inform_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2b46381c832584e10a5063c421c4