### PR TITLE
Add IPR rulepack and tests

### DIFF
--- a/contract_review_app/legal_rules/policy_packs/ipr_core.yaml
+++ b/contract_review_app/legal_rules/policy_packs/ipr_core.yaml
@@ -1,0 +1,340 @@
+rule:
+  id: ipr.agreement_docs_title.company
+  version: 1.0.0
+  title: "Agreement Documentation title vests in Company"
+  law_reference:
+    - "Copyright assignment must be in writing (CDPA 1988 s.90)."
+  severity: low
+  triggers:
+    any:
+      - regex: "(?i)agreement documentation"
+  checks:
+    - id: title_vests_company
+      when:
+        regex: "(?i)(title|ownership).*agreement documentation.*(company)"
+      finding:
+        message: "Титул на Agreement Documentation закреплён за Company."
+        severity_level: low
+        risk: "Риск отсутствует: титул у Company."
+        suggestion:
+          text: "—"
+    - id: title_retained_contractor
+      when:
+        regex: '(?i)title.*(remain|retained).*contractor|assigned\s+later'
+      finding:
+        message: "Титул на Agreement Documentation сохраняется у Contractor или передаётся позднее."
+        severity_level: high
+        risk: "Company может не получить права на документацию."
+        suggestion:
+          text: "Закрепите немедленное переход права на документацию к Company."
+  outcome:
+    status: pass
+    risk_level: low
+    severity: low
+    problem: ""
+    recommendation: ""
+  metadata:
+    tags: ["ipr","documentation","title","company"]
+---
+rule:
+  id: ipr.fg.licence.scope
+  version: 1.0.0
+  title: "Foreground IPR licence to Company — broad grant"
+  law_reference:
+    - "Company must be able to modify and own modifications."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)foreground\s+(intellectual\s+property|ipr)'
+  checks:
+    - id: fg_full_scope
+      when:
+        all:
+          - regex: '(?i)worldwide'
+          - regex: '(?i)royalty-free'
+          - regex: '(?i)perpetual'
+          - regex: '(?i)irrevocable'
+          - regex: '(?i)transferable'
+          - regex: '(?i)sub-?licen(c|s)able'
+          - regex: '(?i)\bmodify\b'
+          - regex: '(?i)modifications?\s+shall\s+vest\s+in\s+company'
+      finding:
+        message: "Широкая лицензия FG IPR в пользу Company присутствует."
+        severity_level: low
+        risk: "—"
+        suggestion:
+          text: "—"
+    - id: fg_missing_scope
+      when:
+        any:
+          - not_regex: "(?i)worldwide"
+          - not_regex: '(?i)royalty-free'
+          - not_regex: "(?i)perpetual"
+          - not_regex: "(?i)irrevocable"
+          - not_regex: "(?i)transferable"
+          - not_regex: "(?i)sub-?licen(c|s)able"
+          - not_regex: '(?i)\bmodify\b'
+          - not_regex: '(?i)modifications?\s+shall\s+vest\s+in\s+company'
+      finding:
+        message: "Лицензия FG IPR не покрывает все ключевые права."
+        severity_level: high
+        risk: "Company может не получить полные права на FG IPR."
+        suggestion:
+          text: "Добавьте worldwide, royalty-free, perpetual, irrevocable, transferable, sublicensable, право modify и vesting of modifications."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "FG licence scope неполная."
+    recommendation: "Расширить лицензию FG IPR."
+  metadata:
+    tags: ["ipr","foreground","licence","scope"]
+---
+rule:
+  id: ipr.bg.licence.conflict
+  version: 1.0.0
+  title: "Background IPR licence — detect term conflict"
+  law_reference:
+    - "Consistency & enforceability of licence terms (UK contract law)."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)background\s+(intellectual\s+property|ipr)'
+  checks:
+    - id: bg_term_conflict
+      when:
+        all:
+          - regex: "(?i)perpetual|irrevocable"
+          - regex: '(?i)only\s+for\s+the\s+duration\s+of\s+the\s+(agreement|call-?off)'
+      finding:
+        message: "Конфликт срока BG-лицензии: perpetual/irrevocable vs only for the duration."
+        severity_level: high
+        risk: "Внутренняя противоречивость условий лицензии."
+        suggestion:
+          text: "Выбрать одну модель срока и убрать конфликт."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "BG licence term conflict."
+    recommendation: "Согласовать единую редакцию срока BG-лицензии."
+  metadata:
+    tags: ["ipr","background","licence","conflict","term"]
+---
+rule:
+  id: ipr.moral_rights.waiver
+  version: 1.0.0
+  title: "Moral rights — unconditional & irrevocable waivers"
+  law_reference:
+    - "CDPA 1988 s.87 allows waiver of moral rights."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)moral\s+rights'
+  checks:
+    - id: moral_rights_missing_waiver
+      when:
+        not_regex: '(?i)irrevocably\s+and\s+unconditionally\s+waive(s)?\s+all\s+moral\s+rights'
+      finding:
+        message: "Отсутствует безусловный отказ от моральных прав."
+        severity_level: high
+        risk: "Автор может препятствовать использованию произведения."
+        suggestion:
+          text: "Вставьте безусловный и безотзывный отказ от всех моральных прав."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "No moral rights waiver."
+    recommendation: "Добавить waiver от всех авторов/исполнителей."
+  metadata:
+    tags: ["ipr","moral rights","waiver"]
+---
+rule:
+  id: ipr.indemnity.remedies
+  version: 1.0.0
+  title: "IPR indemnity with procure/replace/modify remedies"
+  law_reference:
+    - "Indemnifying party must ensure equivalent performance with no extra cost."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)intellectual\s+property'
+      - regex: "(?i)ipr"
+  checks:
+    - id: indemnity_missing_conditions
+      when:
+        any:
+          - not_regex: "(?i)procure"
+          - not_regex: "(?i)replace"
+          - not_regex: "(?i)modify"
+          - not_regex: '(?i)equivalent\s+performance'
+          - not_regex: '(?i)no\s+additional\s+cost'
+          - not_regex: '(?i)no\s+adverse\s+impact'
+          - not_regex: '(?i)subject\s+to\s+(this|the)\s+agreement'
+      finding:
+        message: "Условия IPR indemnity/remedies неполные."
+        severity_level: high
+        risk: "Company может остаться без эквивалентного решения и понести расходы."
+        suggestion:
+          text: "Добавьте: procure licence, replace или modify с equivalent performance, без additional cost, без adverse impact и subject to this Agreement."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "IPR indemnity lacks full remedies."
+    recommendation: "Расширить перечень remedial условий."
+  metadata:
+    tags: ["ipr","indemnity","remedies"]
+---
+rule:
+  id: ipr.brand.use.prohibition
+  version: 1.0.0
+  title: "Brand use prohibition"
+  law_reference:
+    - "Trade mark use requires prior consent."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)company(?:''s)?\s+(name|logo|brand|trademark)'
+  checks:
+    - id: brand_use_allowed
+      when:
+        all:
+          - regex: '(?i)may\s+use.*company(?:''s)?\s+(name|logo|brand|trademark)'
+          - not_regex: '(?i)prior\s+written\s+consent'
+      finding:
+        message: "Разрешение на использование бренда Company дано по умолчанию."
+        severity_level: high
+        risk: "Нежелательное использование названия/логотипов Company."
+        suggestion:
+          text: "Запретите использование бренда без предварительного письменного согласия Company."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "Brand use allowed by default."
+    recommendation: "Добавить запрет на использование без письменного согласия."
+  metadata:
+    tags: ["ipr","brand","consent"]
+---
+rule:
+  id: ipr.supplied_software.definition
+  version: 1.0.0
+  title: "Supplied Software — comprehensive definition"
+  law_reference:
+    - "Software supply should cover all components."
+  severity: medium
+  triggers:
+    any:
+      - regex: '(?i)supplied\s+software'
+  checks:
+    - id: supplied_software_incomplete
+      when:
+        any:
+          - not_regex: '(?i)embedded\s+firmware'
+          - not_regex: '(?i)activation\s+keys'
+          - not_regex: '(?i)test\s+scripts'
+          - not_regex: "(?i)patches|updates"
+          - not_regex: "(?i)manuals"
+      finding:
+        message: "Определение Supplied Software неполное."
+        severity_level: medium
+        risk: "Часть компонентов может быть исключена."
+        suggestion:
+          text: "Уточните, что Supplied Software включает firmware, activation keys, test scripts, patches/updates и manuals."
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: medium
+    problem: "Definition of Supplied Software incomplete."
+    recommendation: "Добавить недостающие элементы."
+  metadata:
+    tags: ["ipr","software","definition"]
+---
+rule:
+  id: ipr.further_assurances.poa
+  version: 1.0.0
+  title: "Further assurances and irrevocable PoA"
+  law_reference:
+    - "Further assurances clauses secure assignment validity."
+  severity: medium
+  triggers:
+    any:
+      - regex: '(?i)intellectual\s+property|ipr'
+  checks:
+    - id: missing_further_assurances
+      when:
+        not_regex: '(?i)further\s+assurances|power\s+of\s+attorney'
+      finding:
+        message: "Отсутствует обязанность подписывать документы/PoA для оформления прав."
+        severity_level: medium
+        risk: "Компания может столкнуться с препятствиями при оформлении прав."
+        suggestion:
+          text: "Добавьте обязанность подписывать документы и безотзывный PoA на Company."
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: medium
+    problem: "No further assurances/PoA."
+    recommendation: "Вставить clause о further assurances и irrevocable PoA."
+  metadata:
+    tags: ["ipr","assurances","poa"]
+---
+rule:
+  id: ipr.oss.guardrails
+  version: 1.0.0
+  title: "Open-source guardrails (SBOM/copyleft)"
+  law_reference:
+    - "OSS components require policy compliance and SBOM."
+  severity: medium
+  triggers:
+    any:
+      - regex: "(?i)software"
+  checks:
+    - id: oss_missing_controls
+      when:
+        not_regex: '(?i)open\s*source|OSS|software\s+bill\s+of\s+materials|SBOM|copyleft'
+      finding:
+        message: "Отсутствуют OSS-политика/SBOM/запрет copyleft."
+        severity_level: medium
+        risk: "Возможны нарушения лицензий OSS и copyleft-заражение."
+        suggestion:
+          text: "Добавьте политику использования OSS, требование SBOM и запрет copyleft-заражения."
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: medium
+    problem: "No OSS guardrails."
+    recommendation: "Добавить требования по OSS и SBOM."
+  metadata:
+    tags: ["ipr","oss","sbom"]
+---
+rule:
+  id: ipr.source_code.escrow
+  version: 1.0.0
+  title: "Source code escrow for critical software"
+  law_reference:
+    - "Escrow ensures access if supplier fails."
+  severity: medium
+  triggers:
+    any:
+      - regex: '(?i)source\s+code'
+  checks:
+    - id: escrow_missing
+      when:
+        not_regex: "(?i)escrow"
+      finding:
+        message: "Отсутствует условие о депонировании исходного кода (escrow)."
+        severity_level: medium
+        risk: "Company рискует потерять доступ к критичному ПО."
+        suggestion:
+          text: "Предусмотрите escrow исходного кода с событиями release: банкротство, отказ поддерживать, нарушение."
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: medium
+    problem: "No source code escrow."
+    recommendation: "Добавить escrow с release events."
+  metadata:
+    tags: ["ipr","escrow","source code"]

--- a/core/rules/ipr/ipr_core.yaml
+++ b/core/rules/ipr/ipr_core.yaml
@@ -1,0 +1,340 @@
+rule:
+  id: ipr.agreement_docs_title.company
+  version: 1.0.0
+  title: "Agreement Documentation title vests in Company"
+  law_reference:
+    - "Copyright assignment must be in writing (CDPA 1988 s.90)."
+  severity: low
+  triggers:
+    any:
+      - regex: "(?i)agreement documentation"
+  checks:
+    - id: title_vests_company
+      when:
+        regex: "(?i)(title|ownership).*agreement documentation.*(company)"
+      finding:
+        message: "Титул на Agreement Documentation закреплён за Company."
+        severity_level: low
+        risk: "Риск отсутствует: титул у Company."
+        suggestion:
+          text: "—"
+    - id: title_retained_contractor
+      when:
+        regex: '(?i)title.*(remain|retained).*contractor|assigned\s+later'
+      finding:
+        message: "Титул на Agreement Documentation сохраняется у Contractor или передаётся позднее."
+        severity_level: high
+        risk: "Company может не получить права на документацию."
+        suggestion:
+          text: "Закрепите немедленное переход права на документацию к Company."
+  outcome:
+    status: pass
+    risk_level: low
+    severity: low
+    problem: ""
+    recommendation: ""
+  metadata:
+    tags: ["ipr","documentation","title","company"]
+---
+rule:
+  id: ipr.fg.licence.scope
+  version: 1.0.0
+  title: "Foreground IPR licence to Company — broad grant"
+  law_reference:
+    - "Company must be able to modify and own modifications."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)foreground\s+(intellectual\s+property|ipr)'
+  checks:
+    - id: fg_full_scope
+      when:
+        all:
+          - regex: '(?i)worldwide'
+          - regex: '(?i)royalty-free'
+          - regex: '(?i)perpetual'
+          - regex: '(?i)irrevocable'
+          - regex: '(?i)transferable'
+          - regex: '(?i)sub-?licen(c|s)able'
+          - regex: '(?i)\bmodify\b'
+          - regex: '(?i)modifications?\s+shall\s+vest\s+in\s+company'
+      finding:
+        message: "Широкая лицензия FG IPR в пользу Company присутствует."
+        severity_level: low
+        risk: "—"
+        suggestion:
+          text: "—"
+    - id: fg_missing_scope
+      when:
+        any:
+          - not_regex: "(?i)worldwide"
+          - not_regex: '(?i)royalty-free'
+          - not_regex: "(?i)perpetual"
+          - not_regex: "(?i)irrevocable"
+          - not_regex: "(?i)transferable"
+          - not_regex: "(?i)sub-?licen(c|s)able"
+          - not_regex: '(?i)\bmodify\b'
+          - not_regex: '(?i)modifications?\s+shall\s+vest\s+in\s+company'
+      finding:
+        message: "Лицензия FG IPR не покрывает все ключевые права."
+        severity_level: high
+        risk: "Company может не получить полные права на FG IPR."
+        suggestion:
+          text: "Добавьте worldwide, royalty-free, perpetual, irrevocable, transferable, sublicensable, право modify и vesting of modifications."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "FG licence scope неполная."
+    recommendation: "Расширить лицензию FG IPR."
+  metadata:
+    tags: ["ipr","foreground","licence","scope"]
+---
+rule:
+  id: ipr.bg.licence.conflict
+  version: 1.0.0
+  title: "Background IPR licence — detect term conflict"
+  law_reference:
+    - "Consistency & enforceability of licence terms (UK contract law)."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)background\s+(intellectual\s+property|ipr)'
+  checks:
+    - id: bg_term_conflict
+      when:
+        all:
+          - regex: "(?i)perpetual|irrevocable"
+          - regex: '(?i)only\s+for\s+the\s+duration\s+of\s+the\s+(agreement|call-?off)'
+      finding:
+        message: "Конфликт срока BG-лицензии: perpetual/irrevocable vs only for the duration."
+        severity_level: high
+        risk: "Внутренняя противоречивость условий лицензии."
+        suggestion:
+          text: "Выбрать одну модель срока и убрать конфликт."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "BG licence term conflict."
+    recommendation: "Согласовать единую редакцию срока BG-лицензии."
+  metadata:
+    tags: ["ipr","background","licence","conflict","term"]
+---
+rule:
+  id: ipr.moral_rights.waiver
+  version: 1.0.0
+  title: "Moral rights — unconditional & irrevocable waivers"
+  law_reference:
+    - "CDPA 1988 s.87 allows waiver of moral rights."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)moral\s+rights'
+  checks:
+    - id: moral_rights_missing_waiver
+      when:
+        not_regex: '(?i)irrevocably\s+and\s+unconditionally\s+waive(s)?\s+all\s+moral\s+rights'
+      finding:
+        message: "Отсутствует безусловный отказ от моральных прав."
+        severity_level: high
+        risk: "Автор может препятствовать использованию произведения."
+        suggestion:
+          text: "Вставьте безусловный и безотзывный отказ от всех моральных прав."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "No moral rights waiver."
+    recommendation: "Добавить waiver от всех авторов/исполнителей."
+  metadata:
+    tags: ["ipr","moral rights","waiver"]
+---
+rule:
+  id: ipr.indemnity.remedies
+  version: 1.0.0
+  title: "IPR indemnity with procure/replace/modify remedies"
+  law_reference:
+    - "Indemnifying party must ensure equivalent performance with no extra cost."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)intellectual\s+property'
+      - regex: "(?i)ipr"
+  checks:
+    - id: indemnity_missing_conditions
+      when:
+        any:
+          - not_regex: "(?i)procure"
+          - not_regex: "(?i)replace"
+          - not_regex: "(?i)modify"
+          - not_regex: '(?i)equivalent\s+performance'
+          - not_regex: '(?i)no\s+additional\s+cost'
+          - not_regex: '(?i)no\s+adverse\s+impact'
+          - not_regex: '(?i)subject\s+to\s+(this|the)\s+agreement'
+      finding:
+        message: "Условия IPR indemnity/remedies неполные."
+        severity_level: high
+        risk: "Company может остаться без эквивалентного решения и понести расходы."
+        suggestion:
+          text: "Добавьте: procure licence, replace или modify с equivalent performance, без additional cost, без adverse impact и subject to this Agreement."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "IPR indemnity lacks full remedies."
+    recommendation: "Расширить перечень remedial условий."
+  metadata:
+    tags: ["ipr","indemnity","remedies"]
+---
+rule:
+  id: ipr.brand.use.prohibition
+  version: 1.0.0
+  title: "Brand use prohibition"
+  law_reference:
+    - "Trade mark use requires prior consent."
+  severity: high
+  triggers:
+    any:
+      - regex: '(?i)company(?:''s)?\s+(name|logo|brand|trademark)'
+  checks:
+    - id: brand_use_allowed
+      when:
+        all:
+          - regex: '(?i)may\s+use.*company(?:''s)?\s+(name|logo|brand|trademark)'
+          - not_regex: '(?i)prior\s+written\s+consent'
+      finding:
+        message: "Разрешение на использование бренда Company дано по умолчанию."
+        severity_level: high
+        risk: "Нежелательное использование названия/логотипов Company."
+        suggestion:
+          text: "Запретите использование бренда без предварительного письменного согласия Company."
+  outcome:
+    status: fail
+    risk_level: high
+    severity: high
+    problem: "Brand use allowed by default."
+    recommendation: "Добавить запрет на использование без письменного согласия."
+  metadata:
+    tags: ["ipr","brand","consent"]
+---
+rule:
+  id: ipr.supplied_software.definition
+  version: 1.0.0
+  title: "Supplied Software — comprehensive definition"
+  law_reference:
+    - "Software supply should cover all components."
+  severity: medium
+  triggers:
+    any:
+      - regex: '(?i)supplied\s+software'
+  checks:
+    - id: supplied_software_incomplete
+      when:
+        any:
+          - not_regex: '(?i)embedded\s+firmware'
+          - not_regex: '(?i)activation\s+keys'
+          - not_regex: '(?i)test\s+scripts'
+          - not_regex: "(?i)patches|updates"
+          - not_regex: "(?i)manuals"
+      finding:
+        message: "Определение Supplied Software неполное."
+        severity_level: medium
+        risk: "Часть компонентов может быть исключена."
+        suggestion:
+          text: "Уточните, что Supplied Software включает firmware, activation keys, test scripts, patches/updates и manuals."
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: medium
+    problem: "Definition of Supplied Software incomplete."
+    recommendation: "Добавить недостающие элементы."
+  metadata:
+    tags: ["ipr","software","definition"]
+---
+rule:
+  id: ipr.further_assurances.poa
+  version: 1.0.0
+  title: "Further assurances and irrevocable PoA"
+  law_reference:
+    - "Further assurances clauses secure assignment validity."
+  severity: medium
+  triggers:
+    any:
+      - regex: '(?i)intellectual\s+property|ipr'
+  checks:
+    - id: missing_further_assurances
+      when:
+        not_regex: '(?i)further\s+assurances|power\s+of\s+attorney'
+      finding:
+        message: "Отсутствует обязанность подписывать документы/PoA для оформления прав."
+        severity_level: medium
+        risk: "Компания может столкнуться с препятствиями при оформлении прав."
+        suggestion:
+          text: "Добавьте обязанность подписывать документы и безотзывный PoA на Company."
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: medium
+    problem: "No further assurances/PoA."
+    recommendation: "Вставить clause о further assurances и irrevocable PoA."
+  metadata:
+    tags: ["ipr","assurances","poa"]
+---
+rule:
+  id: ipr.oss.guardrails
+  version: 1.0.0
+  title: "Open-source guardrails (SBOM/copyleft)"
+  law_reference:
+    - "OSS components require policy compliance and SBOM."
+  severity: medium
+  triggers:
+    any:
+      - regex: "(?i)software"
+  checks:
+    - id: oss_missing_controls
+      when:
+        not_regex: '(?i)open\s*source|OSS|software\s+bill\s+of\s+materials|SBOM|copyleft'
+      finding:
+        message: "Отсутствуют OSS-политика/SBOM/запрет copyleft."
+        severity_level: medium
+        risk: "Возможны нарушения лицензий OSS и copyleft-заражение."
+        suggestion:
+          text: "Добавьте политику использования OSS, требование SBOM и запрет copyleft-заражения."
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: medium
+    problem: "No OSS guardrails."
+    recommendation: "Добавить требования по OSS и SBOM."
+  metadata:
+    tags: ["ipr","oss","sbom"]
+---
+rule:
+  id: ipr.source_code.escrow
+  version: 1.0.0
+  title: "Source code escrow for critical software"
+  law_reference:
+    - "Escrow ensures access if supplier fails."
+  severity: medium
+  triggers:
+    any:
+      - regex: '(?i)source\s+code'
+  checks:
+    - id: escrow_missing
+      when:
+        not_regex: "(?i)escrow"
+      finding:
+        message: "Отсутствует условие о депонировании исходного кода (escrow)."
+        severity_level: medium
+        risk: "Company рискует потерять доступ к критичному ПО."
+        suggestion:
+          text: "Предусмотрите escrow исходного кода с событиями release: банкротство, отказ поддерживать, нарушение."
+  outcome:
+    status: warn
+    risk_level: medium
+    severity: medium
+    problem: "No source code escrow."
+    recommendation: "Добавить escrow с release events."
+  metadata:
+    tags: ["ipr","escrow","source code"]

--- a/tests/panel/helpers.py
+++ b/tests/panel/helpers.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+def analyze_and_render(text: str) -> str:
+    resp = client.post("/api/analyze", json={"text": text})
+    assert resp.status_code == 200
+    data = resp.json()
+    out = []
+    for f in data["analysis"]["findings"]:
+        sev = str(f.get("severity", "")).upper()
+        rid = f.get("rule_id", "")
+        snippet = f.get("snippet", "")
+        advice = f.get("advice", "")
+        law = "; ".join(f.get("law_refs", []))
+        conflict = "; ".join(f.get("conflict_with", []))
+        fix = f.get("suggestion", {}).get("text", "") if isinstance(f.get("suggestion"), dict) else ""
+        out.append(f"[{sev}] {rid} {snippet}\nReason: {advice}\nLaw: {law}\nConflict: {conflict}\nSuggested fix: {fix}")
+    return "\n\n".join(out)

--- a/tests/panel/test_ipr_panel_smoke.py
+++ b/tests/panel/test_ipr_panel_smoke.py
@@ -1,0 +1,11 @@
+from tests.panel.helpers import analyze_and_render
+
+
+def test_ipr_comment_format():
+    txt = (
+        "Title to the Agreement Documentation shall vest in Company. "
+        "Contractor grants a perpetual, irrevocable licence only for the duration of the Agreement."
+    )
+    panel = analyze_and_render(txt)
+    assert "[HIGH]" in panel or "[LOW]" in panel
+    assert panel.count("Agreement Documentation") >= 1

--- a/tests/rules/ipr/test_ipr_rules.py
+++ b/tests/rules/ipr/test_ipr_rules.py
@@ -1,0 +1,152 @@
+import pytest
+from core.engine.runner import load_rule, run_rule
+from core.schemas import AnalysisInput
+
+RULE_PATH = "contract_review_app/legal_rules/policy_packs/ipr_core.yaml"
+AI = lambda text: AnalysisInput(text=text, clause_type="ipr")
+
+def _run(text, rule_id):
+    rule = load_rule(RULE_PATH, rule_id=rule_id)
+    return run_rule(rule, AI(text))
+
+# R1 Agreement Documentation title
+
+def test_agreement_docs_title_pass():
+    txt = "Title to the Agreement Documentation shall vest in Company upon creation."
+    res = _run(txt, "ipr.agreement_docs_title.company")
+    assert res and any("Company" in f.message for f in res.findings)
+
+
+def test_agreement_docs_title_fail():
+    txt = "Title to the Agreement Documentation shall remain with the Contractor and be assigned later."
+    res = _run(txt, "ipr.agreement_docs_title.company")
+    assert res and any("сохраняется" in f.message for f in res.findings)
+
+# R2 Foreground IPR licence
+
+def test_fg_licence_scope_pass():
+    txt = (
+        "Company is granted a worldwide, royalty-free, perpetual, irrevocable, transferable and "
+        "sublicensable licence to modify Foreground IPR. All modifications shall vest in Company."
+    )
+    res = _run(txt, "ipr.fg.licence.scope")
+    assert res and any("присутствует" in f.message for f in res.findings)
+
+
+def test_fg_licence_scope_fail_missing_transferable():
+    txt = (
+        "Company is granted a worldwide, royalty-free, perpetual, irrevocable and sublicensable "
+        "licence to modify Foreground IPR. All modifications shall vest in Company."
+    )
+    res = _run(txt, "ipr.fg.licence.scope")
+    assert res and any("не покрывает" in f.message for f in res.findings)
+
+# R3 Background IPR term conflict
+
+def test_bg_licence_conflict_fail():
+    txt = (
+        "Contractor grants a perpetual, irrevocable licence to its Background IPR, provided that such licence is only for the duration of the Agreement."
+    )
+    res = _run(txt, "ipr.bg.licence.conflict")
+    assert res and any("конфликт" in f.message.lower() for f in res.findings)
+
+
+def test_bg_licence_conflict_ok():
+    txt = "Contractor grants a perpetual, irrevocable licence to its Background IPR."
+    res = _run(txt, "ipr.bg.licence.conflict")
+    assert res is None
+
+# R4 Moral rights waivers
+
+def test_moral_rights_waiver_fail():
+    txt = "Contractor's personnel retain all moral rights in the Works."
+    res = _run(txt, "ipr.moral_rights.waiver")
+    assert res and any("отсутствует" in f.message.lower() for f in res.findings)
+
+
+def test_moral_rights_waiver_pass():
+    txt = "The Contractor's personnel irrevocably and unconditionally waive all moral rights in the Works."
+    res = _run(txt, "ipr.moral_rights.waiver")
+    assert res is None
+
+# R5 IPR indemnity remedies
+
+def test_indemnity_remedies_fail():
+    txt = "Contractor shall indemnify Company for any IPR claim and may replace the item at its option."
+    res = _run(txt, "ipr.indemnity.remedies")
+    assert res and any("неполные" in f.message for f in res.findings)
+
+
+def test_indemnity_remedies_pass():
+    txt = (
+        "Contractor shall indemnify Company for any IPR claim and shall procure a licence or replace or modify the infringing item to provide equivalent performance at no additional cost and no adverse impact on other works or interfaces, subject to this Agreement."
+    )
+    res = _run(txt, "ipr.indemnity.remedies")
+    assert res is None
+
+# R6 Brand use prohibition
+
+def test_brand_use_prohibition_fail():
+    txt = "Contractor may use the Company's name and logo for marketing unless the Company objects."
+    res = _run(txt, "ipr.brand.use.prohibition")
+    assert res and any("бренда" in f.message.lower() for f in res.findings)
+
+
+def test_brand_use_prohibition_pass():
+    txt = "Contractor shall not use the Company's name or logo without the Company's prior written consent."
+    res = _run(txt, "ipr.brand.use.prohibition")
+    assert res is None
+
+# R7 Supplied Software definition
+
+def test_supplied_software_definition_warn():
+    txt = "Supplied Software includes software and manuals."
+    res = _run(txt, "ipr.supplied_software.definition")
+    assert res and any("неполное" in f.message for f in res.findings)
+
+
+def test_supplied_software_definition_ok():
+    txt = (
+        "Supplied Software includes software, embedded firmware, activation keys, test scripts, patches and updates, and manuals."
+    )
+    res = _run(txt, "ipr.supplied_software.definition")
+    assert res is None
+
+# R8 Further assurances / PoA
+
+def test_further_assurances_poa_warn():
+    txt = "Contractor assigns intellectual property rights to Company."
+    res = _run(txt, "ipr.further_assurances.poa")
+    assert res and any("Отсутствует" in f.message for f in res.findings)
+
+
+def test_further_assurances_poa_ok():
+    txt = "Contractor shall execute further assurances to perfect rights and grants an irrevocable power of attorney to the Company to do so."
+    res = _run(txt, "ipr.further_assurances.poa")
+    assert res is None
+
+# R9 OSS guardrails
+
+def test_oss_guardrails_warn():
+    txt = "Supplier shall deliver the software in executable form."
+    res = _run(txt, "ipr.oss.guardrails")
+    assert res and any("OSS" in f.message for f in res.findings)
+
+
+def test_oss_guardrails_ok():
+    txt = "Supplier shall comply with the Company's open source policy, provide an SBOM, and avoid any copyleft software."
+    res = _run(txt, "ipr.oss.guardrails")
+    assert res is None
+
+# R10 Source code escrow
+
+def test_source_code_escrow_warn():
+    txt = "The Contractor shall provide the source code of critical software to the Company."
+    res = _run(txt, "ipr.source_code.escrow")
+    assert res and any("escrow" in f.message.lower() for f in res.findings)
+
+
+def test_source_code_escrow_ok():
+    txt = "For critical software the source code shall be deposited with an escrow agent, to be released on bankruptcy, failure to support or breach."
+    res = _run(txt, "ipr.source_code.escrow")
+    assert res is None

--- a/tests/server/test_fields_propagation_ipr.py
+++ b/tests/server/test_fields_propagation_ipr.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+def test_ipr_fields_propagation_minimal():
+    body = {"text": "Title to the Agreement Documentation shall vest in Company."}
+    resp = client.post("/api/analyze", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    findings = data["analysis"]["findings"]
+    assert findings
+    f0 = findings[0]
+    for key in ("rule_id","severity","advice","law_refs","scope","occurrences","conflict_with","ops"):
+        assert key in f0
+    assert isinstance(f0["law_refs"], list)
+    assert isinstance(f0["conflict_with"], list)
+    assert isinstance(f0["ops"], list)
+    assert isinstance(f0["scope"], dict)


### PR DESCRIPTION
## Summary
- add production IPR rule pack covering agreement docs title, FG/BG licences, moral rights waivers, indemnity remedies, brand use and more
- verify propagation of advice, law refs and other fields through API and panel
- add smoke tests for Word panel rendering

## Testing
- `npm ci >/tmp/npm.log && npm run build >>/tmp/npm.log`
- `curl https://localhost:9443/health` *(fails: Couldn't connect to server)*
- `curl -H "Content-Type: application/json" --data-binary '{"text":"Title to the Agreement Documentation shall vest in Company."}' https://localhost:9443/api/analyze` *(fails: Couldn't connect to server)*
- `pytest -q tests/rules/ipr/test_ipr_rules.py`
- `pytest -q tests/server/test_fields_propagation_ipr.py`
- `pytest -q tests/panel/test_ipr_panel_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9c33df7c832599c4612bbefeb07b