### PR TITLE
feat: build self-test UI from OpenAPI

### DIFF
--- a/tests/panel/test_panel_urls.py
+++ b/tests/panel/test_panel_urls.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+def test_panel_selftest_defaults():
+    html = (Path(__file__).resolve().parents[2] / "word_addin_dev" / "panel_selftest.html").read_text(encoding="utf-8")
+    assert "https://localhost:9443" in html
+    assert "/api/analyze" not in html

--- a/tests/panel/test_selftest_build.js
+++ b/tests/panel/test_selftest_build.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+let code = fs.readFileSync(__dirname + '/../../word_addin_dev/app/selftest.js', 'utf8');
+
+const btns = { html:'', insertAdjacentHTML(pos, html){ this.html += html; } };
+const body = { html:'', insertAdjacentHTML(pos, html){ this.html += html; } };
+
+const sandbox = {
+  console,
+  alert: () => {},
+  onClick: () => {},
+  runGeneric: () => {},
+  document: {
+    getElementById: (id) => {
+      if (id === 'testsBtns') return btns;
+      if (id === 'statusBody') return body;
+      return { addEventListener: () => {}, getElementsByTagName: () => [], style:{}, value:'', textContent:'' };
+    },
+    querySelector: () => ({})
+  },
+  localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+  CAI: { API:{}, Store:{ setBase:()=>{}, get:()=>({}) } },
+  addEventListener: () => {}
+};
+
+sandbox.window = sandbox; sandbox.self = sandbox;
+vm.runInNewContext(code, sandbox);
+
+const paths = {
+  '/api/analyze': { post: {} },
+  '/api/gpt-draft': { post: {} },
+  '/api/trace/{cid}': { get: {} }
+};
+
+sandbox.buildRowsFromOpenAPI(paths);
+
+const btnCount = (btns.html.match(/<button/g) || []).length;
+const rowCount = (body.html.match(/<tr/g) || []).length;
+assert.strictEqual(btnCount, 3);
+assert.strictEqual(rowCount, 3);
+assert.ok(btns.html.includes('POST /api/analyze'));
+assert.ok(btns.html.includes('POST /api/gpt-draft'));
+assert.ok(btns.html.includes('GET /api/trace'));
+assert.ok(!btns.html.includes('qa-recheck'));
+
+console.log('selftest build tests ok');

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -65,16 +65,7 @@
 
     <div class="card">
       <h3>Tests</h3>
-      <div class="btns" style="margin-bottom:8px;">
-        <button id="btnHealth">GET /health</button>
-        <button id="btnAnalyze">POST /api/analyze</button>
-        <button id="btnSummary">POST /api/summary</button>
-        <button id="btnDraft">POST /api/gpt-draft</button>
-        <button id="btnSuggest">POST /api/suggest_edits</button>
-        <button id="btnQA">POST /api/qa-recheck</button>
-        <button id="btnCalloff">POST /api/calloff/validate</button>
-        <button id="btnTrace">GET /api/trace/{cid}</button>
-      </div>
+      <div class="btns" id="testsBtns" style="margin-bottom:8px;"></div>
       <div class="small">CID used for requests: <span id="cidLbl" class="mono pill"></span></div>
       <div class="small">Last response CID (from headers): <span id="lastCidLbl" class="mono pill"></span></div>
       <div style="overflow:auto;">
@@ -90,16 +81,7 @@
               <th>status</th>
             </tr>
           </thead>
-          <tbody>
-            <tr id="row-health"><td>GET /health</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-            <tr id="row-analyze"><td>POST /api/analyze</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-            <tr id="row-summary"><td>POST /api/summary</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-            <tr id="row-draft"><td>POST /api/gpt-draft</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-            <tr id="row-suggest"><td>POST /api/suggest_edits</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-            <tr id="row-qa"><td>POST /api/qa-recheck</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-            <tr id="row-calloff"><td>POST /api/calloff/validate</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-            <tr id="row-trace"><td>GET /api/trace/{cid}</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-          </tbody>
+          <tbody id="statusBody"></tbody>
         </table>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- generate panel self-test buttons and rows from `/openapi.json`
- remove hardcoded endpoint list in self-test panel
- add tests for dynamic self-test construction

## Testing
- `python -m pytest tests/panel/test_panel_urls.py`
- `node tests/panel/test_selftest_build.js`
- `node tests/panel/test_selftest_call.js`


------
https://chatgpt.com/codex/tasks/task_e_68bed01d3b548325ab2877d0224cf1c7