### PR TITLE
feat: detail missing Azure env vars

### DIFF
--- a/contract_review_app/llm/provider.py
+++ b/contract_review_app/llm/provider.py
@@ -58,8 +58,17 @@ class AzureProvider:
             or os.getenv("AZURE_OPENAI_API_KEY")
             or os.getenv("OPENAI_API_KEY")
         )
-        if not (ep and dep and ver and key):
-            raise ProviderError("Azure env is incomplete")
+        missing = []
+        if not ep:
+            missing.append("AZURE_OPENAI_ENDPOINT")
+        if not dep:
+            missing.append("AZURE_OPENAI_DEPLOYMENT")
+        if not ver:
+            missing.append("AZURE_OPENAI_API_VERSION")
+        if not key:
+            missing.append("AZURE_OPENAI_API_KEY")
+        if missing:
+            raise ProviderError("Azure env vars missing: " + ", ".join(missing))
         self.endpoint = ep.rstrip("/")
         self.deployment = dep
         self.api_version = ver

--- a/tests/api/test_llm_provider.py
+++ b/tests/api/test_llm_provider.py
@@ -12,5 +12,10 @@ def test_missing_azure_env_raises(monkeypatch):
         "AZURE_OPENAI_DEPLOYMENT",
     ):
         monkeypatch.delenv(var, raising=False)
-    with pytest.raises(ProviderError):
+    with pytest.raises(ProviderError) as exc:
         get_provider()
+    expected = (
+        "Azure env vars missing: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT, "
+        "AZURE_OPENAI_API_VERSION, AZURE_OPENAI_API_KEY"
+    )
+    assert str(exc.value) == expected


### PR DESCRIPTION
## Summary
- include specific missing Azure env var names in provider error message
- update unit test to assert detailed error output

## Testing
- `pytest tests/api/test_llm_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee58572088325a54a6f88c79c0b58