### PR TITLE
feat: add one-click start script

### DIFF
--- a/ContractAI-Start.bat
+++ b/ContractAI-Start.bat
@@ -1,26 +1,4 @@
 @echo off
-setlocal enableextensions
+setlocal
 cd /d "%~dp0"
-
-set PY=.venv\Scripts\python.exe
-if not exist "%PY%" (
-echo [ERR] .venv not found. Run: python -m venv .venv && .venv\Scripts\pip install -r requirements.txt
-exit /b 1
-)
-
-set CERT=word_addin_dev\certs\panel-cert.pem
-set KEY=word_addin_dev\certs\panel-key.pem
-set PORT=9443
-
-rem (опционально) показать какой питон используем
-echo [INFO] Using "%PY%"
-
-rem старт uvicorn с TLS на localhost
-"%PY%" -m uvicorn contract_review_app.api.app:app ^
---host localhost --port %PORT% ^
---ssl-certfile "%CERT%" --ssl-keyfile "%KEY%" ^
---log-level info --reload ^
---proxy-headers
-
-rem открыть панель
-start "" "https://localhost:%PORT%/panel/panel_selftest.html?v=dev"
+powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File tools\start_oneclick.ps1 -OpenWord:$True %*

--- a/contract_review_app/tests/panel/test_panel_urls.py
+++ b/contract_review_app/tests/panel/test_panel_urls.py
@@ -6,7 +6,7 @@ SELFTEST = ROOT / "word_addin_dev" / "panel_selftest.html"
 
 def test_panel_selftest_default_backend_is_https9443():
     html = SELFTEST.read_text(encoding="utf-8")
-    assert "https://127.0.0.1:9443" in html
+    assert "https://localhost:9443" in html
 
 
 def test_panel_selftest_uses_unified_ls_key():

--- a/tests/start_oneclick.Tests.ps1
+++ b/tests/start_oneclick.Tests.ps1
@@ -1,0 +1,15 @@
+$root = Split-Path -Parent $PSScriptRoot
+. "$root/tools/start_oneclick.ps1"
+
+Describe 'Wait-BackendHealth' {
+    It 'returns true when health eventually ok' {
+        $call = 0
+        Mock -CommandName Test-NetConnection { @{ TcpTestSucceeded = $true } }
+        Mock -CommandName Invoke-WebRequest {
+            $script:call++
+            if ($script:call -lt 2) { throw 'not ready' }
+            @{ StatusCode = 200 }
+        }
+        Wait-BackendHealth -TimeoutSeconds 5 | Should -BeTrue
+    }
+}

--- a/tests/test_llm_ping.py
+++ b/tests/test_llm_ping.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from fastapi.testclient import TestClient
+
+
+def reload_app():
+    for mod in ["contract_review_app.api", "contract_review_app.api.app"]:
+        sys.modules.pop(mod, None)
+    from contract_review_app.api import app as app_module
+
+    importlib.reload(app_module)
+    return TestClient(app_module.app)
+
+
+def test_llm_ping_mock(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    client = reload_app()
+    r = client.get("/api/llm/ping")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+def test_llm_ping_invalid_key(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "azure")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "")
+    client = reload_app()
+    r = client.get("/api/llm/ping")
+    assert r.status_code == 400
+    body = r.json()
+    assert body.get("code") == "invalid_llm_key"

--- a/tools/start_oneclick.ps1
+++ b/tools/start_oneclick.ps1
@@ -1,0 +1,116 @@
+#requires -version 5.1
+[CmdletBinding()]
+param(
+    [switch]$OpenWord,
+    [switch]$CreateShortcut
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+Set-Location $repo
+
+$logFile = Join-Path $env:TEMP 'ContractAI-oneclick.log'
+function Write-Log {
+    param([string]$Message)
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    try { "$ts $Message" | Out-File -FilePath $logFile -Append -Encoding UTF8 } catch {}
+}
+
+function Load-DotEnv {
+    param([string]$Path)
+    if (!(Test-Path $Path)) { Write-Log "[WARN] .env not found"; return }
+    foreach ($line in Get-Content $Path) {
+        if ($line -match '^\s*$' -or $line -match '^\s*#') { continue }
+        $parts = $line -split '=',2
+        if ($parts.Count -ne 2) { continue }
+        $k = $parts[0].Trim()
+        $v = $parts[1].Trim()
+        if ([string]::IsNullOrEmpty($env:$k)) {
+            $env:$k = $v
+        }
+    }
+    Write-Log '[OK] .env loaded'
+}
+
+function Ensure-Certs {
+    $cert = Join-Path $repo 'word_addin_dev\certs\localhost.pem'
+    $key  = Join-Path $repo 'word_addin_dev\certs\localhost-key.pem'
+    if (!(Test-Path $cert) -or !(Test-Path $key)) {
+        Write-Log '[INFO] generating dev certs'
+        & "$repo\.venv\Scripts\python.exe" "$repo\word_addin_dev\gen_dev_certs.py" | Out-Null
+    }
+    return @{cert=$cert; key=$key}
+}
+
+function Start-Backend {
+    param([string]$Cert, [string]$Key)
+    $py = Join-Path $repo '.venv\Scripts\python.exe'
+    $args = @('-m','uvicorn','contract_review_app.api.app:app','--host','localhost','--port','9443',
+              '--ssl-certfile',$Cert,'--ssl-keyfile',$Key)
+    Start-Process -FilePath $py -ArgumentList $args -WindowStyle Minimized -WorkingDirectory $repo | Out-Null
+    Write-Log '[OK] backend started'
+}
+
+function Wait-BackendHealth {
+    param(
+        [string]$Url = 'https://localhost:9443/health',
+        [int]$TimeoutSeconds = 30
+    )
+    for ($i=0; $i -lt $TimeoutSeconds; $i++) {
+        try {
+            $tcp = Test-NetConnection -ComputerName 'localhost' -Port 9443 -WarningAction SilentlyContinue
+            if ($tcp.TcpTestSucceeded) {
+                $r = Invoke-WebRequest -UseBasicParsing -Uri $Url -TimeoutSec 2 -SkipCertificateCheck
+                if ($r.StatusCode -eq 200) { return $true }
+            }
+        } catch {}
+        Start-Sleep -Seconds 1
+    }
+    return $false
+}
+
+function Open-Panel {
+    Start-Process 'https://localhost:9443/panel/panel_selftest.html?v=dev'
+    Write-Log '[OK] panel opened'
+}
+
+function Sideload-Word {
+    $src = Join-Path $repo 'word_addin_dev\manifest.xml'
+    $dst = Join-Path $env:LOCALAPPDATA 'Microsoft\Office\16.0\Wef'
+    New-Item -ItemType Directory -Path $dst -Force | Out-Null
+    Copy-Item $src (Join-Path $dst 'manifest.xml') -Force
+    Start-Process WINWORD.EXE | Out-Null
+    Write-Log '[OK] Word launched'
+}
+
+function Create-Shortcut {
+    $shell = New-Object -ComObject WScript.Shell
+    $desktop = [Environment]::GetFolderPath('Desktop')
+    $lnk = Join-Path $desktop 'Contract AI — Start.lnk'
+    $sc = $shell.CreateShortcut($lnk)
+    $sc.TargetPath = Join-Path $repo 'ContractAI-Start.bat'
+    $sc.WorkingDirectory = $repo
+    $sc.Save()
+    Write-Log '[OK] shortcut created'
+}
+
+function Start-OneClick {
+    Write-Log '[INFO] starting oneclick'
+    $act = Join-Path $repo '.venv\Scripts\Activate.ps1'
+    if (Test-Path $act) { . $act }
+    Load-DotEnv (Join-Path $repo '.env')
+    $c = Ensure-Certs
+    Start-Backend -Cert $c.cert -Key $c.key
+    if (Wait-BackendHealth) {
+        Write-Log '[OK] health ready'
+        Open-Panel
+        if ($OpenWord) { Sideload-Word }
+        if ($CreateShortcut) { Create-Shortcut }
+    } else {
+        Write-Log '[ERR] health timeout'
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Start-OneClick
+}

--- a/word_addin_dev/app/selftest.js
+++ b/word_addin_dev/app/selftest.js
@@ -65,9 +65,9 @@ function joinUrl(base, path){
 }
 function saveBase(){ try{ const v=document.getElementById("backendInput").value.trim(); localStorage.setItem(LS_KEY, v); localStorage.setItem("backendUrl", v); }catch{} }
 function loadBase(){
-  let v = localStorage.getItem(LS_KEY) || document.getElementById("backendInput").value || "https://127.0.0.1:9443";
+  let v = localStorage.getItem(LS_KEY) || document.getElementById("backendInput").value || "https://localhost:9443";
   v = normBase(v);
-  document.getElementById("backendInput").value = v || "https://127.0.0.1:9443";
+  document.getElementById("backendInput").value = v || "https://localhost:9443";
   try{ localStorage.setItem("backendUrl", v); }catch{}
   return v;
 }
@@ -203,6 +203,9 @@ async function testHealth(){
   const r = await callEndpoint({ name:"health", method:"GET", path:"/health" });
   setStatusRow("row-health", r);
   showResp(r);
+  if (r.body) {
+    showMeta(r.body.meta || r.body.llm || {});
+  }
   return r;
 }
 function getSampleText(){

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -47,7 +47,7 @@
 
   <div class="row">
     <label for="backendInput">Backend URL:</label>
-    <input id="backendInput" type="text" value="https://127.0.0.1:9443" class="mono" />
+    <input id="backendInput" type="text" value="https://localhost:9443" class="mono" />
     <button id="saveBtn">Save</button>
     <label for="apiKeyInput">API Key:</label>
     <input id="apiKeyInput" type="text" class="mono" style="width:140px" />


### PR DESCRIPTION
## Summary
- add one-click PowerShell starter that generates certs, waits for /health and optionally opens Word
- open panel self-test against https://localhost:9443 and surface LLM info
- add tests for panel defaults and LLM ping plus Pester helper

## Testing
- `pre-commit run --files tools/start_oneclick.ps1 ContractAI-Start.bat word_addin_dev/panel_selftest.html word_addin_dev/app/selftest.js contract_review_app/tests/panel/test_panel_urls.py tests/test_llm_ping.py tests/start_oneclick.Tests.ps1`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/start_oneclick.Tests.ps1 -EnableExit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb39baf648325b63cd4a1382f6c57