### PR TITLE
feat: add verification and alias for GPT draft

### DIFF
--- a/contract_review_app/core/schemas.py
+++ b/contract_review_app/core/schemas.py
@@ -1129,6 +1129,18 @@ class SuggestEdit(AppBaseModel):
     delete: Optional[str] = None
     rationale: str
     citations: List[Citation]
+    evidence: Optional[List[str]] = None
+    verification_status: Optional[
+        Literal["verified", "partially_verified", "unverified", "failed"]
+    ] = None
+    flags: Optional[List[str]] = None
+    operations: Optional[List[Literal["replace", "insertAfter", "comment"]]] = None
+
+    @model_validator(mode="after")
+    def _autofill_operations(self):
+        if self.operations is None and (self.insert is not None or self.delete is not None):
+            self.operations = ["replace"]
+        return self
 
 
 class SuggestResponse(AppBaseModel):

--- a/tests/api/test_gpt_draft_alias.py
+++ b/tests/api/test_gpt_draft_alias.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from contract_review_app.gpt.gpt_draft_api import router, SCHEMA_VERSION
+
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+def test_gpt_draft_alias_returns_same_response():
+    payload = {"analysis": {"text": "T", "citations": []}}
+    r1 = client.post("/api/gpt-draft", json=payload)
+    r2 = client.post("/api/gpt/draft", json=payload)
+    assert r1.status_code == r2.status_code == 200
+    assert r1.json() == r2.json()
+    assert r1.headers["x-schema-version"] == SCHEMA_VERSION == r2.headers["x-schema-version"]
+    assert r1.json()["schema"] == SCHEMA_VERSION

--- a/tests/llm/test_grounding_in_prompt.py
+++ b/tests/llm/test_grounding_in_prompt.py
@@ -1,0 +1,10 @@
+from contract_review_app.llm.citation_resolver import make_grounding_pack
+from contract_review_app.llm.prompt_builder import build_prompt
+
+
+def test_grounding_includes_evidence_block():
+    citations = [{"system": "UK", "instrument": "Act", "section": "1"}]
+    gp = make_grounding_pack("", "Context text", citations)
+    prompt = build_prompt(mode="friendly", grounding=gp)
+    assert "EVIDENCE:" in prompt
+    assert "[c1]" in prompt

--- a/tests/llm/test_verification_status_plumbed.py
+++ b/tests/llm/test_verification_status_plumbed.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from contract_review_app.llm.api_dto import LLMResponse
+from contract_review_app.llm.citation_resolver import make_grounding_pack
+from contract_review_app.llm.verification import verify_output_contains_citations
+from contract_review_app.gpt.gpt_draft_api import router as draft_router
+
+
+def test_verification_status_propagates_and_triggers_fallback():
+    gp = make_grounding_pack("", "Some clause", [{"instrument": "Act", "section": "1"}])
+    status = verify_output_contains_citations("no refs", gp["evidence"])
+    resp = LLMResponse(provider="test", model="m", result="r", prompt="p", verification_status=status)
+    assert resp.verification_status == "unverified"
+
+    app = FastAPI()
+    app.include_router(draft_router)
+    client = TestClient(app)
+    payload = {
+        "analysis": {
+            "clause_type": "Test",
+            "text": "Clause text",
+            "citations": [{"instrument": "Act", "section": "1"}],
+        }
+    }
+    r = client.post("/api/gpt/draft", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["verification_status"] == "unverified"
+    assert not data["draft_text"].startswith("UPDATED:")

--- a/tests/panel/test_suggest_edit_dto_v14.py
+++ b/tests/panel/test_suggest_edit_dto_v14.py
@@ -1,0 +1,46 @@
+import pytest
+from contract_review_app.core.schemas import SuggestEdit
+
+
+def test_suggest_edit_old_json_valid_and_auto_operations():
+    payload = {
+        "span": {"start": 0, "length": 5},
+        "insert": "new",
+        "delete": "old",
+        "rationale": "because",
+        "citations": [{"instrument": "Act", "section": "1"}],
+    }
+    se = SuggestEdit.model_validate(payload)
+    assert se.operations == ["replace"]
+    dumped = se.model_dump(exclude_none=True)
+    assert dumped["insert"] == "new"
+    assert dumped["delete"] == "old"
+
+
+def test_suggest_edit_new_fields_valid():
+    payload = {
+        "span": {"start": 1, "length": 2},
+        "insert": "b",
+        "rationale": "reason",
+        "citations": [],
+        "evidence": ["source"],
+        "verification_status": "verified",
+        "flags": ["f1"],
+        "operations": ["comment"],
+    }
+    se = SuggestEdit.model_validate(payload)
+    assert se.evidence == ["source"]
+    assert se.verification_status == "verified"
+    assert se.flags == ["f1"]
+    assert se.operations == ["comment"]
+
+
+def test_suggest_edit_auto_operations_on_insert_delete():
+    payload = {
+        "span": {"start": 0, "length": 1},
+        "delete": "x",
+        "rationale": "r",
+        "citations": [],
+    }
+    se = SuggestEdit.model_validate(payload)
+    assert se.operations == ["replace"]


### PR DESCRIPTION
## Summary
- extend SuggestEdit DTO with evidence, verification and operations fields
- integrate grounding and citation verification for GPT drafting
- expose /api/gpt/draft alias with schema header and verification_status

## Testing
- `python -m pytest tests/panel/test_suggest_edit_dto_v14.py tests/llm/test_grounding_in_prompt.py tests/llm/test_verification_status_plumbed.py tests/api/test_gpt_draft_alias.py contract_review_app/tests/api/test_gpt_draft_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd9aaf9f70832581cc277aadeeff98