### PR TITLE
feat: enforce API key for write routes

### DIFF
--- a/scripts/run_block3_tests.ps1
+++ b/scripts/run_block3_tests.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference="Stop"
+pytest -q tests\panel\test_gpt_draft_payload.py;          if ($LASTEXITCODE -ne 0) { Read-Host "FAIL draft"; exit 1 }
+pytest -q tests\panel\test_suggest_ops_minimal.py;        if ($LASTEXITCODE -ne 0) { Read-Host "FAIL suggest"; exit 1 }
+pytest -q tests\panel\test_anchor_sentence_scope.py;      if ($LASTEXITCODE -ne 0) { Read-Host "FAIL anchor"; exit 1 }
+pytest -q tests\panel\test_analyze_offsets.py;            if ($LASTEXITCODE -ne 0) { Read-Host "FAIL offsets"; exit 1 }
+pytest -q tests\security\test_privacy_redaction.py;       if ($LASTEXITCODE -ne 0) { Read-Host "FAIL privacy"; exit 1 }
+pytest -q tests\security\test_audit_log.py;               if ($LASTEXITCODE -ne 0) { Read-Host "FAIL audit"; exit 1 }
+pytest -q tests\security\test_api_key_auth.py;            if ($LASTEXITCODE -ne 0) { Read-Host "FAIL apikey"; exit 1 }
+pytest -q tests\panel\test_panel_flows.py;                if ($LASTEXITCODE -ne 0) { Read-Host "FAIL e2e"; exit 1 }
+Write-Host "OK: Block 3 ALL GREEN"; Read-Host "Press Enter to exit"

--- a/tests/panel/test_panel_flows.py
+++ b/tests/panel/test_panel_flows.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+
+client = TestClient(app)
+
+
+def _apply_ops(text: str, ops):
+    result = text
+    for op in sorted(ops, key=lambda o: o["start"], reverse=True):
+        result = result[: op["start"]] + op["replacement"] + result[op["end"] :]
+    return result
+
+
+def test_panel_end_to_end_flow():
+    # Step 1: analyze mini NDA
+    fixture = Path(__file__).resolve().parents[1] / "fixtures" / "nda_mini.txt"
+    text = fixture.read_text(encoding="utf-8")
+    r = client.post("/api/analyze", json={"text": text})
+    assert r.status_code == 200
+    findings = r.json()["analysis"]["findings"]
+    assert findings
+    norm_text = text.replace("\r\n", "\n").replace("\r", "\n")
+    valid = 0
+    for f in findings:
+        start = f["start"]
+        end = f["end"]
+        snippet = f["snippet"].replace("\r\n", "\n").replace("\r", "\n")
+        assert 0 <= start <= end <= len(norm_text)
+        if norm_text[start:end] == snippet:
+            valid += 1
+    assert valid >= 1
+
+    # Step 2: draft
+    payload = {"text": "Ping", "mode": "friendly", "before_text": "", "after_text": ""}
+    r = client.post("/api/gpt-draft", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("proposed_text", "").strip() != ""
+
+    # Step 3: suggest edits
+    original = "bad clause"
+    r = client.post("/api/suggest_edits", json={"text": original})
+    assert r.status_code == 200
+    sugg = r.json()
+    proposed = sugg.get("proposed_text", "")
+    ops = sugg.get("ops", [])
+    if proposed and proposed != original:
+        assert ops, "ops should describe edits"
+        patched = _apply_ops(original, ops)
+        assert patched == proposed

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,0 +1,37 @@
+import importlib
+from fastapi.testclient import TestClient
+
+
+def _get_client(monkeypatch):
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "secret")
+    import contract_review_app.api.app as app_module
+    importlib.reload(app_module)
+    return TestClient(app_module.app)
+
+
+def test_api_key_auth(monkeypatch):
+    client = _get_client(monkeypatch)
+    payload = {"text": "Hello"}
+
+    r = client.post("/api/analyze", json=payload)
+    assert r.status_code == 401
+    r = client.post("/api/gpt-draft", json={"text": "Ping", "mode": "friendly"})
+    assert r.status_code == 401
+    r = client.post("/api/suggest_edits", json=payload)
+    assert r.status_code == 401
+
+    headers = {"x-api-key": "secret"}
+    assert client.post("/api/analyze", json=payload, headers=headers).status_code == 200
+    assert (
+        client.post(
+            "/api/gpt-draft",
+            json={"text": "Ping", "mode": "friendly"},
+            headers=headers,
+        ).status_code
+        == 200
+    )
+    assert (
+        client.post("/api/suggest_edits", json=payload, headers=headers).status_code
+        == 200
+    )


### PR DESCRIPTION
## Summary
- gate write endpoints behind `x-api-key` when `FEATURE_REQUIRE_API_KEY` is enabled
- drive CORS allowlist from `ALLOWED_ORIGINS`
- add API key auth tests and panel e2e flow test

## Testing
- `pytest -q tests/security/test_api_key_auth.py`
- `pytest -q tests/panel/test_panel_flows.py`
- `pytest -q tests/panel/test_gpt_draft_payload.py tests/security/test_audit_log.py`
- `pytest -q tests/panel/test_suggest_ops_minimal.py tests/panel/test_anchor_sentence_scope.py tests/panel/test_analyze_offsets.py tests/security/test_privacy_redaction.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc685d47b88325b92804b859bf86c1