### PR TITLE
feat: add dev fallback for audit encryption

### DIFF
--- a/contract_review_app/core/audit.py
+++ b/contract_review_app/core/audit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -25,7 +26,14 @@ def audit(event: str, user: Optional[str], doc_hash: Optional[str], details: Dic
     }
     if details:
         record.update(details)
-    secure_write(os.path.join("var", "audit.log"), json.dumps(record, sort_keys=True), append=True)
+    try:
+        secure_write(
+            os.path.join("var", "audit.log"),
+            json.dumps(record, sort_keys=True),
+            append=True,
+        )
+    except Exception as exc:  # pragma: no cover - rare
+        logging.warning("failed to write audit log: %s", exc)
 
 
 __all__ = ["audit"]

--- a/contract_review_app/security/secure_store.py
+++ b/contract_review_app/security/secure_store.py
@@ -1,19 +1,37 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
 from cryptography.fernet import Fernet
 
-_cipher: Fernet | None = None
+
+class _NoopCipher:
+    """Identity cipher used when encryption key is missing in dev."""
+
+    def encrypt(self, data: bytes) -> bytes:  # pragma: no cover - trivial
+        return data
+
+    def decrypt(self, token: bytes) -> bytes:  # pragma: no cover - trivial
+        return token
 
 
-def _get_cipher() -> Fernet:
+_cipher: Fernet | _NoopCipher | None = None
+
+
+def _get_cipher() -> Fernet | _NoopCipher:
     global _cipher
     if _cipher is not None:
         return _cipher
     key = os.getenv("CR_ATREST_KEY")
     if not key:
+        if os.getenv("ENV", "dev").lower() != "prod":
+            logging.warning(
+                "CR_ATREST_KEY not set; audit log will be stored in plaintext"
+            )
+            _cipher = _NoopCipher()
+            return _cipher
         raise RuntimeError("CR_ATREST_KEY not set")
     # assume key is standard Fernet key (base64 urlsafe)
     _cipher = Fernet(key)

--- a/tests/api/test_analyze.py
+++ b/tests/api/test_analyze.py
@@ -1,0 +1,47 @@
+import json
+import logging
+from importlib import reload
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+
+import contract_review_app.security.secure_store as secure_store
+import contract_review_app.core.audit as audit_module
+import contract_review_app.api.app as app_module
+
+
+def _make_client(monkeypatch, tmp_path: Path) -> TestClient:
+    monkeypatch.chdir(tmp_path)
+    reload(secure_store)
+    reload(audit_module)
+    reload(app_module)
+    return TestClient(app_module.app)
+
+
+def test_analyze_ok_without_atrest_key(tmp_path, monkeypatch, caplog):
+    """DEV fallback: no key still results in 200 and plaintext audit log."""
+
+    monkeypatch.delenv("CR_ATREST_KEY", raising=False)
+    client = _make_client(monkeypatch, tmp_path)
+    with caplog.at_level(logging.WARNING):
+        resp = client.post("/api/analyze", json={"text": "hi", "language": "en"})
+    assert resp.status_code == 200
+    assert "CR_ATREST_KEY not set" in caplog.text
+    raw = (Path("var") / "audit.log").read_bytes()
+    assert b"{" in raw  # stored without encryption
+
+
+def test_audit_encrypts_when_key_present(tmp_path, monkeypatch):
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("CR_ATREST_KEY", key)
+    client = _make_client(monkeypatch, tmp_path)
+    resp = client.post("/api/analyze", json={"text": "hi", "language": "en"})
+    assert resp.status_code == 200
+    path = Path("var") / "audit.log"
+    raw = path.read_bytes().strip()
+    assert raw and b"{" not in raw
+    decrypted = secure_store.secure_read(path)
+    assert decrypted != raw
+    json.loads(decrypted)
+


### PR DESCRIPTION
## Summary
- handle missing `CR_ATREST_KEY` in dev by logging a warning and writing audit logs without encryption
- guard audit logging to avoid crashes when encryption fails
- test audit log plaintext fallback and encryption with key

## Testing
- `pytest tests/api/test_analyze.py -q`
- `pytest tests/security/test_at_rest_encryption.py -q`
- `pytest tests/security/test_dsar_endpoints.py -q`
- `pytest tests/api/test_analyze_minimal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef0b987848325a1a4f90ed296245f