### PR TITLE
docs: mention PyYAML requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Contract AI
 
+## Installation
+
+Install required packages and verify that **PyYAML** is available for rule pack parsing by `/api/analyze`:
+
+```bash
+pip install -r requirements.txt
+python -c "import yaml"
+```
+
 ## LLM config
 
 Environment variables controlling the language model provider:
@@ -34,7 +43,8 @@ Defaults use a deterministic mock model so the application works without keys. S
 The `/health` endpoint verifies that required rule engine dependencies are
 available. It attempts to import **PyYAML** and load rule packs during
 application start. If these checks fail, `/health` reports a non-OK status
-so deployments can detect missing dependencies.
+so deployments can detect missing dependencies. PyYAML must be present or
+`/api/analyze` will not load rule packs.
 
 ## Word Add-in
 

--- a/docs/codex/RUNBOOK.md
+++ b/docs/codex/RUNBOOK.md
@@ -1,4 +1,13 @@
-﻿# RUNBOOK
+# RUNBOOK
+
+## Setup
+
+Install dependencies and confirm **PyYAML** is installed so `/api/analyze` can parse rule packs:
+
+```bash
+pip install -r requirements.txt
+python -c "import yaml"
+```
 
 ## Panel (HTTPS 3000)
 python .\word_addin_dev\serve_https_panel.py 


### PR DESCRIPTION
## Summary
- document PyYAML requirement for `/api/analyze` and add a quick import check
- note PyYAML setup step in deployment runbook

## Testing
- `python -c "import yaml; print('ok')"`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', No module named 'fpdf', No module named 'respx')*

------
https://chatgpt.com/codex/tasks/task_e_68bee169e4bc832588908b22a6eeb4f9