### PR TITLE
Normalize health paths and add packaging config

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -18,7 +18,7 @@ import time
 from datetime import datetime, timezone
 import logging
 from contextlib import asynccontextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple
 
 from collections import OrderedDict
@@ -1293,7 +1293,12 @@ async def health() -> JSONResponse:
     }
     try:
         if rules_loader and hasattr(rules_loader, "loaded_packs"):
-            payload.setdefault("meta", {})["rules"] = rules_loader.loaded_packs()
+            packs = rules_loader.loaded_packs()
+            for pack in packs:
+                p = pack.get("path")
+                if p:
+                    pack["path"] = PurePosixPath(Path(p)).as_posix()
+            payload.setdefault("meta", {})["rules"] = packs
     except Exception:
         payload.setdefault("meta", {})["rules"] = []
     headers = {"x-schema-version": SCHEMA_VERSION}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,17 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "contract-ai"
+name = "contract_ai"
 version = "0.0.0"
+description = "Contract analysis engine + Word panel"
+requires-python = ">=3.10"
+readme = "README.md"
+license = {text = "Proprietary"}
+dynamic = ["dependencies"]
 
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.package-data]
-"*" = ["*.yaml"]
+[tool.setuptools.packages.find]
+where = ["."]
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ cryptography>=42
 requests
 python-dotenv==1.0.1
 pytest-xdist==3.6.1
+build>=1.2.1

--- a/tests/rules/test_packaging_manifest.py
+++ b/tests/rules/test_packaging_manifest.py
@@ -3,6 +3,11 @@ import tarfile
 import zipfile
 import subprocess
 from pathlib import Path
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("build") is None:  # pragma: no cover - optional dependency
+    pytest.skip("python -m build not available", allow_module_level=True)
 
 
 def test_packaging_manifest(tmp_path):


### PR DESCRIPTION
## Summary
- Normalize rule pack paths in `/health` to use POSIX separators
- Add minimal `pyproject.toml` and include build tool in dev requirements
- Skip packaging test if `build` module is missing

## Testing
- `python -m build`
- `pytest tests/panel/test_whole_doc_analyze_smoke.py -q`
- `pytest tests/panel/test_slots_exist.py -q`
- `SSL_CERT_FILE=certs/dev.crt PANEL_BASE="https://localhost:9443" pytest tests/panel/test_gpt_draft_payload.py -q`
- `pytest tests/rules/test_rules_inventory.py -q`
- `pytest tests/rules/test_findings_schema_fields.py -q`
- `pytest tests/rules/test_server_threshold.py -q`
- `pytest tests/panel/test_anchor_sentence_scope.py -q`
- `pytest tests/panel/test_aggregation_dedup.py -q`
- `pytest tests/rules/test_packaging_manifest.py -q`

### /health output
```json
[
  {
    "path": "contract_review_app/legal_rules/policy_packs/core_en_v1.yaml",
    "rule_count": 7
  },
  {
    "path": "contract_review_app/legal_rules/policy_packs/governing_law_england_wales.yaml",
    "rule_count": 1
  },
  {
    "path": "contract_review_app/legal_rules/policy_packs/msa_oilgas_uk_v1.yaml",
    "rule_count": 22
  },
  {
    "path": "core/rules/uk/calloff/01_calloff_exclude_other_terms.yaml",
    "rule_count": 1
  },
  {
    "path": "core/rules/uk/calloff/02_calloff_formation_by_performance_controls.yaml",
    "rule_count": 1
  }
]
```

------
https://chatgpt.com/codex/tasks/task_e_68bb57b11c288325852b87a776927970