### PR TITLE
Add citation presets and resolver keys

### DIFF
--- a/contract_review_app/core/citation_resolver.py
+++ b/contract_review_app/core/citation_resolver.py
@@ -36,47 +36,84 @@ _OGUK_MODEL_AGREEMENT = Citation(
     evidence_text="Standard industry terms for offshore oil and gas contracts.",
 )
 
+# Additional citation presets
+_UK_GDPR_ART_28 = Citation(
+    system="UK",
+    instrument="UK GDPR",
+    section="Art. 28",
+    title="Processor",
+    source="ICO",
+)
+
+_POCA_2002_S333A = Citation(
+    system="UK",
+    instrument="POCA 2002",
+    section="s.333A",
+    title="Proceeds of Crime Act 2002",
+    source="UK legislation",
+)
+
+_UCTA_1977_S2_1 = Citation(
+    system="UK",
+    instrument="UCTA 1977",
+    section="s.2(1)",
+    title="Unfair Contract Terms Act 1977",
+    source="UK legislation",
+)
+
+_CA_2006_S1159 = Citation(
+    system="UK",
+    instrument="Companies Act 2006",
+    section="s.1159",
+    title="Companies Act 2006",
+    source="UK legislation",
+)
+
+_CA_2006_S1161 = Citation(
+    system="UK",
+    instrument="Companies Act 2006",
+    section="s.1161",
+    title="Companies Act 2006",
+    source="UK legislation",
+)
+
+_DPA_2018_PART2 = Citation(
+    system="UK",
+    instrument="DPA 2018",
+    section="Part 2",
+    title="Data Protection Act 2018",
+    source="UK legislation",
+)
+
+_BRIBERY_ACT_2010_S7 = Citation(
+    system="UK",
+    instrument="Bribery Act 2010",
+    section="s.7",
+    title="Bribery Act 2010",
+    source="UK legislation",
+)
+
 _OIL_GAS_RE = re.compile(r"\boil\b|\bgas\b", re.IGNORECASE)
 
 # lightweight fallback map for keyword search
 _KEYWORD_MAP = {
-    "gdpr": _UK_GDPR_ART_28_3,
+    # general GDPR reference
+    "gdpr": _UK_GDPR_ART_28,
+    "uk gdpr": _UK_GDPR_ART_28,
+    # other instruments
+    "poca": _POCA_2002_S333A,
+    "tipping": _POCA_2002_S333A,
+    "ucta": _UCTA_1977_S2_1,
+    "companies act": _CA_2006_S1159,
+    "dpa": _DPA_2018_PART2,
+    "bribery": _BRIBERY_ACT_2010_S7,
     "oguk": _OGUK_MODEL_AGREEMENT,
     "oil": _OGUK_MODEL_AGREEMENT,
     "gas": _OGUK_MODEL_AGREEMENT,
 }
 
-# explicit rule/code mappings
-_RULE_MAP = {
-    "poca": Citation(
-        system="UK",
-        instrument="POCA 2002",
-        section="s.327",
-        title="Proceeds of Crime Act 2002",
-        source="UK legislation",
-    ),
-    "ucta": Citation(
-        system="UK",
-        instrument="UCTA 1977",
-        section="s.2",
-        title="Unfair Contract Terms Act 1977",
-        source="UK legislation",
-    ),
-    "companiesact": Citation(
-        system="UK",
-        instrument="Companies Act 2006",
-        section="s.172",
-        title="Companies Act 2006",
-        source="UK legislation",
-    ),
-    "ukgdpr": Citation(
-        system="UK",
-        instrument="UK GDPR",
-        section="Art. 5",
-        title="UK General Data Protection Regulation",
-        source="ICO",
-    ),
-}
+# explicit rule/code mappings (kept for future use; currently empty)
+_RULE_MAP: dict[str, Citation] = {}
 
 
 def resolve_citation(finding: Finding) -> Optional[Citation]:
@@ -108,6 +145,87 @@ def resolve_citation(finding: Finding) -> Optional[Citation]:
 
         if _OIL_GAS_RE.search(message) or "oguk" in message or "oguk" in code:
             citation = deepcopy(_OGUK_MODEL_AGREEMENT)
+            logger.info(
+                "resolve_citation cid=%s rule=%s",
+                f"{citation.instrument} {citation.section}",
+                rule,
+            )
+            return citation
+
+        # UK acts/regs
+        if (
+            "poca" in message
+            or "poca" in code
+            or "poca" in rule
+            or "tipping" in message
+            or "tipping" in code
+            or "tipping" in rule
+        ):
+            citation = deepcopy(_POCA_2002_S333A)
+            logger.info(
+                "resolve_citation cid=%s rule=%s",
+                f"{citation.instrument} {citation.section}",
+                rule,
+            )
+            return citation
+
+        if "ucta" in message or "ucta" in code or "ucta" in rule:
+            citation = deepcopy(_UCTA_1977_S2_1)
+            logger.info(
+                "resolve_citation cid=%s rule=%s",
+                f"{citation.instrument} {citation.section}",
+                rule,
+            )
+            return citation
+
+        if (
+            "companies act" in message
+            or "companies act" in rule
+            or "companiesact" in code
+            or "companiesact" in rule
+            or ("ca" in code and ("1159" in code or "1161" in code))
+            or ("ca" in rule and ("1159" in rule or "1161" in rule))
+        ):
+            if "1161" in message or "1161" in code or "1161" in rule:
+                citation = deepcopy(_CA_2006_S1161)
+            elif "1159" in message or "1159" in code or "1159" in rule:
+                citation = deepcopy(_CA_2006_S1159)
+            else:
+                citation = deepcopy(_CA_2006_S1159)
+            logger.info(
+                "resolve_citation cid=%s rule=%s",
+                f"{citation.instrument} {citation.section}",
+                rule,
+            )
+            return citation
+
+        if "dpa" in message or "dpa" in code or "dpa" in rule:
+            citation = deepcopy(_DPA_2018_PART2)
+            logger.info(
+                "resolve_citation cid=%s rule=%s",
+                f"{citation.instrument} {citation.section}",
+                rule,
+            )
+            return citation
+
+        if (
+            "uk gdpr" in message
+            or "uk gdpr" in code
+            or "uk gdpr" in rule
+            or "gdpr" in message
+            or "gdpr" in code
+            or "gdpr" in rule
+        ):
+            citation = deepcopy(_UK_GDPR_ART_28)
+            logger.info(
+                "resolve_citation cid=%s rule=%s",
+                f"{citation.instrument} {citation.section}",
+                rule,
+            )
+            return citation
+
+        if "bribery" in message or "bribery" in code or "bribery" in rule:
+            citation = deepcopy(_BRIBERY_ACT_2010_S7)
             logger.info(
                 "resolve_citation cid=%s rule=%s",
                 f"{citation.instrument} {citation.section}",

--- a/data/corpus_demo/bribery_act_2010_s7.yaml
+++ b/data/corpus_demo/bribery_act_2010_s7.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "UKBA_2010"
+    act_title: "Bribery Act 2010"
+    section_code: "s.7"
+    section_title: "Failure of commercial organisations to prevent bribery"
+    version: "2020-01"
+    updated_at: "2020-01-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/2010/23/section/7"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      A commercial organisation can be guilty of an offence if it fails to prevent bribery.

--- a/data/corpus_demo/companies_act_2006_s1159.yaml
+++ b/data/corpus_demo/companies_act_2006_s1159.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "CA_2006"
+    act_title: "Companies Act 2006"
+    section_code: "s.1159"
+    section_title: "Meaning of 'subsidiary'"
+    version: "2020-01"
+    updated_at: "2020-01-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/2006/46/section/1159"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      Defines when a company is a subsidiary of another company.

--- a/data/corpus_demo/companies_act_2006_s1161.yaml
+++ b/data/corpus_demo/companies_act_2006_s1161.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "CA_2006"
+    act_title: "Companies Act 2006"
+    section_code: "s.1161"
+    section_title: "Meaning of 'subsidiary undertaking'"
+    version: "2020-01"
+    updated_at: "2020-01-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/2006/46/section/1161"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      Defines when an undertaking is a subsidiary undertaking.

--- a/data/corpus_demo/dpa_2018_part2.yaml
+++ b/data/corpus_demo/dpa_2018_part2.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "DPA_2018"
+    act_title: "Data Protection Act 2018"
+    section_code: "Part 2"
+    section_title: "General processing"
+    version: "2023-12"
+    updated_at: "2023-12-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/2018/12/part/2"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      Part 2 sets out the general processing regime for UK data protection law.

--- a/data/corpus_demo/poca_2002_s333a.yaml
+++ b/data/corpus_demo/poca_2002_s333a.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "POCA_2002"
+    act_title: "Proceeds of Crime Act 2002"
+    section_code: "s.333A"
+    section_title: "Tipping off"
+    version: "2020-01"
+    updated_at: "2020-01-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/2002/29/section/333A"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      It is an offence to disclose information likely to prejudice an investigation under POCA.

--- a/data/corpus_demo/ucta_1977_s2_1.yaml
+++ b/data/corpus_demo/ucta_1977_s2_1.yaml
@@ -1,0 +1,15 @@
+items:
+  - source: "legislation.gov.uk"
+    jurisdiction: "UK"
+    act_code: "UCTA_1977"
+    act_title: "Unfair Contract Terms Act 1977"
+    section_code: "s.2(1)"
+    section_title: "Negligence liability"
+    version: "2020-01"
+    updated_at: "2020-01-01T00:00:00Z"
+    url: "https://www.legislation.gov.uk/ukpga/1977/50/section/2"
+    rights: "Open Government Licence v3.0"
+    lang: "en"
+    script: "Latn"
+    text: |
+      A person cannot exclude or restrict liability for negligence resulting in death or personal injury.

--- a/tests/analysis/test_citation_resolver.py
+++ b/tests/analysis/test_citation_resolver.py
@@ -1,0 +1,29 @@
+import pytest
+from contract_review_app.core.citation_resolver import resolve_citation
+from contract_review_app.core.schemas import Finding, Span
+
+
+def _f(code: str = "", rule: str = "", message: str = "") -> Finding:
+    f = Finding(code=code, message=message, span=Span(start=0, length=1))
+    if rule:
+        object.__setattr__(f, "rule", rule)
+    return f
+
+
+@pytest.mark.parametrize(
+    "finding,instrument,section",
+    [
+        (_f(code="uk_poca_tipping_off"), "POCA 2002", "s.333A"),
+        (_f(rule="uk_ucta_liability"), "UCTA 1977", "s.2(1)"),
+        (_f(code="ca1159"), "Companies Act 2006", "s.1159"),
+        (_f(rule="ca1161"), "Companies Act 2006", "s.1161"),
+        (_f(code="dpa_demo"), "DPA 2018", "Part 2"),
+        (_f(code="gdpr_art_28"), "UK GDPR", "Art. 28"),
+        (_f(message="adequate procedures and bribery"), "Bribery Act 2010", "s.7"),
+    ],
+)
+def test_citation_resolver_new_presets(finding, instrument, section):
+    cit = resolve_citation(finding)
+    assert cit is not None
+    assert cit.instrument == instrument
+    assert cit.section == section

--- a/tests/pipeline/test_resolver_stub.py
+++ b/tests/pipeline/test_resolver_stub.py
@@ -8,10 +8,13 @@ def _f(code: str) -> Finding:
 
 def test_resolver_known_rules():
     cases = {
-        "POCA": ("POCA 2002", "s.327"),
-        "UCTA": ("UCTA 1977", "s.2"),
-        "CompaniesAct": ("Companies Act 2006", "s.172"),
-        "UKGDPR": ("UK GDPR", "Art. 5"),
+        "POCA": ("POCA 2002", "s.333A"),
+        "UCTA": ("UCTA 1977", "s.2(1)"),
+        "CompaniesAct": ("Companies Act 2006", "s.1159"),
+        "CA1161": ("Companies Act 2006", "s.1161"),
+        "UKGDPR": ("UK GDPR", "Art. 28"),
+        "DPA": ("DPA 2018", "Part 2"),
+        "Bribery": ("Bribery Act 2010", "s.7"),
     }
     for code, (instrument, section) in cases.items():
         cit = resolve_citation(_f(code))


### PR DESCRIPTION
## Summary
- expand citation presets for UK acts including POCA s.333A, UCTA s.2(1), Companies Act s.1159/1161, DPA 2018 Part 2, UK GDPR Art.28 and Bribery Act s.7
- map new keywords and strong rule detection to these instruments in the citation resolver
- include demo corpus snippets and tests for new citations

## Testing
- `pytest -q tests/analysis/test_citation_resolver.py`
- `pytest -q tests/pipeline/test_resolver_stub.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc59a8b7a483258a38d6747238e037