### PR TITLE
Implement parse→classify→rule pipeline for /api/analyze

### DIFF
--- a/contract_review_app/analysis/classifier.py
+++ b/contract_review_app/analysis/classifier.py
@@ -11,6 +11,7 @@ _CLAUSE_PATTERNS: Dict[str, List[re.Pattern[str]]] = {
     "governing_law": [
         re.compile(r"governing\s+law", re.I),
         re.compile(r"choice\s+of\s+law", re.I),
+        re.compile(r"governed\s+by\s+the\s+laws?", re.I),
     ],
     "confidentiality": [
         re.compile(r"confidential", re.I),

--- a/scripts/run_block2_tests.ps1
+++ b/scripts/run_block2_tests.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference="Stop"
+pytest -q tests\analysis\test_parser_docx_pdf.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL parser"; exit 1 }
+pytest -q tests\analysis\test_classifier_basic.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL classifier"; exit 1 }
+pytest -q tests\rules\uk\test_poca_tipping_off.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL poca"; exit 1 }
+pytest -q tests\rules\uk\test_ucta_2_1_invalid.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL ucta"; exit 1 }
+pytest -q tests\rules\uk\test_outdated_laws.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL outdated"; exit 1 }
+pytest -q tests\rules\uk\test_bribery_missing.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL bribery"; exit 1 }
+pytest -q tests\rules\test_gl_jurisdiction_conflict.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL gl/jurisdiction"; exit 1 }
+pytest -q tests\analysis\test_citation_resolver.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL citations"; exit 1 }
+pytest -q tests\panel\test_anchor_sentence_scope.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL anchor"; exit 1 }
+pytest -q tests\panel\test_aggregation_dedup.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL dedup"; exit 1 }
+pytest -q tests\rules\test_server_threshold.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL threshold"; exit 1 }
+pytest -q tests\panel\test_analyze_engine_pipeline.py; if ($LASTEXITCODE -ne 0) { Read-Host "FAIL pipeline"; exit 1 }
+Write-Host "OK: Block 2 ALL GREEN"; Read-Host "Press Enter to exit"

--- a/tests/fixtures/nda_mini.txt
+++ b/tests/fixtures/nda_mini.txt
@@ -1,0 +1,5 @@
+Definitions Bribery is strictly prohibited and each party shall maintain policies. Reference is made to the Companies Act 1985.
+Confidentiality The Parties shall keep all information confidential and shall not disclose it to any person.
+Data Protection The Supplier complies with the Data Protection Act 1998.
+Limitation of Liability The Supplier excludes liability for death or personal injury caused by negligence. The Supplier excludes any liability for fraud or fraudulent misrepresentation.
+Governing Law This Agreement is governed by the laws of England and Wales and the parties submit to the exclusive jurisdiction of the Scottish courts.

--- a/tests/panel/test_analyze_engine_pipeline.py
+++ b/tests/panel/test_analyze_engine_pipeline.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_analyze_engine_pipeline_returns_findings():
+    fixture = Path(__file__).resolve().parents[1] / "fixtures" / "nda_mini.txt"
+    text = fixture.read_text(encoding="utf-8")
+    r = client.post("/api/analyze", json={"text": text})
+    assert r.status_code == 200
+    findings = r.json()["analysis"]["findings"]
+    assert len(findings) >= 6


### PR DESCRIPTION
## Summary
- Wire full analysis pipeline in `/api/analyze` parsing text, classifying segments, running legal rules and resolving citations with risk filtering and feature flag for optional LLM hints
- Expand classifier to recognise clauses governed by laws phrased as "governed by the laws"
- Add integration test and fixture for mini‑NDA and convenience PowerShell script for block2 tests

## Testing
- `pytest -q tests/rules/test_server_threshold.py`
- `pytest -q tests/panel/test_anchor_sentence_scope.py`
- `pytest -q tests/panel/test_aggregation_dedup.py`
- `pytest -q tests/panel/test_analyze_engine_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc5b39f01c832590634b1e86d0ab2a