### PR TITLE
raise ProviderError for misconfigured Azure provider

### DIFF
--- a/contract_review_app/llm/provider.py
+++ b/contract_review_app/llm/provider.py
@@ -137,10 +137,8 @@ def get_provider():
     # explicit selector; env var wins
     # hint for local runs: set LLM_PROVIDER=azure
     want = (os.getenv("LLM_PROVIDER") or "").lower()
+    if want in {"", "mock"}:
+        return MockProvider()
     if want == "azure":
-        try:
-            return AzureProvider()
-        except ProviderError:
-            # fall through to mock if misconfigured
-            return MockProvider()
-    return MockProvider()
+        return AzureProvider()
+    raise ProviderError(f"Unsupported LLM_PROVIDER: {want}")

--- a/tests/api/test_llm_provider.py
+++ b/tests/api/test_llm_provider.py
@@ -1,0 +1,16 @@
+import pytest
+from contract_review_app.llm.provider import get_provider, ProviderError
+
+
+def test_missing_azure_env_raises(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "azure")
+    # Ensure required Azure variables are not set
+    for var in (
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_OPENAI_API_VERSION",
+        "AZURE_OPENAI_DEPLOYMENT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(ProviderError):
+        get_provider()

--- a/tests/test_llm_ping.py
+++ b/tests/test_llm_ping.py
@@ -22,7 +22,10 @@ def test_llm_ping_mock(monkeypatch):
 
 def test_llm_ping_invalid_key(monkeypatch):
     monkeypatch.setenv("LLM_PROVIDER", "azure")
-    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "changeme")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://eastus.example.com")
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")
     client = reload_app()
     r = client.get("/api/llm/ping")
     assert r.status_code == 400


### PR DESCRIPTION
## Summary
- prevent silent fallback to mock provider when `LLM_PROVIDER=azure` and configuration is invalid
- only default to `MockProvider` when provider is unset or `mock`
- add regression test to ensure missing Azure env vars raise `ProviderError`
- adjust ping test to supply full Azure config

## Testing
- `pre-commit run --files contract_review_app/llm/provider.py tests/test_llm_ping.py tests/api/test_llm_provider.py`
- `pytest tests/api/test_llm_provider.py tests/test_llm_ping.py`


------
https://chatgpt.com/codex/tasks/task_e_68bee42d67ec83258b94950cd7cd1809