### PR TITLE
Fix self-test parsing and PowerShell env loader

### DIFF
--- a/contract_review_app/tests/panel/test_panel_urls.py
+++ b/contract_review_app/tests/panel/test_panel_urls.py
@@ -20,3 +20,10 @@ def test_normbase_forces_https_for_9443():
     assert (
         "replace(/^http:\/\/(127\\.0\\.0\\.1|localhost)(:9443)" in html
     ), "normBase must force https for :9443"
+
+
+def test_selftest_has_llm_fields():
+    html = SELFTEST.read_text(encoding="utf-8")
+    assert 'id="llmProv"' in html
+    assert 'id="llmModel"' in html
+    assert 'id="llmBadge"' in html

--- a/tests/panel/test_selftest_call.js
+++ b/tests/panel/test_selftest_call.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+let code = fs.readFileSync(__dirname + '/../../word_addin_dev/app/selftest.js', 'utf8');
+
+const sandbox = {
+  console,
+  alert: () => {},
+  fetch: async (url, opts = {}) => {
+    // health endpoint should not send x-api-key
+    assert.ok(url.endsWith('/health'));
+    assert.ok(!opts.headers || !('x-api-key' in opts.headers));
+    const headers = new Map([
+      ['x-cid', 'cid-h'],
+      ['x-schema-version', '1.0'],
+      ['x-latency-ms', '42']
+    ]);
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: k => headers.get(k) },
+      json: async () => ({ status: 'ok', llm:{provider:'p',model:'m',mode:'mock'} })
+    };
+  },
+  CAI: {
+    API: {
+      analyze: async (text) => {
+        assert.strictEqual(sandbox.localStorage.getItem('api_key'), 'KEY123');
+        const headers = new Map([
+          ['x-cid', 'cid-a'],
+          ['x-schema-version', '1.1'],
+          ['x-latency-ms', '7']
+        ]);
+        return { ok:true, resp:{ status:200, headers:{ get: k => headers.get(k) } }, json:{ status:'ok', meta:{} } };
+      }
+    },
+    Store: { setBase: () => {}, get: () => ({}) }
+  },
+  document: {
+    getElementById: (id) => {
+      const el = { value: '', textContent: '', style:{}, className:'', addEventListener: () => {} };
+      if (id === 'backendInput') el.value = 'https://localhost:9443';
+      if (id === 'apiKeyInput') el.value = 'KEY123';
+      return el;
+    },
+    querySelector: () => ({})
+  },
+  localStorage: {
+    _data: { 'api_key': 'OLD' },
+    getItem(k){ return this._data[k] || null; },
+    setItem(k,v){ this._data[k] = String(v); },
+    removeItem(k){ delete this._data[k]; }
+  },
+  addEventListener: () => {}
+};
+sandbox.window = sandbox; sandbox.self = sandbox;
+
+vm.runInNewContext(code, sandbox);
+
+(async () => {
+  const rHealth = await sandbox.callEndpoint({ name:'health', method:'GET', path:'/health' });
+  assert.strictEqual(rHealth.code, 200);
+  assert.strictEqual(rHealth.xcid, 'cid-h');
+  assert.strictEqual(rHealth.xschema, '1.0');
+  const rAnalyze = await sandbox.callEndpoint({ name:'analyze', method:'POST', path:'/api/analyze', body:{text:'hi'} });
+  assert.strictEqual(rAnalyze.code, 200);
+  assert.strictEqual(rAnalyze.xcid, 'cid-a');
+  console.log('selftest call tests ok');
+})();

--- a/tools/start_oneclick.ps1
+++ b/tools/start_oneclick.ps1
@@ -25,8 +25,9 @@ function Load-DotEnv {
         if ($parts.Count -ne 2) { continue }
         $k = $parts[0].Trim()
         $v = $parts[1].Trim()
-        if ([string]::IsNullOrEmpty($env:$k)) {
-            $env:$k = $v
+        $cur = [System.Environment]::GetEnvironmentVariable($k, "Process")
+        if ([string]::IsNullOrEmpty($cur)) {
+            [System.Environment]::SetEnvironmentVariable($k, $v, "Process")
         }
     }
     Write-Log '[OK] .env loaded'


### PR DESCRIPTION
## Summary
- update panel self-test to read HTTP status, headers and JSON from current API client
- ensure self-test sends x-api-key on requests and respects Backend URL temporarily
- repair start_oneclick.ps1 env loader using Get/SetEnvironmentVariable and add tests

## Testing
- `node tests/panel/test_store_state.js`
- `node tests/panel/test_selftest_call.js`
- `pytest` *(fails: 90 errors during collection)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/start_oneclick.Tests.ps1"` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_68beb9c7bf0c8325a4434ea192fd301b