### PR TITLE
B2-01 fix: parser v1 + runtime fixtures (no binary in repo), reuse intake offsets; tests green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ Thumbs.db
 
 # Local environment
 .env
+
+# Test fixtures
+tests/analysis/*.docx
+tests/analysis/*.pdf

--- a/contract_review_app/analysis/parser.py
+++ b/contract_review_app/analysis/parser.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass
+from typing import Dict, List
+
+from docx import Document
+from pdfminer.high_level import extract_text
+
+from contract_review_app.intake.parser import ParsedDocument as IntakeParsedDocument
+
+
+@dataclass
+class ParsedDoc:
+    normalized_text: str
+    offset_map: List[int]
+    segments: List[Dict[str, object]]
+
+
+_HEADING_RE = re.compile(r"^[A-Z0-9 .\-]{6,}$")
+_NUMBERING_RE = re.compile(r"^(?P<num>\d+(?:\.\d+)*)(?:\.)?\s+")
+_SUBPOINT_RE = re.compile(r"^\(?([a-z]|[ivxlcdm]+|\d+)\)", re.IGNORECASE)
+
+
+def _segment_lines(text: str) -> List[Dict[str, object]]:
+    segments: List[Dict[str, object]] = []
+    pos = 0
+    lines = text.split("\n")
+    for line in lines:
+        start = pos
+        end = start + len(line)
+        pos = end + 1
+
+        if line == "":
+            continue
+
+        kind = "paragraph"
+        number = None
+        heading_text = None
+
+        m_num = _NUMBERING_RE.match(line)
+        if _HEADING_RE.match(line) or m_num:
+            kind = "heading"
+            if m_num:
+                number = m_num.group("num")
+            heading_text = line
+        else:
+            m = _SUBPOINT_RE.match(line)
+            if m:
+                number = m.group(1)
+
+        segments.append(
+            {
+                "id": len(segments) + 1,
+                "kind": kind,
+                "start": start,
+                "end": end,
+                "text": line,
+                "heading": heading_text,
+                "number": number,
+                "parent_id": None,
+            }
+        )
+    return segments
+
+
+def parse_text(text: str) -> ParsedDoc:
+    intake_doc = IntakeParsedDocument.from_text(text)
+    segments = _segment_lines(intake_doc.normalized_text)
+    return ParsedDoc(
+        normalized_text=intake_doc.normalized_text,
+        offset_map=intake_doc.offset_map,
+        segments=segments,
+    )
+
+
+def parse_docx(data: bytes) -> ParsedDoc:
+    document = Document(io.BytesIO(data))
+    text = "\n".join(p.text for p in document.paragraphs)
+    return parse_text(text)
+
+
+def parse_pdf(data: bytes) -> ParsedDoc:
+    text = extract_text(io.BytesIO(data)) or ""
+    return parse_text(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ include-package-data = true
 [tool.setuptools.packages.find]
 where = ["."]
 
+[project.optional-dependencies]
+test = ["python-docx", "pdfminer.six", "fpdf2"]
+

--- a/tests/analysis/test_parser_docx_pdf.py
+++ b/tests/analysis/test_parser_docx_pdf.py
@@ -1,0 +1,40 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+from docx import Document
+from fpdf import FPDF
+
+from contract_review_app.analysis.parser import parse_docx, parse_pdf
+
+
+def test_parse_docx(tmp_path: Path):
+    doc = Document()
+    doc.add_heading("HEADING ONE", level=1)
+    for i in range(1, 7):
+        doc.add_paragraph(f"{i}. Item {i}")
+    doc.add_paragraph("Regular paragraph.")
+    file_path = tmp_path / "sample.docx"
+    doc.save(file_path)
+    data = file_path.read_bytes()
+    parsed = parse_docx(data)
+    assert len(parsed.normalized_text) > 0
+    assert len(parsed.segments) >= 8
+    for seg in parsed.segments:
+        assert 0 <= seg["start"] < seg["end"] <= len(parsed.normalized_text)
+    assert any(seg["kind"] == "heading" and seg.get("number") for seg in parsed.segments)
+
+
+def test_parse_pdf(tmp_path: Path):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.multi_cell(0, 10, "First line\nSecond line\nThird line")
+    file_path = tmp_path / "sample.pdf"
+    pdf.output(str(file_path))
+    data = file_path.read_bytes()
+    parsed = parse_pdf(data)
+    assert len(parsed.normalized_text) > 0
+    assert len(parsed.segments) >= 3
+    for seg in parsed.segments:
+        assert 0 <= seg["start"] < seg["end"] <= len(parsed.normalized_text)


### PR DESCRIPTION
## Summary
- add analysis parser wrapping intake normalization for text, DOCX, and PDF with heading detection
- generate DOCX/PDF fixtures at test runtime and ignore committed binaries
- include test dependencies for document parsing

## Testing
- `pip install python-docx pdfminer.six fpdf2`
- `pip install fastapi`
- `pip install httpx`
- `pip install numpy`
- `pytest -q tests/analysis/test_parser_docx_pdf.py`
- `pytest -q tests/panel/test_anchor_sentence_scope.py`
- `echo 'OK: B2-01 green'`

## Example
```python
[{'id': 1, 'kind': 'heading', 'start': 0, 'end': 7, 'text': 'HEADING', 'heading': 'HEADING', 'number': None, 'parent_id': None}, {'id': 2, 'kind': 'heading', 'start': 8, 'end': 21, 'text': '1. First item', 'heading': '1. First item', 'number': '1', 'parent_id': None}, {'id': 3, 'kind': 'paragraph', 'start': 22, 'end': 32, 'text': 'a) subitem', 'heading': None, 'number': 'a', 'parent_id': None}]
```

------
https://chatgpt.com/codex/tasks/task_e_68bc5669d1e8832593336da412e4497b