### PR TITLE
feat: show LLM mode and ping latency in self-test

### DIFF
--- a/tests/panel/test_llm_banner.js
+++ b/tests/panel/test_llm_banner.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const elements = {
+  llmProv: { textContent: '' },
+  llmModel: { textContent: '' },
+  llmLatency: { textContent: '', className: '' },
+  llmBadge: { style: { display: 'none' } },
+  backendInput: { value: 'https://localhost:9443' },
+  apiKeyInput: { value: '' },
+  cidLbl: { textContent: '' },
+  lastCidLbl: { textContent: '' },
+  resp: { textContent: '' },
+};
+
+const calls = [];
+
+const sandbox = {
+  console,
+  alert: () => {},
+  document: {
+    getElementById: id => elements[id] || { textContent: '', style: {}, className: '', addEventListener: () => {} },
+    querySelector: () => ({})
+  },
+  localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+  addEventListener: (ev, fn) => { if (ev === 'DOMContentLoaded') sandbox._dom = fn; },
+  CAI: {
+    API: {
+      get: async path => {
+        calls.push(path);
+        if (path === '/health') {
+          return {
+            ok: true,
+            json: { status: 'ok', llm: { provider: 'mock', models: { draft: 'mock-static' }, mode: 'mock' } },
+            resp: { status: 200, headers: { get: () => null } },
+            meta: {}
+          };
+        }
+        if (path === '/api/llm/ping') {
+          return {
+            ok: true,
+            json: { status: 'ok' },
+            resp: { status: 200, headers: { get: k => (k === 'x-latency-ms' ? '7' : null) } },
+            meta: { latencyMs: 7 }
+          };
+        }
+        throw new Error('unexpected path ' + path);
+      }
+    },
+    Store: { setBase: () => {}, get: () => ({}) }
+  }
+};
+
+sandbox.window = sandbox; sandbox.self = sandbox;
+
+const code = fs.readFileSync(__dirname + '/../../word_addin_dev/app/selftest.js', 'utf8');
+vm.runInNewContext(code, sandbox);
+
+// Stub openapi loader to avoid network
+sandbox.loadOpenAPI = async () => ({});
+sandbox.buildRowsFromOpenAPI = () => {};
+
+(async () => {
+  await sandbox._dom();
+  assert.strictEqual(calls[0], '/health');
+  assert.strictEqual(elements.llmProv.textContent, 'mock');
+  assert.strictEqual(elements.llmModel.textContent, 'mock-static');
+  assert.strictEqual(elements.llmLatency.textContent, 'mock');
+  assert.strictEqual(elements.llmLatency.className, 'ok');
+  await sandbox.pingLLM();
+  assert.ok(calls.includes('/api/llm/ping'));
+  assert.strictEqual(elements.llmLatency.textContent, '7ms');
+  assert.strictEqual(elements.llmLatency.className, 'ok');
+  console.log('llm banner tests ok');
+})();


### PR DESCRIPTION
## Summary
- fetch `/health` on load to display LLM provider, model, and mode
- add ping button calling `/api/llm/ping` and treat mock mode as ok
- add unit test for banner and latency display

## Testing
- `pre-commit run --files word_addin_dev/app/selftest.js tests/panel/test_llm_banner.js`
- `node tests/panel/test_selftest_build.js && node tests/panel/test_selftest_call.js && node tests/panel/test_store_state.js && node tests/panel/test_llm_banner.js && npx mocha tests/panel/test_parse_findings.js`
- `pytest tests/test_llm_ping.py`


------
https://chatgpt.com/codex/tasks/task_e_68bed40224cc8325a5f80ce93c4a83c4