### PR TITLE
Add server-side redlines and caching headers

### DIFF
--- a/contract_review_app/core/diff.py
+++ b/contract_review_app/core/diff.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import difflib
+from typing import Tuple
+
+
+def make_diff(before: str, after: str) -> Tuple[str, str]:
+    """Return unified and HTML diffs for the given texts.
+
+    The unified diff uses :func:`difflib.unified_diff` and the HTML diff uses
+    :class:`difflib.HtmlDiff` without relying on any external libraries.
+    """
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    unified = "\n".join(
+        difflib.unified_diff(
+            before_lines,
+            after_lines,
+            fromfile="before",
+            tofile="after",
+            lineterm="",
+        )
+    )
+    html = difflib.HtmlDiff().make_table(before_lines, after_lines)
+    return unified, html

--- a/tests/panel/test_panel_redlines_api.py
+++ b/tests/panel/test_panel_redlines_api.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_panel_redlines_returns_diffs():
+    payload = {"before_text": "hello world", "after_text": "hello there"}
+    r = client.post("/api/panel/redlines", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "ok"
+    diff_u = data.get("diff_unified", "")
+    diff_h = data.get("diff_html", "")
+    assert diff_u and diff_h
+    lines = diff_u.splitlines()
+    assert lines[0].startswith("--- ")
+    assert lines[1].startswith("+++ ")
+    assert any(l.startswith("@@") for l in lines)

--- a/tests/security/test_api_key_auth_b5.py
+++ b/tests/security/test_api_key_auth_b5.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api import app as app_module
+
+client = TestClient(app_module.app)
+
+
+def test_api_key_required(monkeypatch):
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "secret")
+    app_module.FEATURE_REQUIRE_API_KEY = True
+    app_module.API_KEY = "secret"
+
+    r = client.post("/api/analyze", json={"text": "hi"})
+    assert r.status_code == 401
+
+    r = client.post("/api/analyze", json={"text": "hi"}, headers={"x-api-key": "secret"})
+    assert r.status_code == 200

--- a/tests/security/test_privacy_redaction_b5.py
+++ b/tests/security/test_privacy_redaction_b5.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_privacy_redaction_and_scrub():
+    text = (
+        "Contact John Smith at john@example.com or +44 1234 567890. "
+        "NI AB123456C."
+    )
+    r = client.post("/api/gpt-draft", json={"text": text, "mode": "friendly"})
+    assert r.status_code == 200
+    data = r.json()
+    sensitive = ["John Smith", "john@example.com", "+44 1234 567890", "AB123456C"]
+    combined = " ".join(
+        [
+            data.get("proposed_text", ""),
+            data.get("rationale", ""),
+            data.get("after_text", ""),
+            data.get("diff", {}).get("value", ""),
+            " ".join(data.get("evidence", [])),
+        ]
+    )
+    for item in sensitive:
+        assert item not in combined


### PR DESCRIPTION
## Summary
- add diff utilities and /api/panel/redlines endpoint returning unified and HTML diffs
- implement ETag/x-cache support for /api/analyze and /api/gpt-draft
- add tests for cache headers, API-key enforcement and PII scrubbing

## Testing
- `pytest tests/panel/test_suggest_edit_dto_v14.py -q`
- `pytest tests/llm/test_grounding_in_prompt.py -q`
- `pytest tests/llm/test_verification_status_plumbed.py -q`
- `pytest tests/api/test_gpt_draft_alias.py -q`
- `pytest tests/panel/test_panel_redlines_api.py -q`
- `pytest tests/panel/test_cache_headers_v2.py -q`
- `pytest tests/security/test_api_key_auth_b5.py -q`
- `pytest tests/security/test_privacy_redaction_b5.py -q`
- `pytest tests/panel/test_anchor_sentence_scope.py -q`
- `pytest tests/rules/test_server_threshold.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ea7ce6c8325a6617d185e22d6b6