### PR TITLE
Add segment classifier and UK legal rule set

### DIFF
--- a/contract_review_app/analysis/classifier.py
+++ b/contract_review_app/analysis/classifier.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+from contract_review_app.legal_rules import loader
+
+# Mapping of clause types to regex patterns used for detection.
+# Patterns are searched in both heading and text of a segment.
+_CLAUSE_PATTERNS: Dict[str, List[re.Pattern[str]]] = {
+    "governing_law": [
+        re.compile(r"governing\s+law", re.I),
+        re.compile(r"choice\s+of\s+law", re.I),
+    ],
+    "confidentiality": [
+        re.compile(r"confidential", re.I),
+        re.compile(r"non[-\s]?disclosure", re.I),
+    ],
+    "limitation_of_liability": [
+        re.compile(r"limitation\s+of\s+liabilit", re.I),
+        re.compile(r"limit[^\n]{0,40}liabilit", re.I),
+        re.compile(r"liabilit", re.I),
+    ],
+    "intellectual_property": [
+        re.compile(r"intellectual\s+property", re.I),
+        re.compile(r"\bipr\b", re.I),
+    ],
+    "data_protection": [
+        re.compile(r"data\s+protection", re.I),
+        re.compile(r"\bgdpr\b", re.I),
+        re.compile(r"personal\s+data", re.I),
+    ],
+    "dispute_resolution": [
+        re.compile(r"dispute\s+resolution", re.I),
+        re.compile(r"jurisdiction", re.I),
+        re.compile(r"arbitration", re.I),
+        re.compile(r"courts?", re.I),
+    ],
+    "definitions": [
+        re.compile(r"definitions", re.I),
+        re.compile(r"interpretation", re.I),
+    ],
+    "parties": [
+        re.compile(r"parties", re.I),
+    ],
+}
+
+
+def _detect_clause(text: str) -> str | None:
+    """Return clause_type inferred from *text* or ``None``."""
+    for ctype, pats in _CLAUSE_PATTERNS.items():
+        for pat in pats:
+            if pat.search(text):
+                return ctype
+    return None
+
+
+def classify_segments(segments: List[Dict]) -> None:
+    """Enrich *segments* in-place with ``clause_type`` and rule findings.
+
+    For each segment a ``clause_type`` is inferred from its heading/text.  If a
+    type is determined, deterministic YAML rules are executed against the
+    segment's text and any matching findings are stored under ``findings``.
+    """
+
+    for seg in segments:
+        heading = seg.get("heading") or ""
+        text = seg.get("text") or ""
+        combined = f"{heading} {text}".lower()
+
+        clause_type = _detect_clause(combined)
+        seg["clause_type"] = clause_type
+
+        if not clause_type:
+            continue
+
+        # Execute deterministic rules and retain only those matching this clause
+        # type.  The loader returns findings already structured with ``scope``
+        # and ``occurrences`` fields, which we keep untouched.
+        findings = loader.match_text(text)
+        seg["findings"] = [
+            f for f in findings if f.get("clause_type") == clause_type
+        ]

--- a/core/rules/uk/definitions/16_outdated_companies_act_1985.yaml
+++ b/core/rules/uk/definitions/16_outdated_companies_act_1985.yaml
@@ -1,0 +1,9 @@
+rule:
+  id: uk_ca_1985_outdated
+  clause_type: definitions
+  severity: medium
+  patterns:
+    - "(?i)companies act 1985"
+  advice: "Replace reference with Companies Act 2006."
+  law_refs:
+    - "Companies Act 2006 ss.1159, 1161"

--- a/core/rules/uk/definitions/17_bribery_act_missing.yaml
+++ b/core/rules/uk/definitions/17_bribery_act_missing.yaml
@@ -1,0 +1,8 @@
+rule:
+  id: uk_bribery_act_missing
+  clause_type: definitions
+  severity: medium
+  patterns:
+    - '(?is)^(?!.*(bribery act|anti-?bribery)).*bribery'
+  advice: 'Reference the UK Bribery Act 2010 or anti-bribery obligations.'
+  law_refs: []

--- a/core/rules/uk/interpretation/18_gl_jurisdiction_conflict.yaml
+++ b/core/rules/uk/interpretation/18_gl_jurisdiction_conflict.yaml
@@ -1,0 +1,8 @@
+rule:
+  id: gl_jurisdiction_conflict
+  clause_type: governing_law
+  severity: medium
+  patterns:
+    - "(?is)(?=.*laws? of england and wales)(?=.*scottish courts?).+"
+  advice: "Avoid conflict between English law and Scottish courts."
+  law_refs: []

--- a/core/rules/uk/personnel/13_outdated_dpa_1998.yaml
+++ b/core/rules/uk/personnel/13_outdated_dpa_1998.yaml
@@ -1,0 +1,8 @@
+rule:
+  id: uk_dpa_1998_outdated
+  clause_type: data_protection
+  severity: medium
+  patterns:
+    - "(?i)data protection act 1998"
+  advice: "Update to Data Protection Act 2018 or UK GDPR."
+  law_refs: []

--- a/core/rules/uk/section3/18_confidentiality_poca_tipping_off_carveout.yaml
+++ b/core/rules/uk/section3/18_confidentiality_poca_tipping_off_carveout.yaml
@@ -1,0 +1,9 @@
+rule:
+  id: uk_poca_tipping_off
+  clause_type: confidentiality
+  severity: high
+  patterns:
+    - "(?is)confidential.*disclos(?!.*(law|regulator))"
+  advice: "Include carve-out for disclosures required by law or by a regulator."
+  law_refs:
+    - "POCA 2002 s.333A"

--- a/core/rules/uk/section3/19_liability_fraud_exclusion_invalid.yaml
+++ b/core/rules/uk/section3/19_liability_fraud_exclusion_invalid.yaml
@@ -1,0 +1,9 @@
+rule:
+  id: uk_fraud_exclusion_invalid
+  clause_type: limitation_of_liability
+  severity: high
+  patterns:
+    - '(?is)(?:exclude|limit)[^.]{0,80}fraud'
+    - '(?is)(?:exclude|limit)[^.]{0,80}fraudulent\s+misrepresentation'
+  advice: 'Liability for fraud or fraudulent misrepresentation cannot be excluded.'
+  law_refs: []

--- a/core/rules/uk/section3/20_liability_ucta_2_1_invalid.yaml
+++ b/core/rules/uk/section3/20_liability_ucta_2_1_invalid.yaml
@@ -1,0 +1,9 @@
+rule:
+  id: uk_ucta_2_1_invalid
+  clause_type: limitation_of_liability
+  severity: high
+  patterns:
+    - '(?is)(?:exclude(?:s)?\s+liability|not\s+be\s+liable)[^.]{0,80}(?:death|personal injury)[^.]{0,80}negligence'
+  advice: 'Liability for death or personal injury caused by negligence cannot be excluded.'
+  law_refs:
+    - 'UCTA 1977 s.2(1)'

--- a/tests/analysis/test_classifier_basic.py
+++ b/tests/analysis/test_classifier_basic.py
@@ -1,0 +1,13 @@
+from contract_review_app.analysis.classifier import classify_segments
+
+
+def test_classifier_basic():
+    segments = [
+        {"heading": "GOVERNING LAW", "text": "This agreement is governed by the laws of England and Wales."},
+        {"heading": "", "text": "Each party shall keep the confidential information secret."},
+        {"heading": "Data Protection", "text": "Supplier complies with Data Protection Act 1998."},
+    ]
+    classify_segments(segments)
+    assert segments[0]["clause_type"] == "governing_law"
+    assert segments[1]["clause_type"] == "confidentiality"
+    assert segments[2]["clause_type"] == "data_protection"

--- a/tests/rules/test_gl_jurisdiction_conflict.py
+++ b/tests/rules/test_gl_jurisdiction_conflict.py
@@ -1,0 +1,10 @@
+from contract_review_app.legal_rules import loader
+
+
+def test_gl_jurisdiction_conflict():
+    text = (
+        "This Agreement is governed by the laws of England and Wales and the parties submit to the exclusive jurisdiction of the Scottish courts."
+    )
+    loader.load_rule_packs()
+    findings = loader.match_text(text)
+    assert any(f["rule_id"] == "gl_jurisdiction_conflict" for f in findings)

--- a/tests/rules/uk/test_bribery_missing.py
+++ b/tests/rules/uk/test_bribery_missing.py
@@ -1,0 +1,17 @@
+from contract_review_app.legal_rules import loader
+
+
+def _hit(text: str) -> bool:
+    loader.load_rule_packs()
+    findings = loader.match_text(text)
+    return any(f["rule_id"] == "uk_bribery_act_missing" for f in findings)
+
+
+def test_bribery_act_missing_detected():
+    text = "Bribery is strictly prohibited and each party shall maintain policies."
+    assert _hit(text)
+
+
+def test_bribery_act_present_not_detected():
+    text = "The parties shall comply with the UK Bribery Act 2010 and maintain anti-bribery policies."
+    assert not _hit(text)

--- a/tests/rules/uk/test_outdated_laws.py
+++ b/tests/rules/uk/test_outdated_laws.py
@@ -1,0 +1,15 @@
+from contract_review_app.legal_rules import loader
+
+
+def _hit(rule_id: str, text: str) -> bool:
+    loader.load_rule_packs()
+    findings = loader.match_text(text)
+    return any(f["rule_id"] == rule_id for f in findings)
+
+
+def test_companies_act_1985_flag():
+    assert _hit("uk_ca_1985_outdated", "Reference is made to the Companies Act 1985.")
+
+
+def test_dpa_1998_flag():
+    assert _hit("uk_dpa_1998_outdated", "The Supplier complies with the Data Protection Act 1998.")

--- a/tests/rules/uk/test_poca_tipping_off.py
+++ b/tests/rules/uk/test_poca_tipping_off.py
@@ -1,0 +1,19 @@
+from contract_review_app.legal_rules import loader
+
+
+def _hit(text: str) -> bool:
+    loader.load_rule_packs()
+    findings = loader.match_text(text)
+    return any(f["rule_id"] == "uk_poca_tipping_off" for f in findings)
+
+
+def test_poca_tipping_off_detects_missing_carveout():
+    text = "The Parties shall keep all information confidential and shall not disclose it to any person."
+    assert _hit(text)
+
+
+def test_poca_tipping_off_not_triggered_with_carveout():
+    text = (
+        "The Parties shall keep all information confidential and shall not disclose it to any person except as required by law or by a regulator."
+    )
+    assert not _hit(text)

--- a/tests/rules/uk/test_ucta_2_1_invalid.py
+++ b/tests/rules/uk/test_ucta_2_1_invalid.py
@@ -1,0 +1,8 @@
+from contract_review_app.legal_rules import loader
+
+
+def test_ucta_2_1_invalid_triggers():
+    text = "The Supplier excludes liability for death or personal injury caused by negligence."
+    loader.load_rule_packs()
+    findings = loader.match_text(text)
+    assert any(f["rule_id"] == "uk_ucta_2_1_invalid" for f in findings)


### PR DESCRIPTION
## Summary
- classify document segments by heading keywords and run deterministic rules
- add UK compliance rules for confidentiality carve-outs, liability, outdated laws, bribery and jurisdiction conflicts
- test classifier and new rules

## Testing
- `pytest -q tests/analysis/test_classifier_basic.py`
- `pytest -q tests/rules/uk/test_poca_tipping_off.py`
- `pytest -q tests/rules/uk/test_ucta_2_1_invalid.py`
- `pytest -q tests/rules/uk/test_outdated_laws.py`
- `pytest -q tests/rules/uk/test_bribery_missing.py`
- `pytest -q tests/rules/test_gl_jurisdiction_conflict.py`
- `pytest -q tests/panel/test_aggregation_dedup.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc5786f83c8325af1856d977a6e337