### PR TITLE
Add ParsedDocument invariants and fuzz tests

### DIFF
--- a/contract_review_app/intake/README.md
+++ b/contract_review_app/intake/README.md
@@ -1,0 +1,28 @@
+# Intake module
+
+Utilities for preparing raw contract text for downstream processing.
+
+## Normalization
+
+* Windows (``\r\n``) and legacy Mac (``\r``) line endings are converted to
+  ``\n``.
+* Curly quotes, various dashes and non‑breaking spaces are replaced with their
+  ASCII equivalents.
+* Zero‑width characters are stripped.
+
+The normalization step builds a strict offset map so every character in the
+normalized text can be traced back to the original position.
+
+## Splitting
+
+``splitter.split_into_candidate_blocks`` segments the normalized text using a
+set of heuristics:
+
+1. paragraphs are split on double new lines;
+2. numbered or alphabetical list items and headings start new blocks;
+3. very long paragraphs are further divided into sentences;
+4. short blocks and adjacent headings may be merged;
+5. lines that break a sentence mid‑way are merged back together.
+
+The resulting spans are non‑overlapping and aim to cover at least 99.5% of the
+non‑whitespace characters in the normalized text.

--- a/contract_review_app/intake/parser.py
+++ b/contract_review_app/intake/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from hashlib import sha256
 from typing import Dict, List, Optional, Tuple, cast
 
 from contract_review_app.intake.normalization import normalize_text
@@ -8,10 +9,24 @@ from contract_review_app.intake.langseg import segment_lang_script
 
 @dataclass(frozen=True)
 class ParsedDocument:
+    """Normalized view of the input document with positional mapping.
+
+    Attributes:
+        content: Raw text as supplied by the caller.
+        normalized_text: Result after ``normalize_text``.
+        offset_map: ``offset_map[i]`` gives index in ``content`` for
+            ``normalized_text[i]``.  The map is strictly increasing.
+        segments: Language/script segments covering the normalized text.
+        checksum_sha256: SHA256 hex digest of the original ``content``.
+        doc_uid: Stable identifier computed from ``normalized_text``.
+    """
+
     content: str
     normalized_text: str
     offset_map: List[int]
     segments: List[Dict[str, object]]
+    checksum_sha256: str
+    doc_uid: str
 
     @classmethod
     def from_text(cls, raw: str) -> "ParsedDocument":
@@ -19,7 +34,16 @@ class ParsedDocument:
             raw = ""
         norm, omap = normalize_text(raw)
         segs = segment_lang_script(norm)
-        doc = cls(content=raw, normalized_text=norm, offset_map=omap, segments=segs)
+        checksum = sha256(raw.encode("utf-8")).hexdigest()
+        doc_uid = sha256(norm.encode("utf-8")).hexdigest()
+        doc = cls(
+            content=raw,
+            normalized_text=norm,
+            offset_map=omap,
+            segments=segs,
+            checksum_sha256=checksum,
+            doc_uid=doc_uid,
+        )
         doc._assert_invariants()
         return doc
 
@@ -44,13 +68,25 @@ class ParsedDocument:
     def _assert_invariants(self) -> None:
         om = self.offset_map
         nt = self.normalized_text
+        n_raw = len(self.content)
         assert len(om) == len(nt), "offset_map length must equal normalized_text length"
         prev = -1
-        n_raw = len(self.content)
         for j, r in enumerate(om):
             assert 0 <= r < n_raw, f"raw index out of bounds at normalized {j}: {r}"
-            assert r >= prev, f"offset_map must be non-decreasing at {j}: {r} < {prev}"
+            assert (
+                r > prev
+            ), f"offset_map must be strictly increasing at {j}: {r} <= {prev}"
             prev = r
+
+        # sanity check single-char span mapping
+        for i in range(len(nt)):
+            span = self.map_norm_span_to_raw(i, i + 1)
+            assert span is not None, f"failed to map char at {i}"
+            a, b = span
+            assert 0 <= a < b <= n_raw, f"invalid raw span {span} for norm {i}:{i+1}"
+
+        assert len(self.checksum_sha256) == 64
+        assert len(self.doc_uid) == 64
         if len(nt) == 0:
             assert self.segments == [] or all(
                 s.get("start", 0) == 0 and s.get("end", 0) == 0 for s in self.segments

--- a/tests/fixtures/intake_fancy.txt
+++ b/tests/fixtures/intake_fancy.txt
@@ -1,0 +1,4 @@
+“Quoted text”—with non-breaking spaces and a zero-width joiner A‍B.
+Another line to provide length and ensure mapping works across lines.
+
+And CRLF.

--- a/tests/fixtures/intake_mixed.txt
+++ b/tests/fixtures/intake_mixed.txt
@@ -1,0 +1,2 @@
+Hello Привіт
+This line mixes English and українська.

--- a/tests/fixtures/intake_simple.txt
+++ b/tests/fixtures/intake_simple.txt
@@ -1,0 +1,2 @@
+Hello world.
+This is a test document.

--- a/tests/intake/test_map_norm_to_raw.py
+++ b/tests/intake/test_map_norm_to_raw.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import random
+from contract_review_app.intake.parser import ParsedDocument
+from contract_review_app.intake.normalization import normalize_text
+
+
+def test_map_norm_span_to_raw_roundtrip() -> None:
+    raw = Path("tests/fixtures/intake_fancy.txt").read_text(encoding="utf-8")
+    doc = ParsedDocument.from_text(raw)
+    nt = doc.normalized_text
+    rnd = random.Random(12345)
+    if len(nt) <= 1:
+        return
+    for _ in range(50):
+        a = rnd.randrange(0, len(nt) - 1)
+        b = rnd.randrange(a + 1, len(nt) + 1)
+        span = doc.map_norm_span_to_raw(a, b)
+        assert span is not None
+        s, e = span
+        assert 0 <= s < e <= len(doc.content)
+        piece = doc.content[s:e]
+        assert piece
+        norm_piece, _ = normalize_text(piece)
+        assert norm_piece == nt[a:b]

--- a/tests/intake/test_offsets_invariants.py
+++ b/tests/intake/test_offsets_invariants.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import pytest
+from contract_review_app.intake.parser import ParsedDocument
+
+FIXTURES = [
+    "tests/fixtures/intake_simple.txt",
+    "tests/fixtures/intake_mixed.txt",
+    "tests/fixtures/intake_fancy.txt",
+]
+
+
+@pytest.mark.parametrize("fname", FIXTURES)
+def test_span_invariants(fname: str) -> None:
+    raw = Path(fname).read_text(encoding="utf-8")
+    doc = ParsedDocument.from_text(raw)
+
+    assert all(
+        0 <= doc.offset_map[i] < len(doc.content)
+        and doc.offset_map[i] < doc.offset_map[i + 1]
+        for i in range(len(doc.offset_map) - 1)
+    )
+
+    spans = [(int(s["start"]), int(s["end"])) for s in doc.segments]
+    spans.sort()
+    prev_end = 0
+    for start, end in spans:
+        assert prev_end <= start
+        assert start < end
+        prev_end = end
+
+    nt = doc.normalized_text
+    total = sum(1 for ch in nt if not ch.isspace())
+    covered = 0
+    for start, end in spans:
+        covered += sum(1 for ch in nt[start:end] if not ch.isspace())
+    if total:
+        assert covered / total >= 0.995


### PR DESCRIPTION
## Summary
- extend `ParsedDocument` with SHA256 checksum fields and stricter invariants for offset mapping
- document normalization and splitting heuristics for intake
- add tests ensuring segment spans are monotonic and nearly cover the text
- fuzz test mapping between normalized and raw spans

## Testing
- `pytest -q tests/intake/test_offsets_invariants.py`
- `pytest -q tests/intake/test_map_norm_to_raw.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc487aeea88325ae4680f8bfbb7784