### PR TITLE
harden azure llm ping and config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ LLM_TEMPERATURE=0.2
 
 Defaults use a deterministic mock model so the application works without keys. Set the relevant variables for live providers.
 
+| Variable | Valid example | Invalid example |
+| --- | --- | --- |
+| `AZURE_OPENAI_API_KEY` | `0123456789abcdef0123456789ab` | `changeme` |
+| `AZURE_OPENAI_ENDPOINT` | `https://eastus.api.cognitive.microsoft.com` | `http://localhost` |
+| `AZURE_OPENAI_DEPLOYMENT` | `gpt-4o-mini` | *(empty string)* |
+| `AZURE_OPENAI_API_VERSION` | `2024-02-15-preview` | *(empty string)* |
+| `MODEL_DRAFT` | `gpt-4o-mini` | *(empty string → ignored)* |
+| `MODEL_SUGGEST` | `gpt-4o-mini` | *(empty string → ignored)* |
+| `MODEL_QA` | `gpt-4o-mini` | *(empty string → ignored)* |
+
 ## Word Add-in
 
 After running an analysis the task pane displays the current CID. You can open

--- a/contract_review_app/gpt/config.py
+++ b/contract_review_app/gpt/config.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
+import logging
+
+try:  # pragma: no cover - best effort
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:  # pragma: no cover - optional dependency
+    pass
 
 
 ALLOWED_PROVIDERS = {"azure", "mock"}
@@ -36,6 +44,7 @@ class LLMConfig:
 
 
 def load_llm_config() -> LLMConfig:
+    log = logging.getLogger("contract_ai")
     provider = os.getenv("LLM_PROVIDER", "mock").strip().lower() or "mock"
     if provider not in ALLOWED_PROVIDERS:
         provider = "mock"
@@ -47,35 +56,57 @@ def load_llm_config() -> LLMConfig:
     cfg.max_tokens = int(os.getenv("LLM_MAX_TOKENS", "800"))
     cfg.temperature = float(os.getenv("LLM_TEMPERATURE", "0.2"))
 
+    key = ""
     if provider == "azure":
-        cfg.azure_api_key = (
+        key = (
             os.getenv("AZURE_OPENAI_KEY")
             or os.getenv("AZURE_OPENAI_API_KEY")
             or os.getenv("OPENAI_API_KEY")
-        )
-        cfg.azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
-        cfg.azure_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
-        default_model = os.getenv("AZURE_OPENAI_DEPLOYMENT", "")
-        cfg.model_draft = os.getenv("MODEL_DRAFT", default_model)
-        cfg.model_suggest = os.getenv("MODEL_SUGGEST", cfg.model_draft)
-        cfg.model_qa = os.getenv("MODEL_QA", cfg.model_draft)
+            or ""
+        ).strip()
+        cfg.azure_api_key = key or None
+        cfg.azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT") or None
+        cfg.azure_api_version = os.getenv("AZURE_OPENAI_API_VERSION") or None
+        cfg.azure_deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT") or None
+        default_model = cfg.azure_deployment or ""
+        cfg.model_draft = os.getenv("MODEL_DRAFT") or default_model
+        cfg.model_suggest = os.getenv("MODEL_SUGGEST") or cfg.model_draft
+        cfg.model_qa = os.getenv("MODEL_QA") or cfg.model_draft
         required = ["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_API_VERSION"]
-        if not cfg.azure_api_key:
+        if not key:
             required.append("AZURE_OPENAI_KEY")
     else:  # mock
         default_model = "mock-static"
-        cfg.model_draft = os.getenv("MODEL_DRAFT", default_model)
-        cfg.model_suggest = os.getenv("MODEL_SUGGEST", cfg.model_draft)
-        cfg.model_qa = os.getenv("MODEL_QA", cfg.model_draft)
+        cfg.model_draft = os.getenv("MODEL_DRAFT") or default_model
+        cfg.model_suggest = os.getenv("MODEL_SUGGEST") or cfg.model_draft
+        cfg.model_qa = os.getenv("MODEL_QA") or cfg.model_draft
         required = []
 
     missing = [name for name in required if not os.getenv(name)]
     cfg.missing = missing
-    cfg.valid = (provider == "mock") or not missing
+
+    invalid_key = False
+    if provider == "azure":
+        if not key or key in {"*", "changeme"} or len(key) < 24:
+            invalid_key = True
+    cfg.valid = (provider == "mock") or (not missing and not invalid_key)
     if provider == "mock":
         cfg.mode = "mock"
     elif cfg.valid:
         cfg.mode = "live"
     else:
         cfg.mode = "mock-or-error"
+
+    masked = (key[:4] + "***") if key else ""
+    log.info(
+        "LLM config: provider=%s model_draft=%s model_suggest=%s model_qa=%s endpoint=%s api_version=%s key=%s valid=%s",
+        cfg.provider,
+        cfg.model_draft,
+        cfg.model_suggest,
+        cfg.model_qa,
+        cfg.azure_endpoint or "",
+        cfg.azure_api_version or "",
+        masked,
+        cfg.valid,
+    )
     return cfg

--- a/contract_review_app/tests/api/test_llm_ping.py
+++ b/contract_review_app/tests/api/test_llm_ping.py
@@ -1,0 +1,111 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _reload_app():
+    modules = [
+        "contract_review_app.api",
+        "contract_review_app.api.app",
+    ]
+    for m in modules:
+        sys.modules.pop(m, None)
+    from contract_review_app.api import app as app_module
+
+    importlib.reload(app_module)
+    return TestClient(app_module.app), modules
+
+
+@pytest.fixture()
+def client():
+    client, modules = _reload_app()
+    try:
+        yield client
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+def test_ping_mock(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.delenv("AZURE_KEY_INVALID", raising=False)
+    client, modules = _reload_app()
+    try:
+        r = client.get("/api/llm/ping")
+        assert r.status_code == 200
+        assert r.json()["status"] == "ok"
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+def test_ping_invalid_key(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "azure")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "changeme")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://eastus.example.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
+    client, modules = _reload_app()
+    try:
+        r = client.get("/api/llm/ping")
+        assert r.status_code == 400
+        body = r.json()
+        assert body.get("code") == "invalid_llm_key"
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+def test_ping_success(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "azure")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "a" * 32)
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://eastus.example.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
+    monkeypatch.delenv("AZURE_KEY_INVALID", raising=False)
+    client, modules = _reload_app()
+    try:
+        import contract_review_app.llm.provider as provider_mod
+
+        monkeypatch.setattr(
+            provider_mod.AzureProvider,
+            "ping",
+            lambda self: {"ok": True, "latency_ms": 1},
+        )
+        r = client.get("/api/llm/ping")
+        assert r.status_code == 200
+        assert r.json()["status"] == "ok"
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+def test_models_fallback(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "azure")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "a" * 32)
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://eastus.example.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
+    monkeypatch.setenv("MODEL_DRAFT", "")
+    monkeypatch.setenv("MODEL_SUGGEST", "")
+    monkeypatch.setenv("MODEL_QA", "")
+    monkeypatch.delenv("AZURE_KEY_INVALID", raising=False)
+    client, modules = _reload_app()
+    try:
+        r = client.get("/health")
+        assert r.status_code == 200
+        models = r.json()["llm"]["models"]
+        assert models["draft"] == "gpt-4o-mini"
+        assert models["suggest"] == "gpt-4o-mini"
+        assert models["qa"] == "gpt-4o-mini"
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)


### PR DESCRIPTION
## Summary
- mask and log LLM config with env precedence, ignoring empty model overrides
- expose Azure metadata and runtime key validation in provider and ping endpoint
- document LLM env vars and cover ping scenarios in tests

## Testing
- `curl -k https://localhost:9443/health` *(fails: Couldn't connect to server)*
- `curl -k https://localhost:9443/api/llm/ping` *(fails: Couldn't connect to server)*
- `pytest -q contract_review_app/tests/api/test_llm_ping.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb18c5a5c8325a3f340c9e98b25a9