### PR TITLE
feat: add explain DTOs

### DIFF
--- a/contract_review_app/core/schemas.py
+++ b/contract_review_app/core/schemas.py
@@ -67,6 +67,8 @@ __all__ = [
     "DeltaMetrics",
     "QARecheckIn",
     "QARecheckOut",
+    "ExplainRequest",
+    "ExplainResponse",
     # trace
     "TraceOut",
     # helpers (both long and short names)
@@ -1218,6 +1220,28 @@ class QARecheckOut(AppBaseModel):
             data.setdefault("status_from", d.get("status_from", "OK"))
             data.setdefault("status_to", d.get("status_to", "OK"))
         return data
+
+
+# ============================================================================
+# Explain endpoint
+# ============================================================================
+class ExplainRequest(AppBaseModel):
+    """Request DTO for /api/explain."""
+
+    finding: Finding
+    text: Optional[str] = None
+    citations: Optional[List[Citation]] = None
+
+
+class ExplainResponse(AppBaseModel):
+    """Response DTO for /api/explain."""
+
+    reasoning: str
+    citations: List[Citation] = Field(default_factory=list)
+    evidence: List[Evidence] = Field(default_factory=list)
+    verification_status: Literal["ok", "missing_citations", "invalid"] = "ok"
+    trace: Optional[str] = None
+    x_schema_version: str = Field(default=SCHEMA_VERSION, alias="x_schema_version")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- add `ExplainRequest` and `ExplainResponse` models for /api/explain
- expose new models in schema exports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfminer')*
- `pytest tests/analysis/test_parser_docx_pdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bda89ed3888325afe9a898a0e73f5d