### PR TITLE
B6 — Explainability v1: /api/explain endpoint + deterministic grounding, verification, privacy, audit

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -298,6 +298,7 @@ from contract_review_app.gpt.service import (
 
 from .cache import IDEMPOTENCY_CACHE
 from .corpus_search import router as corpus_router
+from .explain import router as explain_router
 
 # Orchestrator / Engine imports
 try:
@@ -745,7 +746,7 @@ def _custom_openapi():
         "x-latency-ms": 12,
         "x-cid": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     }
-    for p in ["/api/analyze", "/api/gpt-draft"]:
+    for p in ["/api/analyze", "/api/gpt-draft", "/api/explain"]:
         op = openapi_schema.get("paths", {}).get(p, {}).get("post")
         if not op:
             continue
@@ -1352,6 +1353,7 @@ async def health() -> JSONResponse:
             "timeout_s": LLM_CONFIG.timeout_s,
         },
         "provider": PROVIDER_META,
+        "endpoints": ["/api/analyze", "/api/gpt-draft", "/api/explain"],
     }
     try:
         if rules_loader and hasattr(rules_loader, "loaded_packs"):
@@ -2296,6 +2298,7 @@ async def api_learning_update(response: Response, body: LearningUpdateIn):
 # Mount router
 app.include_router(router)
 app.include_router(corpus_router)
+app.include_router(explain_router)
 
 
 # --------------------------------------------------------------------

--- a/contract_review_app/api/explain.py
+++ b/contract_review_app/api/explain.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from typing import List, Optional
+
+from fastapi import APIRouter, Request, HTTPException
+from fastapi.responses import JSONResponse
+
+from contract_review_app.core.schemas import ExplainRequest, ExplainResponse, Citation, Evidence
+from contract_review_app.core.citation_resolver import resolve_citation
+from contract_review_app.core.privacy import redact_pii, scrub_llm_output
+from contract_review_app.corpus.db import SessionLocal
+from contract_review_app.retrieval.search import search_corpus
+from contract_review_app.llm.citation_resolver import make_grounding_pack
+from contract_review_app.llm.prompt_builder import build_prompt
+from contract_review_app.llm.provider import get_provider
+from contract_review_app.llm.verification import verify_output_contains_citations
+from contract_review_app.core.audit import audit
+from .headers import apply_std_headers, compute_cid
+
+
+router = APIRouter(prefix="/api")
+
+_TRUTHY = {"1", "true", "yes", "on", "enabled"}
+
+
+def _env_truthy(name: str) -> bool:
+    return (os.getenv(name, "") or "").strip().lower() in _TRUTHY
+
+
+def _require_api_key(request: Request) -> None:
+    if _env_truthy("FEATURE_REQUIRE_API_KEY"):
+        api_key = os.getenv("API_KEY", "")
+        if request.headers.get("x-api-key") != api_key:
+            raise HTTPException(status_code=401, detail="missing or invalid api key")
+
+
+# instantiate provider once for explain endpoint
+LLM_PROVIDER = get_provider()
+
+
+_RULE_HINTS = {
+    "uk_poca_tipping_off": {
+        "why": "Disclosing a suspicious activity report may constitute tipping off under POCA.",
+        "fix": "Include an explicit carve-out allowing disclosures required by POCA.",
+    },
+    "uk_ucta_2_1_invalid": {
+        "why": "UCTA 1977 prohibits excluding liability for death or personal injury caused by negligence.",
+        "fix": "Remove or modify the exclusion to comply with UCTA 1977.",
+    },
+    "uk_fraud_exclusion_invalid": {
+        "why": "Liability for fraud or fraudulent misrepresentation cannot be excluded.",
+        "fix": "Carve out fraud and fraudulent misrepresentation from the exclusion.",
+    },
+    "uk_dpa_1998_outdated": {
+        "why": "References to the Data Protection Act 1998 are outdated.",
+        "fix": "Update the clause to refer to the Data Protection Act 2018 or UK GDPR.",
+    },
+    "uk_ca_1985_outdated": {
+        "why": "Companies Act 1985 has been replaced by the Companies Act 2006.",
+        "fix": "Refer to the Companies Act 2006 instead.",
+    },
+    "uk_bribery_act_missing": {
+        "why": "Anti-bribery provisions should reference the UK Bribery Act 2010.",
+        "fix": "Add a reference to compliance with the Bribery Act 2010.",
+    },
+    "gl_jurisdiction_conflict": {
+        "why": "Governing law and jurisdiction clauses are inconsistent.",
+        "fix": "Align governing law with the jurisdiction clause or clarify the relationship.",
+    },
+}
+
+
+def _deterministic_reasoning(finding, citation: Optional[Citation]) -> str:
+    info = _RULE_HINTS.get(getattr(finding, "code", ""), {})
+    instrument = (citation.instrument if citation else info.get("instrument", "")) or "Unknown"
+    section = (citation.section if citation else info.get("section", "")) or ""
+    why = info.get("why", "Potential legal non-compliance.")
+    fix = info.get("fix", "Review and amend the clause accordingly.")
+    return (
+        f"{finding.message}. Legal basis: {instrument} §{section}. "
+        f"Why this matters: {why}. How to fix: {fix}."
+    )
+
+
+def _gather_evidence(citations: List[Citation]) -> List[Evidence]:
+    evidence: List[Evidence] = []
+    try:
+        with SessionLocal() as session:
+            for cit in citations:
+                query = f"{cit.instrument} {cit.section}".strip()
+                rows = search_corpus(session, query, top=3)
+                for r in rows[:3]:
+                    snippet = (r.get("snippet") or r.get("text") or "")[:320]
+                    evidence.append(Evidence(text=snippet, source=cit.instrument, link=cit.url))
+    except Exception:
+        return []
+    return evidence
+
+
+@router.post("/explain", response_model=ExplainResponse)
+async def api_explain(body: ExplainRequest, request: Request) -> JSONResponse:
+    _require_api_key(request)
+    started = time.perf_counter()
+    cid = compute_cid(request)
+
+    text = body.text or ""
+    doc_hash = hashlib.sha256(text.encode("utf-8")).hexdigest() if text else None
+
+    finding = body.finding
+    citations = body.citations or []
+    if not citations:
+        cit = resolve_citation(finding)
+        if cit:
+            citations = [cit]
+
+    evidence = _gather_evidence(citations)
+
+    context = ""
+    if text and getattr(finding, "span", None):
+        span = finding.span
+        end_pos = span.start + (getattr(span, "length", 0) or 0)
+        start = max(0, span.start - 400)
+        end = min(len(text), end_pos + 400)
+        context = text[start:end]
+
+    redacted_context, pii_map = redact_pii(context)
+
+    grounding = make_grounding_pack(finding.message, redacted_context, [c.model_dump() for c in citations])
+
+    use_llm = _env_truthy("FEATURE_LLM_EXPLAIN")
+    reasoning = ""
+    verification_status = "ok"
+
+    if use_llm:
+        try:
+            prompt = build_prompt("explain", grounding)
+            res = LLM_PROVIDER.chat(
+                [{"role": "user", "content": prompt}],
+                temperature=0.0,
+                top_p=1.0,
+            )
+            llm_reasoning = scrub_llm_output(res.get("content", ""), pii_map)
+            v = verify_output_contains_citations(llm_reasoning, grounding.get("evidence", []))
+            if v == "verified":
+                reasoning = llm_reasoning
+                verification_status = "ok"
+            else:
+                verification_status = "missing_citations"
+                reasoning = _deterministic_reasoning(finding, citations[0] if citations else None)
+        except Exception:
+            verification_status = "invalid"
+            reasoning = _deterministic_reasoning(finding, citations[0] if citations else None)
+    else:
+        reasoning = _deterministic_reasoning(finding, citations[0] if citations else None)
+
+    reasoning = scrub_llm_output(reasoning, pii_map)
+
+    resp_obj = ExplainResponse(
+        reasoning=reasoning,
+        citations=citations,
+        evidence=evidence,
+        verification_status=verification_status,
+        trace=cid,
+    )
+
+    resp = JSONResponse(resp_obj.model_dump(by_alias=True))
+    apply_std_headers(resp, request, started)
+    resp.headers["x-cache"] = "miss"
+
+    audit(
+        "explain",
+        request.headers.get("x-user"),
+        doc_hash,
+        {
+            "citations_count": len(citations),
+            "evidence_count": len(evidence),
+            "rule_code": getattr(finding, "code", ""),
+            "cid": cid,
+        },
+    )
+
+    return resp

--- a/contract_review_app/llm/prompt_builder.py
+++ b/contract_review_app/llm/prompt_builder.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 
+PROMPT_VERSION = "explain-1.0"
+
 def build_prompt(mode: str, grounding: Dict[str, Any]) -> str:
     """Build a deterministic prompt using the grounding package."""
     lines: List[str] = []

--- a/contract_review_app/llm/provider.py
+++ b/contract_review_app/llm/provider.py
@@ -21,7 +21,16 @@ class MockProvider:
     name = "mock"
     model = "mock"
 
-    def chat(self, messages: List[Dict[str, str]], **opts: Any) -> Dict[str, Any]:
+    def chat(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        max_tokens: int = 1024,
+        timeout: int = 30,
+        **opts: Any,
+    ) -> Dict[str, Any]:
+        """Deterministic chat interface for tests."""
         text = "\n".join(m.get("content", "") for m in messages)
         usage = {"total_tokens": len(text.split())}
         return {"content": f"[MOCK] {text}", "usage": usage}
@@ -65,6 +74,7 @@ class AzureProvider:
         self,
         messages: List[Dict[str, str]],
         temperature: float = 0.0,
+        top_p: float = 1.0,
         max_tokens: int = 1024,
         timeout: int = 30,
     ) -> Dict[str, Any]:
@@ -75,6 +85,7 @@ class AzureProvider:
             json={
                 "messages": messages,
                 "temperature": temperature,
+                "top_p": top_p,
                 "max_tokens": max_tokens,
             },
             timeout=timeout,

--- a/tests/api/test_explain_deterministic_fallback.py
+++ b/tests/api/test_explain_deterministic_fallback.py
@@ -1,0 +1,22 @@
+import os
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_explain_deterministic(monkeypatch):
+    monkeypatch.setenv("FEATURE_LLM_EXPLAIN", "0")
+    req = {
+        "finding": {
+            "code": "uk_ucta_2_1_invalid",
+            "message": "Exclusion of liability for personal injury",
+            "span": {"start": 0, "end": 10},
+        },
+        "text": "Exclusion of liability for personal injury is void.",
+    }
+    resp = client.post("/api/explain", json=req)
+    data = resp.json()
+    assert "Legal basis:" in data["reasoning"]
+    assert "UCTA" in data["reasoning"]

--- a/tests/api/test_explain_endpoint.py
+++ b/tests/api/test_explain_endpoint.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_explain_basic():
+    req = {
+        "finding": {
+            "code": "uk_ucta_2_1_invalid",
+            "message": "Exclusion of liability for personal injury",
+            "span": {"start": 0, "end": 10},
+        },
+        "text": "Exclusion of liability for personal injury is void.",
+    }
+    resp = client.post("/api/explain", json=req)
+    assert resp.status_code == 200
+    assert resp.headers["x-schema-version"] == "1.3"
+    data = resp.json()
+    assert data["x_schema_version"] == "1.3"
+    assert data["reasoning"]
+    assert data["trace"]
+    assert any("UCTA" in c.get("instrument", "") for c in data["citations"])
+    assert any("2(1)" in c.get("section", "") for c in data["citations"])
+    assert data["verification_status"] in {"ok", "missing_citations"}

--- a/tests/api/test_explain_headers_health.py
+++ b/tests/api/test_explain_headers_health.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_explain_headers_and_health():
+    req = {
+        "finding": {
+            "code": "uk_ucta_2_1_invalid",
+            "message": "Exclusion of liability for personal injury",
+            "span": {"start": 0, "end": 10},
+        },
+        "text": "Exclusion of liability for personal injury is void.",
+    }
+    resp = client.post("/api/explain", json=req)
+    assert resp.status_code == 200
+    assert "x-cid" in resp.headers
+    assert resp.headers["x-schema-version"] == "1.3"
+
+    health = client.get("/health")
+    data = health.json()
+    assert "/api/explain" in data.get("endpoints", [])
+    assert data.get("schema") == "1.3"

--- a/tests/api/test_explain_llm_verification.py
+++ b/tests/api/test_explain_llm_verification.py
@@ -1,0 +1,38 @@
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+import contract_review_app.api.explain as explain_mod
+
+client = TestClient(app)
+
+
+REQ = {
+    "finding": {
+        "code": "uk_ucta_2_1_invalid",
+        "message": "Exclusion of liability for personal injury",
+        "span": {"start": 0, "end": 10},
+    },
+    "text": "Exclusion of liability for personal injury is void.",
+}
+
+
+def test_llm_verification(monkeypatch):
+    monkeypatch.setenv("FEATURE_LLM_EXPLAIN", "1")
+
+    def no_refs(messages, **kwargs):
+        return {"content": "some explanation without refs", "usage": {}}
+
+    monkeypatch.setattr(explain_mod.LLM_PROVIDER, "chat", no_refs)
+    resp = client.post("/api/explain", json=REQ)
+    data = resp.json()
+    assert data["verification_status"] == "missing_citations"
+    assert "Legal basis:" in data["reasoning"]  # fallback used
+
+    def with_refs(messages, **kwargs):
+        return {"content": "reason [c1]", "usage": {}}
+
+    monkeypatch.setattr(explain_mod.LLM_PROVIDER, "chat", with_refs)
+    resp2 = client.post("/api/explain", json=REQ)
+    data2 = resp2.json()
+    assert data2["verification_status"] == "ok"
+    assert "reason" in data2["reasoning"]

--- a/tests/security/test_explain_api_key.py
+++ b/tests/security/test_explain_api_key.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+REQ = {
+    "finding": {
+        "code": "uk_ucta_2_1_invalid",
+        "message": "Exclusion of liability for personal injury",
+        "span": {"start": 0, "end": 10},
+    },
+    "text": "Exclusion of liability for personal injury is void.",
+}
+
+
+def test_api_key_required(monkeypatch):
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "secret")
+    resp = client.post("/api/explain", json=REQ)
+    assert resp.status_code == 401
+    resp2 = client.post("/api/explain", headers={"x-api-key": "secret"}, json=REQ)
+    assert resp2.status_code == 200

--- a/tests/security/test_explain_audit_log.py
+++ b/tests/security/test_explain_audit_log.py
@@ -1,0 +1,35 @@
+import json
+import os
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def _read_audit():
+    with open("var/audit.log", "r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh]
+
+
+def test_explain_audit_log(tmp_path):
+    if os.path.exists("var/audit.log"):
+        os.remove("var/audit.log")
+    req = {
+        "finding": {
+            "code": "uk_ucta_2_1_invalid",
+            "message": "Exclusion of liability for personal injury",
+            "span": {"start": 0, "end": 10},
+        },
+        "text": "Exclusion of liability for personal injury is void.",
+    }
+    resp = client.post("/api/explain", json=req)
+    assert resp.status_code == 200
+    lines = _read_audit()
+    assert lines
+    rec = lines[-1]
+    assert rec["event"] == "explain"
+    assert rec.get("citations_count") >= 1
+    assert rec.get("evidence_count") >= 0
+    assert rec.get("rule_code") == "uk_ucta_2_1_invalid"
+    assert "doc_hash" in rec

--- a/tests/security/test_explain_privacy.py
+++ b/tests/security/test_explain_privacy.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+import contract_review_app.api.explain as explain_mod
+
+client = TestClient(app)
+
+
+def test_explain_privacy(monkeypatch):
+    monkeypatch.setenv("FEATURE_LLM_EXPLAIN", "1")
+
+    def echo_tokens(messages, **kwargs):
+        return {"content": "<EMAIL_0> <PHONE_0> <NI_0>", "usage": {}}
+
+    monkeypatch.setattr(explain_mod.LLM_PROVIDER, "chat", echo_tokens)
+    text = "Contact john@example.com or 123-456-7890 NI AB123456C"
+    req = {
+        "finding": {
+            "code": "uk_ucta_2_1_invalid",
+            "message": "Exclusion of liability",
+            "span": {"start": 0, "end": 10},
+        },
+        "text": text,
+    }
+    resp = client.post("/api/explain", json=req)
+    data = resp.json()
+    assert "john@example.com" not in data["reasoning"]
+    assert "123-456-7890" not in data["reasoning"]
+    assert "AB123456C" not in data["reasoning"]


### PR DESCRIPTION
## Summary
- add /api/explain endpoint returning reasoning, citations, evidence, and trace
- enforce PII redaction, citation verification, and audit logging with deterministic fallback
- expose explain endpoint in health and OpenAPI and tighten LLM provider determinism

## Testing
- `pytest -q tests/panel/test_slots_exist.py`
- `pytest -q tests/panel/test_whole_doc_analyze_smoke.py`
- `pytest -q tests/api/test_explain_endpoint.py`
- `pytest -q tests/api/test_explain_deterministic_fallback.py`
- `pytest -q tests/security/test_explain_privacy.py`
- `pytest -q tests/security/test_explain_audit_log.py`
- `pytest -q tests/api/test_explain_headers_health.py`
- `pytest -q tests/api/test_explain_llm_verification.py`
- `pytest -q tests/security/test_explain_api_key.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdaa1e87248325812f8a01292a1727