### PR TITLE
Normalize QA rules, unify trace store, add citation resolver models

### DIFF
--- a/contract_review_app/api/error_handlers.py
+++ b/contract_review_app/api/error_handlers.py
@@ -14,7 +14,12 @@ def register_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(RequestValidationError)
     async def _handle_validation_error(request: Request, exc: RequestValidationError):
         """Return pydantic validation details untouched."""
-        resp = JSONResponse({"detail": exc.errors()}, status_code=422)
+        detail = exc.errors()
+        for err in detail:
+            ctx = err.get("ctx")
+            if ctx and "error" in ctx:
+                ctx["error"] = str(ctx["error"])
+        resp = JSONResponse({"detail": detail}, status_code=422)
         apply_std_headers(
             resp, request, getattr(request.state, "started_at", time.perf_counter())
         )

--- a/contract_review_app/gpt/gpt_draft_api.py
+++ b/contract_review_app/gpt/gpt_draft_api.py
@@ -250,3 +250,13 @@ def api_gpt_draft_gptdto(payload: Dict[str, Any], response: Response) -> GPTDraf
 @router.post("/api/gpt/draft", include_in_schema=False)
 def api_gpt_draft_redirect():
     return Response(status_code=307, headers={"Location": "/api/gpt-draft"})
+
+
+@router.post("/api/gpt_draft", include_in_schema=False)
+def api_gpt_draft_redirect_uscore():
+    return Response(status_code=307, headers={"Location": "/api/gpt-draft"})
+
+
+@router.post("/gpt-draft", include_in_schema=False)
+def api_gpt_draft_redirect_plain():
+    return Response(status_code=307, headers={"Location": "/api/gpt-draft"})

--- a/openapi.json
+++ b/openapi.json
@@ -1,360 +1,680 @@
 {
-  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "Acceptance": {
+        "properties": {
+          "acceptance_rate": {
+            "title": "Acceptance Rate",
+            "type": "number"
+          },
+          "applied": {
+            "title": "Applied",
+            "type": "integer"
+          },
+          "rejected": {
+            "title": "Rejected",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "applied",
+          "rejected",
+          "acceptance_rate"
+        ],
+        "title": "Acceptance",
+        "type": "object"
+      },
+      "AnalyzeRequest": {
+        "additionalProperties": false,
+        "description": "Public request DTO for ``/api/analyze``.\n\nAccepts ``text`` as a required field while allowing legacy aliases\n``clause`` and ``body`` for backward compatibility. The aliases are\nfolded into ``text`` during validation so downstream logic only needs to\nhandle a single attribute.",
+        "example": {
+          "text": "Hello"
+        },
+        "properties": {
+          "language": {
+            "default": "en",
+            "title": "Language",
+            "type": "string"
+          },
+          "mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mode"
+          },
+          "risk": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Risk"
+          },
+          "text": {
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "AnalyzeRequest",
+        "type": "object"
+      },
+      "AnalyzeResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "analysis": {
+            "additionalProperties": true,
+            "title": "Analysis",
+            "type": "object"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "analysis"
+        ],
+        "title": "AnalyzeResponse",
+        "type": "object"
+      },
+      "CitationInput": {
+        "additionalProperties": false,
+        "properties": {
+          "instrument": {
+            "title": "Instrument",
+            "type": "string"
+          },
+          "section": {
+            "title": "Section",
+            "type": "string"
+          }
+        },
+        "required": [
+          "instrument",
+          "section"
+        ],
+        "title": "CitationInput",
+        "type": "object"
+      },
+      "CitationResolveRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "citations": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CitationInput"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Citations"
+          },
+          "findings": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/QaFindingInput"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Findings"
+          }
+        },
+        "title": "CitationResolveRequest",
+        "type": "object"
+      },
+      "CitationResolveResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "citations": {
+            "items": {
+              "$ref": "#/components/schemas/CitationInput"
+            },
+            "title": "Citations",
+            "type": "array"
+          }
+        },
+        "required": [
+          "citations"
+        ],
+        "title": "CitationResolveResponse",
+        "type": "object"
+      },
+      "Coverage": {
+        "properties": {
+          "coverage": {
+            "title": "Coverage",
+            "type": "number"
+          },
+          "rules_fired": {
+            "title": "Rules Fired",
+            "type": "integer"
+          },
+          "rules_total": {
+            "title": "Rules Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "rules_total",
+          "rules_fired",
+          "coverage"
+        ],
+        "title": "Coverage",
+        "type": "object"
+      },
+      "DraftIn": {
+        "properties": {
+          "after_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "After Text"
+          },
+          "before_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Before Text"
+          },
+          "language": {
+            "default": "en",
+            "title": "Language",
+            "type": "string"
+          },
+          "mode": {
+            "default": "medium",
+            "enum": [
+              "friendly",
+              "medium",
+              "strict"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "text": {
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "DraftIn",
+        "type": "object"
+      },
+      "DraftOut": {
+        "properties": {
+          "after_text": {
+            "title": "After Text",
+            "type": "string"
+          },
+          "before_text": {
+            "title": "Before Text",
+            "type": "string"
+          },
+          "context_after": {
+            "title": "Context After",
+            "type": "string"
+          },
+          "context_before": {
+            "title": "Context Before",
+            "type": "string"
+          },
+          "diff": {
+            "additionalProperties": true,
+            "title": "Diff",
+            "type": "object"
+          },
+          "evidence": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              }
+            ],
+            "title": "Evidence"
+          },
+          "mode": {
+            "title": "Mode",
+            "type": "string"
+          },
+          "proposed_text": {
+            "title": "Proposed Text",
+            "type": "string"
+          },
+          "rationale": {
+            "title": "Rationale",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "x_schema_version": {
+            "title": "X Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "mode",
+          "proposed_text",
+          "rationale",
+          "evidence",
+          "before_text",
+          "after_text",
+          "diff",
+          "x_schema_version",
+          "context_before",
+          "context_after"
+        ],
+        "title": "DraftOut",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "LearningUpdateIn": {
+        "properties": {
+          "force": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": false,
+            "title": "Force"
+          }
+        },
+        "title": "LearningUpdateIn",
+        "type": "object"
+      },
+      "MetricsResponse": {
+        "properties": {
+          "metrics": {
+            "$ref": "#/components/schemas/QualityMetrics"
+          },
+          "schema_version": {
+            "default": "1.3",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "snapshot_at": {
+            "format": "date-time",
+            "title": "Snapshot At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "snapshot_at",
+          "metrics"
+        ],
+        "title": "MetricsResponse",
+        "type": "object"
+      },
+      "Perf": {
+        "properties": {
+          "avg_ms_per_page": {
+            "title": "Avg Ms Per Page",
+            "type": "number"
+          },
+          "docs": {
+            "title": "Docs",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "docs",
+          "avg_ms_per_page"
+        ],
+        "title": "Perf",
+        "type": "object"
+      },
+      "ProblemDetail": {
+        "properties": {
+          "code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "extra": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra"
+          },
+          "instance": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance"
+          },
+          "status": {
+            "title": "Status",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "type": {
+            "default": "/errors/general",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "status"
+        ],
+        "title": "ProblemDetail",
+        "type": "object"
+      },
+      "QaFindingInput": {
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "rule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rule"
+          }
+        },
+        "title": "QaFindingInput",
+        "type": "object"
+      },
+      "QaRecheckRequest": {
+        "additionalProperties": false,
+        "description": "Request model for ``/api/qa-recheck``.\n\n``rules`` accepts either a mapping of rule flags or a list of small\ndictionaries which will be merged into a single mapping for backward\ncompatibility with legacy clients.",
+        "properties": {
+          "profile": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "smart",
+            "title": "Profile"
+          },
+          "rules": {
+            "additionalProperties": true,
+            "title": "Rules",
+            "type": "object"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "QaRecheckRequest",
+        "type": "object"
+      },
+      "QualityMetrics": {
+        "properties": {
+          "acceptance": {
+            "$ref": "#/components/schemas/Acceptance"
+          },
+          "coverage": {
+            "$ref": "#/components/schemas/Coverage"
+          },
+          "perf": {
+            "$ref": "#/components/schemas/Perf"
+          },
+          "rules": {
+            "items": {
+              "$ref": "#/components/schemas/RuleMetric"
+            },
+            "title": "Rules",
+            "type": "array"
+          }
+        },
+        "required": [
+          "rules",
+          "coverage",
+          "acceptance",
+          "perf"
+        ],
+        "title": "QualityMetrics",
+        "type": "object"
+      },
+      "RedlinesIn": {
+        "properties": {
+          "after_text": {
+            "title": "After Text",
+            "type": "string"
+          },
+          "before_text": {
+            "title": "Before Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "before_text",
+          "after_text"
+        ],
+        "title": "RedlinesIn",
+        "type": "object"
+      },
+      "RedlinesOut": {
+        "properties": {
+          "diff_html": {
+            "title": "Diff Html",
+            "type": "string"
+          },
+          "diff_unified": {
+            "title": "Diff Unified",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "diff_unified",
+          "diff_html"
+        ],
+        "title": "RedlinesOut",
+        "type": "object"
+      },
+      "RuleMetric": {
+        "properties": {
+          "f1": {
+            "title": "F1",
+            "type": "number"
+          },
+          "fn": {
+            "title": "Fn",
+            "type": "integer"
+          },
+          "fp": {
+            "title": "Fp",
+            "type": "integer"
+          },
+          "precision": {
+            "title": "Precision",
+            "type": "number"
+          },
+          "recall": {
+            "title": "Recall",
+            "type": "number"
+          },
+          "rule_id": {
+            "title": "Rule Id",
+            "type": "string"
+          },
+          "tp": {
+            "title": "Tp",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "rule_id",
+          "tp",
+          "fp",
+          "fn",
+          "precision",
+          "recall",
+          "f1"
+        ],
+        "title": "RuleMetric",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
   "info": {
     "title": "Contract Review App API",
     "version": "1.0"
   },
+  "openapi": "3.1.0",
   "paths": {
-    "/api/llm/ping": {
-      "get": {
-        "summary": "Llm Ping",
-        "operationId": "llm_ping_api_llm_ping_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/analyze": {
-      "post": {
-        "summary": "Api Analyze",
-        "operationId": "api_analyze_api_analyze_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AnalyzeRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnalyzeResponse"
-                },
-                "examples": {
-                  "default": {
-                    "summary": "Example",
-                    "value": {},
-                    "headers": {
-                      "x-schema-version": "1.3",
-                      "x-latency-ms": 12,
-                      "x-cid": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    }
-                  }
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
     "/analyze": {
       "post": {
-        "summary": "Analyze Alias",
         "operationId": "analyze_alias_analyze_post",
         "requestBody": {
           "content": {
@@ -368,683 +688,12 @@
         },
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/llm/ping": {
-      "get": {
-        "summary": "Llm Ping Alias",
-        "operationId": "llm_ping_alias_llm_ping_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/health": {
-      "get": {
-        "summary": "Health",
-        "description": "Health endpoint with schema version and rule count.",
-        "operationId": "health_health_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/trace": {
-      "get": {
-        "summary": "List Trace",
-        "operationId": "list_trace_api_trace_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/trace/{cid}": {
-      "get": {
-        "summary": "Get Trace",
-        "operationId": "get_trace_api_trace__cid__get",
-        "parameters": [
-          {
-            "name": "cid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -1054,18 +703,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -1101,22 +739,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -1126,18 +753,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -1147,912 +763,35 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
-      }
-    },
-    "/api/report/{cid}.html": {
-      "get": {
-        "summary": "Api Report Html",
-        "operationId": "api_report_html_api_report__cid__html_get",
-        "parameters": [
-          {
-            "name": "cid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/report/{cid}.pdf": {
-      "get": {
-        "summary": "Api Report Pdf",
-        "operationId": "api_report_pdf_api_report__cid__pdf_get",
-        "parameters": [
-          {
-            "name": "cid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/metrics": {
-      "get": {
-        "summary": "Api Metrics",
-        "operationId": "api_metrics_api_metrics_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetricsResponse"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/metrics.csv": {
-      "get": {
-        "summary": "Api Metrics Csv",
-        "operationId": "api_metrics_csv_api_metrics_csv_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/metrics.html": {
-      "get": {
-        "summary": "Api Metrics Html",
-        "operationId": "api_metrics_html_api_metrics_html_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
+        },
+        "summary": "Analyze Alias"
       }
     },
     "/api/admin/purge": {
       "post": {
-        "summary": "Api Admin Purge",
         "operationId": "api_admin_purge_api_admin_purge_post",
         "parameters": [
           {
-            "name": "dry",
             "in": "query",
+            "name": "dry",
             "required": false,
             "schema": {
-              "type": "integer",
               "default": 1,
-              "title": "Dry"
+              "title": "Dry",
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -2062,18 +801,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -2109,22 +837,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -2134,18 +851,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -2155,21 +861,40 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Api Admin Purge"
+      }
+    },
+    "/api/analyze": {
+      "post": {
+        "operationId": "api_analyze_api_analyze_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "text": "Hello"
               },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
+              "schema": {
+                "$ref": "#/components/schemas/AnalyzeRequest"
               }
             }
           },
-          "504": {
-            "description": "Gateway Timeout",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyzeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
             "content": {
               "application/json": {
                 "schema": {
@@ -2177,29 +902,79 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
               }
-            }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Api Analyze"
       }
     },
     "/api/analyze/replay": {
       "get": {
-        "summary": "Analyze Replay",
         "operationId": "analyze_replay_api_analyze_replay_get",
         "parameters": [
           {
-            "name": "cid",
             "in": "query",
+            "name": "cid",
             "required": false,
             "schema": {
               "anyOf": [
@@ -2214,8 +989,8 @@
             }
           },
           {
-            "name": "hash",
             "in": "query",
+            "name": "hash",
             "required": false,
             "schema": {
               "anyOf": [
@@ -2232,23 +1007,12 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -2258,18 +1022,227 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Analyze Replay"
+      }
+    },
+    "/api/calloff/validate": {
+      "post": {
+        "operationId": "api_calloff_validate_api_calloff_validate_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-cid",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Cid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Api Calloff Validate"
+      }
+    },
+    "/api/citation/resolve": {
+      "post": {
+        "operationId": "api_citation_resolve_api_citation_resolve_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-cid",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Cid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CitationResolveRequest"
               }
             }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CitationResolveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -2309,18 +1282,7 @@
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Unprocessable Entity"
           },
           "429": {
             "content": {
@@ -2330,18 +1292,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -2351,21 +1302,37 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Api Citation Resolve"
+      }
+    },
+    "/api/companies/search": {
+      "post": {
+        "operationId": "api_companies_search_api_companies_search_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Payload",
+                "type": "object"
               }
             }
           },
-          "504": {
-            "description": "Gateway Timeout",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
             "content": {
               "application/json": {
                 "schema": {
@@ -2373,62 +1340,97 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
               }
-            }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Api Companies Search",
+        "tags": [
+          "integrations"
+        ]
       }
     },
-    "/api/summary": {
+    "/api/companies/{number}": {
       "get": {
-        "summary": "Api Summary Get",
-        "operationId": "api_summary_get_api_summary_get",
+        "operationId": "api_company_profile_api_companies__number__get",
         "parameters": [
           {
-            "name": "mode",
-            "in": "query",
-            "required": false,
+            "in": "path",
+            "name": "number",
+            "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Mode"
+              "title": "Number",
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -2438,18 +1440,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -2485,22 +1476,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -2510,18 +1490,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -2531,278 +1500,46 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
-      },
-      "post": {
-        "summary": "Api Summary Post",
-        "operationId": "api_summary_post_api_summary_post",
-        "parameters": [
-          {
-            "name": "mode",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Mode"
-            }
-          },
-          {
-            "name": "x-cid",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Cid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
+        },
+        "summary": "Api Company Profile",
+        "tags": [
+          "integrations"
+        ]
       }
     },
-    "/summary": {
+    "/api/dsar/access": {
       "get": {
-        "summary": "Summary Get Alias",
-        "operationId": "summary_get_alias_summary_get",
+        "operationId": "dsar_access_api_dsar_access_get",
         "parameters": [
           {
-            "name": "mode",
             "in": "query",
-            "required": false,
+            "name": "identifier",
+            "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Mode"
+              "title": "Identifier",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "title": "Token",
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -2812,18 +1549,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -2859,22 +1585,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -2884,18 +1599,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -2905,278 +1609,43 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
-      },
-      "post": {
-        "summary": "Summary Post Alias",
-        "operationId": "summary_post_alias_summary_post",
-        "parameters": [
-          {
-            "name": "mode",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Mode"
-            }
-          },
-          {
-            "name": "x-cid",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Cid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
+        },
+        "summary": "Dsar Access"
       }
     },
-    "/api/qa-recheck": {
+    "/api/dsar/erasure": {
       "post": {
-        "summary": "Api Qa Recheck",
-        "operationId": "api_qa_recheck_api_qa_recheck_post",
+        "operationId": "dsar_erasure_api_dsar_erasure_post",
         "parameters": [
           {
-            "name": "x-cid",
-            "in": "header",
-            "required": false,
+            "in": "query",
+            "name": "identifier",
+            "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Cid"
+              "title": "Identifier",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "title": "Token",
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -3186,18 +1655,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -3233,22 +1691,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -3258,18 +1705,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -3279,84 +1715,43 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Dsar Erasure"
       }
     },
-    "/api/suggest_edits": {
-      "post": {
-        "summary": "Api Suggest Edits",
-        "operationId": "api_suggest_edits_api_suggest_edits_post",
+    "/api/dsar/export": {
+      "get": {
+        "operationId": "dsar_export_api_dsar_export_get",
         "parameters": [
           {
-            "name": "x-cid",
-            "in": "header",
-            "required": false,
+            "in": "query",
+            "name": "identifier",
+            "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Cid"
+              "title": "Identifier",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "title": "Token",
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -3366,18 +1761,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -3413,22 +1797,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -3438,18 +1811,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -3459,46 +1821,14 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Dsar Export"
       }
     },
     "/api/gpt-draft": {
       "post": {
-        "summary": "Gpt Draft",
         "operationId": "gpt_draft_api_gpt_draft_post",
         "requestBody": {
           "content": {
@@ -3512,39 +1842,16 @@
         },
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DraftOut"
-                },
-                "examples": {
-                  "default": {
-                    "summary": "Example",
-                    "value": {},
-                    "headers": {
-                      "x-schema-version": "1.3",
-                      "x-latency-ms": 12,
-                      "x-cid": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    }
-                  }
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
-            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -3552,50 +1859,39 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
-            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Unauthorized"
           },
           "403": {
-            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Forbidden"
           },
           "404": {
-            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Not Found"
           },
           "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
@@ -3603,20 +1899,9 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Unprocessable Entity"
           },
           "429": {
-            "description": "Too Many Requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -3624,20 +1909,9 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
-            "description": "Internal Server Error",
             "content": {
               "application/json": {
                 "schema": {
@@ -3645,419 +1919,23 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
-      }
-    },
-    "/api/panel/redlines": {
-      "post": {
-        "summary": "Panel Redlines",
-        "operationId": "panel_redlines_api_panel_redlines_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RedlinesIn"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RedlinesOut"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
+        "summary": "Gpt Draft"
       }
     },
     "/api/health": {
       "get": {
-        "summary": "Health Alias",
         "operationId": "health_alias_api_health_get",
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/suggest_edits": {
-      "post": {
-        "summary": "Suggest Edits Alias",
-        "operationId": "suggest_edits_alias_suggest_edits_post",
-        "parameters": [
-          {
-            "name": "x-cid",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Cid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -4067,18 +1945,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -4110,27 +1977,6 @@
             },
             "description": "Not Found"
           },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
           "429": {
             "content": {
               "application/json": {
@@ -4139,18 +1985,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -4160,226 +1995,14 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
-      }
-    },
-    "/api/calloff/validate": {
-      "post": {
-        "summary": "Api Calloff Validate",
-        "operationId": "api_calloff_validate_api_calloff_validate_post",
-        "parameters": [
-          {
-            "name": "x-cid",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Cid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
+        },
+        "summary": "Health Alias"
       }
     },
     "/api/learning/log": {
       "post": {
-        "summary": "Api Learning Log",
         "operationId": "api_learning_log_api_learning_log_post",
         "requestBody": {
           "content": {
@@ -4396,7 +2019,6 @@
             "description": "Successful Response"
           },
           "400": {
-            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -4404,71 +2026,49 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
-            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Unauthorized"
           },
           "403": {
-            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Forbidden"
           },
           "404": {
-            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Not Found"
           },
           "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
-            "description": "Too Many Requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -4476,20 +2076,9 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
-            "description": "Internal Server Error",
             "content": {
               "application/json": {
                 "schema": {
@@ -4497,45 +2086,14 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Api Learning Log"
       }
     },
     "/api/learning/update": {
       "post": {
-        "summary": "Api Learning Update",
         "operationId": "api_learning_update_api_learning_update_post",
         "requestBody": {
           "content": {
@@ -4549,26 +2107,14 @@
         },
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
-            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -4576,71 +2122,49 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
-            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Unauthorized"
           },
           "403": {
-            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Forbidden"
           },
           "404": {
-            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Not Found"
           },
           "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
-            "description": "Too Many Requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -4648,20 +2172,9 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
-            "description": "Internal Server Error",
             "content": {
               "application/json": {
                 "schema": {
@@ -4669,56 +2182,326 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Api Learning Update"
       }
     },
-    "/api/companies/search": {
+    "/api/llm/ping": {
+      "get": {
+        "operationId": "llm_ping_api_llm_ping_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Llm Ping"
+      }
+    },
+    "/api/metrics": {
+      "get": {
+        "operationId": "api_metrics_api_metrics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Api Metrics"
+      }
+    },
+    "/api/metrics.csv": {
+      "get": {
+        "operationId": "api_metrics_csv_api_metrics_csv_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Api Metrics Csv"
+      }
+    },
+    "/api/metrics.html": {
+      "get": {
+        "operationId": "api_metrics_html_api_metrics_html_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Api Metrics Html"
+      }
+    },
+    "/api/panel/redlines": {
       "post": {
-        "tags": [
-          "integrations"
-        ],
-        "summary": "Api Companies Search",
-        "operationId": "api_companies_search_api_companies_search_post",
+        "operationId": "panel_redlines_api_panel_redlines_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": true,
-                "type": "object",
-                "title": "Payload"
+                "$ref": "#/components/schemas/RedlinesIn"
               }
             }
           },
@@ -4726,26 +2509,130 @@
         },
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedlinesOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Panel Redlines"
+      }
+    },
+    "/api/qa-recheck": {
+      "post": {
+        "operationId": "api_qa_recheck_api_qa_recheck_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-cid",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Cid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QaRecheckRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
-            "description": "Bad Request",
             "content": {
               "application/json": {
                 "schema": {
@@ -4753,71 +2640,49 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
-            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Unauthorized"
           },
           "403": {
-            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Forbidden"
           },
           "404": {
-            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
-            }
+            },
+            "description": "Not Found"
           },
           "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
-            "description": "Too Many Requests",
             "content": {
               "application/json": {
                 "schema": {
@@ -4825,20 +2690,9 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
-            "description": "Internal Server Error",
             "content": {
               "application/json": {
                 "schema": {
@@ -4846,79 +2700,34 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Api Qa Recheck"
       }
     },
-    "/api/companies/{number}": {
+    "/api/report/{cid}.html": {
       "get": {
-        "tags": [
-          "integrations"
-        ],
-        "summary": "Api Company Profile",
-        "operationId": "api_company_profile_api_companies__number__get",
+        "operationId": "api_report_html_api_report__cid__html_get",
         "parameters": [
           {
-            "name": "number",
             "in": "path",
+            "name": "cid",
             "required": true,
             "schema": {
-              "type": "string",
-              "title": "Number"
+              "title": "Cid",
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -4928,18 +2737,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -4975,22 +2773,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -5000,18 +2787,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -5021,86 +2797,34 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Api Report Html"
       }
     },
-    "/api/dsar/access": {
+    "/api/report/{cid}.pdf": {
       "get": {
-        "summary": "Dsar Access",
-        "operationId": "dsar_access_api_dsar_access_get",
+        "operationId": "api_report_pdf_api_report__cid__pdf_get",
         "parameters": [
           {
-            "name": "identifier",
-            "in": "query",
+            "in": "path",
+            "name": "cid",
             "required": true,
             "schema": {
-              "type": "string",
-              "title": "Identifier"
-            }
-          },
-          {
-            "name": "token",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Token"
+              "title": "Cid",
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -5110,18 +2834,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -5157,22 +2870,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -5182,18 +2884,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -5203,415 +2894,19 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Internal Server Error"
           }
-        }
+        },
+        "summary": "Api Report Pdf"
       }
     },
-    "/api/dsar/erasure": {
+    "/api/suggest_edits": {
       "post": {
-        "summary": "Dsar Erasure",
-        "operationId": "dsar_erasure_api_dsar_erasure_post",
+        "operationId": "api_suggest_edits_api_suggest_edits_post",
         "parameters": [
           {
-            "name": "identifier",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Identifier"
-            }
-          },
-          {
-            "name": "token",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/dsar/export": {
-      "get": {
-        "summary": "Dsar Export",
-        "operationId": "dsar_export_api_dsar_export_get",
-        "parameters": [
-          {
-            "name": "identifier",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Identifier"
-            }
-          },
-          {
-            "name": "token",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "429": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          },
-          "504": {
-            "description": "Gateway Timeout",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/citations/resolve": {
-      "post": {
-        "summary": "Api Citation Resolve",
-        "operationId": "api_citation_resolve_api_citations_resolve_post",
-        "parameters": [
-          {
-            "name": "x-cid",
             "in": "header",
+            "name": "x-cid",
             "required": false,
             "schema": {
               "anyOf": [
@@ -5626,37 +2921,14 @@
             }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CitationResolveRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CitationResolveResponse"
-                }
+                "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -5666,18 +2938,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -5717,18 +2978,7 @@
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Unprocessable Entity"
           },
           "429": {
             "content": {
@@ -5738,18 +2988,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -5759,21 +2998,43 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Api Suggest Edits"
+      }
+    },
+    "/api/summary": {
+      "get": {
+        "operationId": "api_summary_get_api_summary_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "mode",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Mode"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
           },
-          "504": {
-            "description": "Gateway Timeout",
+          "400": {
             "content": {
               "application/json": {
                 "schema": {
@@ -5781,29 +3042,93 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
               }
-            }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
-        }
-      }
-    },
-    "/api/citation/resolve": {
+        },
+        "summary": "Api Summary Get"
+      },
       "post": {
-        "summary": "Api Citation Resolve",
-        "operationId": "api_citation_resolve_api_citation_resolve_post",
+        "operationId": "api_summary_post_api_summary_post",
         "parameters": [
           {
-            "name": "x-cid",
+            "in": "query",
+            "name": "mode",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Mode"
+            }
+          },
+          {
             "in": "header",
+            "name": "x-cid",
             "required": false,
             "schema": {
               "anyOf": [
@@ -5818,37 +3143,14 @@
             }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CitationResolveRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
-            "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CitationResolveResponse"
-                }
+                "schema": {}
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Successful Response"
           },
           "400": {
             "content": {
@@ -5858,18 +3160,7 @@
                 }
               }
             },
-            "description": "Bad Request",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Bad Request"
           },
           "401": {
             "content": {
@@ -5905,22 +3196,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             },
-            "description": "Unprocessable Entity",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Validation Error"
           },
           "429": {
             "content": {
@@ -5930,18 +3210,7 @@
                 }
               }
             },
-            "description": "Too Many Requests",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
+            "description": "Too Many Requests"
           },
           "500": {
             "content": {
@@ -5951,21 +3220,25 @@
                 }
               }
             },
-            "description": "Internal Server Error",
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Api Summary Post"
+      }
+    },
+    "/api/trace": {
+      "get": {
+        "operationId": "list_trace_api_trace_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
               }
-            }
+            },
+            "description": "Successful Response"
           },
-          "504": {
-            "description": "Gateway Timeout",
+          "400": {
             "content": {
               "application/json": {
                 "schema": {
@@ -5973,847 +3246,636 @@
                 }
               }
             },
-            "headers": {
-              "x-schema-version": {
-                "$ref": "#/components/headers/XSchemaVersion"
-              },
-              "x-latency-ms": {
-                "$ref": "#/components/headers/XLatencyMs"
-              },
-              "x-cid": {
-                "$ref": "#/components/headers/XCid"
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "Acceptance": {
-        "properties": {
-          "applied": {
-            "type": "integer",
-            "title": "Applied"
+            "description": "Bad Request"
           },
-          "rejected": {
-            "type": "integer",
-            "title": "Rejected"
-          },
-          "acceptance_rate": {
-            "type": "number",
-            "title": "Acceptance Rate"
-          }
-        },
-        "type": "object",
-        "required": [
-          "applied",
-          "rejected",
-          "acceptance_rate"
-        ],
-        "title": "Acceptance"
-      },
-      "AnalyzeRequest": {
-        "additionalProperties": false,
-        "description": "Public request DTO for ``/api/analyze``.\n\nAccepts ``text`` as a required field while allowing legacy aliases\n``clause`` and ``body`` for backward compatibility. The aliases are\nfolded into ``text`` during validation so downstream logic only needs to\nhandle a single attribute.",
-        "properties": {
-          "text": {
-            "title": "Text",
-            "type": "string"
-          },
-          "language": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Language"
-          },
-          "mode": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Mode"
-          },
-          "risk": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Risk"
-          }
-        },
-        "required": [
-          "text"
-        ],
-        "title": "AnalyzeRequest",
-        "type": "object"
-      },
-      "AnalyzeResponse": {
-        "additionalProperties": true,
-        "properties": {
-          "status": {
-            "title": "Status",
-            "type": "string"
-          },
-          "analysis": {
-            "additionalProperties": true,
-            "title": "Analysis",
-            "type": "object"
-          }
-        },
-        "required": [
-          "status",
-          "analysis"
-        ],
-        "title": "AnalyzeResponse",
-        "type": "object"
-      },
-      "Citation": {
-        "additionalProperties": false,
-        "properties": {
-          "instrument": {
-            "title": "Instrument",
-            "type": "string"
-          },
-          "section": {
-            "title": "Section",
-            "type": "string"
-          }
-        },
-        "required": [
-          "instrument",
-          "section"
-        ],
-        "title": "Citation",
-        "type": "object"
-      },
-      "CitationResolveRequest": {
-        "properties": {
-          "findings": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/Finding"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Findings"
-          },
-          "citations": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/Citation"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Citations"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "title": "CitationResolveRequest"
-      },
-      "CitationResolveResponse": {
-        "properties": {
-          "citations": {
-            "items": {
-              "$ref": "#/components/schemas/Citation"
-            },
-            "type": "array",
-            "title": "Citations"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "citations"
-        ],
-        "title": "CitationResolveResponse"
-      },
-      "Coverage": {
-        "properties": {
-          "rules_total": {
-            "type": "integer",
-            "title": "Rules Total"
-          },
-          "rules_fired": {
-            "type": "integer",
-            "title": "Rules Fired"
-          },
-          "coverage": {
-            "type": "number",
-            "title": "Coverage"
-          }
-        },
-        "type": "object",
-        "required": [
-          "rules_total",
-          "rules_fired",
-          "coverage"
-        ],
-        "title": "Coverage"
-      },
-      "DraftIn": {
-        "properties": {
-          "text": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Text"
-          },
-          "language": {
-            "type": "string",
-            "title": "Language",
-            "default": "en"
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "friendly",
-              "medium",
-              "strict"
-            ],
-            "title": "Mode",
-            "default": "medium"
-          },
-          "before_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Before Text"
-          },
-          "after_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "After Text"
-          }
-        },
-        "type": "object",
-        "required": [
-          "text"
-        ],
-        "title": "DraftIn"
-      },
-      "DraftOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "mode": {
-            "type": "string",
-            "title": "Mode"
-          },
-          "proposed_text": {
-            "type": "string",
-            "title": "Proposed Text"
-          },
-          "rationale": {
-            "type": "string",
-            "title": "Rationale"
-          },
-          "evidence": {
-            "anyOf": [
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "additionalProperties": true,
-                "type": "object"
-              }
-            ],
-            "title": "Evidence"
-          },
-          "before_text": {
-            "type": "string",
-            "title": "Before Text"
-          },
-          "after_text": {
-            "type": "string",
-            "title": "After Text"
-          },
-          "diff": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Diff"
-          },
-          "x_schema_version": {
-            "type": "string",
-            "title": "X Schema Version"
-          },
-          "context_before": {
-            "type": "string",
-            "title": "Context Before"
-          },
-          "context_after": {
-            "type": "string",
-            "title": "Context After"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "mode",
-          "proposed_text",
-          "rationale",
-          "evidence",
-          "before_text",
-          "after_text",
-          "diff",
-          "x_schema_version",
-          "context_before",
-          "context_after"
-        ],
-        "title": "DraftOut"
-      },
-      "Finding": {
-        "$defs": {
-          "Span": {
-            "additionalProperties": false,
-            "properties": {
-              "start": {
-                "minimum": 0,
-                "title": "Start",
-                "type": "integer"
-              },
-              "end": {
-                "minimum": 0,
-                "title": "End",
-                "type": "integer"
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
               }
             },
-            "required": [
-              "start",
-              "end"
-            ],
-            "title": "Span",
-            "type": "object"
-          }
-        },
-        "additionalProperties": false,
-        "properties": {
-          "span": {
-            "$ref": "#/components/schemas/Span"
+            "description": "Unauthorized"
           },
-          "text": {
-            "title": "Text",
-            "type": "string"
-          },
-          "lang": {
-            "enum": [
-              "latin",
-              "cyrillic"
-            ],
-            "title": "Lang",
-            "type": "string"
-          }
-        },
-        "required": [
-          "span",
-          "text",
-          "lang"
-        ],
-        "title": "Finding",
-        "type": "object"
-      },
-      "LearningUpdateIn": {
-        "properties": {
-          "force": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Force",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "LearningUpdateIn"
-      },
-      "MetricsResponse": {
-        "properties": {
-          "schema_version": {
-            "type": "string",
-            "title": "Schema Version",
-            "default": "1.3"
-          },
-          "snapshot_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Snapshot At"
-          },
-          "metrics": {
-            "$ref": "#/components/schemas/QualityMetrics"
-          }
-        },
-        "type": "object",
-        "required": [
-          "snapshot_at",
-          "metrics"
-        ],
-        "title": "MetricsResponse"
-      },
-      "Perf": {
-        "properties": {
-          "docs": {
-            "type": "integer",
-            "title": "Docs"
-          },
-          "avg_ms_per_page": {
-            "type": "number",
-            "title": "Avg Ms Per Page"
-          }
-        },
-        "type": "object",
-        "required": [
-          "docs",
-          "avg_ms_per_page"
-        ],
-        "title": "Perf"
-      },
-      "ProblemDetail": {
-        "properties": {
-          "type": {
-            "default": "/errors/general",
-            "title": "Type",
-            "type": "string"
-          },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
-          "status": {
-            "title": "Status",
-            "type": "integer"
-          },
-          "detail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Detail"
-          },
-          "instance": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Instance"
-          },
-          "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Code"
-          },
-          "extra": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Extra"
-          }
-        },
-        "required": [
-          "title",
-          "status"
-        ],
-        "title": "ProblemDetail",
-        "type": "object"
-      },
-      "QualityMetrics": {
-        "properties": {
-          "rules": {
-            "items": {
-              "$ref": "#/components/schemas/RuleMetric"
-            },
-            "type": "array",
-            "title": "Rules"
-          },
-          "coverage": {
-            "$ref": "#/components/schemas/Coverage"
-          },
-          "acceptance": {
-            "$ref": "#/components/schemas/Acceptance"
-          },
-          "perf": {
-            "$ref": "#/components/schemas/Perf"
-          }
-        },
-        "type": "object",
-        "required": [
-          "rules",
-          "coverage",
-          "acceptance",
-          "perf"
-        ],
-        "title": "QualityMetrics"
-      },
-      "RedlinesIn": {
-        "properties": {
-          "before_text": {
-            "type": "string",
-            "title": "Before Text"
-          },
-          "after_text": {
-            "type": "string",
-            "title": "After Text"
-          }
-        },
-        "type": "object",
-        "required": [
-          "before_text",
-          "after_text"
-        ],
-        "title": "RedlinesIn"
-      },
-      "RedlinesOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "diff_unified": {
-            "type": "string",
-            "title": "Diff Unified"
-          },
-          "diff_html": {
-            "type": "string",
-            "title": "Diff Html"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "diff_unified",
-          "diff_html"
-        ],
-        "title": "RedlinesOut"
-      },
-      "RuleMetric": {
-        "properties": {
-          "rule_id": {
-            "type": "string",
-            "title": "Rule Id"
-          },
-          "tp": {
-            "type": "integer",
-            "title": "Tp"
-          },
-          "fp": {
-            "type": "integer",
-            "title": "Fp"
-          },
-          "fn": {
-            "type": "integer",
-            "title": "Fn"
-          },
-          "precision": {
-            "type": "number",
-            "title": "Precision"
-          },
-          "recall": {
-            "type": "number",
-            "title": "Recall"
-          },
-          "f1": {
-            "type": "number",
-            "title": "F1"
-          }
-        },
-        "type": "object",
-        "required": [
-          "rule_id",
-          "tp",
-          "fp",
-          "fn",
-          "precision",
-          "recall",
-          "f1"
-        ],
-        "title": "RuleMetric"
-      },
-      "Span": {
-        "additionalProperties": false,
-        "properties": {
-          "start": {
-            "minimum": 0,
-            "title": "Start",
-            "type": "integer"
-          },
-          "end": {
-            "minimum": 0,
-            "title": "End",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "start",
-          "end"
-        ],
-        "title": "Span",
-        "type": "object"
-      },
-      "Segment": {
-        "$defs": {
-          "Span": {
-            "additionalProperties": false,
-            "properties": {
-              "start": {
-                "minimum": 0,
-                "title": "Start",
-                "type": "integer"
-              },
-              "end": {
-                "minimum": 0,
-                "title": "End",
-                "type": "integer"
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
               }
             },
-            "required": [
-              "start",
-              "end"
-            ],
-            "title": "Span",
-            "type": "object"
-          }
-        },
-        "additionalProperties": false,
-        "properties": {
-          "span": {
-            "$ref": "#/components/schemas/Span"
+            "description": "Forbidden"
           },
-          "lang": {
-            "enum": [
-              "latin",
-              "cyrillic"
-            ],
-            "title": "Lang",
-            "type": "string"
-          }
-        },
-        "required": [
-          "span",
-          "lang"
-        ],
-        "title": "Segment",
-        "type": "object"
-      },
-      "SearchHit": {
-        "$defs": {
-          "Span": {
-            "additionalProperties": false,
-            "properties": {
-              "start": {
-                "minimum": 0,
-                "title": "Start",
-                "type": "integer"
-              },
-              "end": {
-                "minimum": 0,
-                "title": "End",
-                "type": "integer"
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
               }
             },
-            "required": [
-              "start",
-              "end"
-            ],
-            "title": "Span",
-            "type": "object"
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "additionalProperties": false,
-        "properties": {
-          "doc_id": {
-            "title": "Doc Id",
-            "type": "string"
-          },
-          "score": {
-            "title": "Score",
-            "type": "number"
-          },
-          "span": {
-            "$ref": "#/components/schemas/Span"
-          },
-          "snippet": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Snippet"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Title"
-          },
-          "text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Text"
-          },
-          "meta": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Meta"
-          },
-          "bm25_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Bm25 Score"
-          },
-          "cosine_sim": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Cosine Sim"
-          },
-          "rank_fusion": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Rank Fusion"
-          }
-        },
-        "required": [
-          "doc_id",
-          "score",
-          "span"
-        ],
-        "title": "SearchHit",
-        "type": "object"
+        "summary": "List Trace"
       }
     },
-    "headers": {
-      "XSchemaVersion": {
-        "schema": {
-          "type": "string"
+    "/api/trace/{cid}": {
+      "get": {
+        "operationId": "get_trace_api_trace__cid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "title": "Cid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
         },
-        "example": "1.3"
+        "summary": "Get Trace"
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Health endpoint with schema version and rule count.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Health"
+      }
+    },
+    "/llm/ping": {
+      "get": {
+        "operationId": "llm_ping_alias_llm_ping_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Llm Ping Alias"
+      }
+    },
+    "/suggest_edits": {
+      "post": {
+        "operationId": "suggest_edits_alias_suggest_edits_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-cid",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Cid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Suggest Edits Alias"
+      }
+    },
+    "/summary": {
+      "get": {
+        "operationId": "summary_get_alias_summary_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "mode",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Mode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Summary Get Alias"
       },
-      "XLatencyMs": {
-        "schema": {
-          "type": "integer",
-          "format": "int32"
+      "post": {
+        "operationId": "summary_post_alias_summary_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "mode",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Mode"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-cid",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Cid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
         },
-        "example": 12
-      },
-      "XCid": {
-        "schema": {
-          "type": "string",
-          "pattern": "^[0-9a-f]{64}$"
-        },
-        "example": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        "summary": "Summary Post Alias"
       }
     }
   }

--- a/tests/api/test_analyze.py
+++ b/tests/api/test_analyze.py
@@ -19,7 +19,7 @@ def test_minimal_ok(monkeypatch):
         assert r.json().get("status") == "ok"
 
 
-def test_validation_message_contains_loc_and_msg(monkeypatch):
+def test_validation_details_present(monkeypatch):
     monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
     monkeypatch.setenv("API_KEY", "local-test-key-123")
     with TestClient(app) as c:

--- a/tests/api/test_citation_resolver.py
+++ b/tests/api/test_citation_resolver.py
@@ -1,0 +1,44 @@
+import os
+from types import SimpleNamespace
+from fastapi.testclient import TestClient
+import contract_review_app.api.app as app_module
+from contract_review_app.api.app import app
+
+
+def _h():
+    return {"x-api-key": os.environ.get("API_KEY", "local-test-key-123"), "x-schema-version": "1.3"}
+
+
+def _patch(monkeypatch):
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "local-test-key-123")
+
+
+def test_one_of_ok_citations(monkeypatch):
+    _patch(monkeypatch)
+    with TestClient(app) as c:
+        r = c.post("/api/citation/resolve", json={"citations": [{"instrument": "ACT", "section": "1"}]}, headers=_h())
+        assert r.status_code == 200
+        assert r.json()["citations"][0]["instrument"] == "ACT"
+
+
+def test_one_of_ok_findings(monkeypatch):
+    _patch(monkeypatch)
+    def fake_resolve(f):
+        return SimpleNamespace(instrument="ACT", section="1")
+    monkeypatch.setattr(app_module, "resolve_citation", fake_resolve)
+    with TestClient(app) as c:
+        r = c.post("/api/citation/resolve", json={"findings": [{"message": "x"}]}, headers=_h())
+        assert r.status_code == 200
+        assert r.json()["citations"][0]["section"] == "1"
+
+
+def test_both_or_none_400_message(monkeypatch):
+    _patch(monkeypatch)
+    with TestClient(app) as c:
+        r1 = c.post("/api/citation/resolve", json={}, headers=_h())
+        assert r1.status_code == 400
+        assert r1.json()["detail"] == "Exactly one of findings or citations is required"
+        r2 = c.post("/api/citation/resolve", json={"citations": [], "findings": []}, headers=_h())
+        assert r2.status_code == 400
+        assert r2.json()["detail"] == "Exactly one of findings or citations is required"

--- a/tests/api/test_gpt_draft.py
+++ b/tests/api/test_gpt_draft.py
@@ -1,9 +1,11 @@
 import os
+import os
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
 
 
-def _h(): return {"x-api-key": os.environ.get("API_KEY","local-test-key-123"), "x-schema-version":"1.3"}
+def _h():
+    return {"x-api-key": os.environ.get("API_KEY", "local-test-key-123"), "x-schema-version": "1.3"}
 
 
 def test_minimal_body_ok(monkeypatch):
@@ -15,11 +17,13 @@ def test_minimal_body_ok(monkeypatch):
         assert r.json().get("status") == "ok"
 
 
-def test_openapi_has_single_gpt_draft_path():
+def test_legacy_route_redirects_or_hidden():
     with TestClient(app) as c:
         spec = c.get("/openapi.json").json()
-    paths = spec["paths"].keys()
-    assert "/api/gpt-draft" in paths
-    assert "/api/gpt/draft" not in paths
-    assert "/api/gpt_draft" not in paths
-    assert "/gpt-draft" not in paths
+        paths = spec["paths"].keys()
+        assert "/api/gpt-draft" in paths
+        for p in ["/api/gpt/draft", "/api/gpt_draft", "/gpt-draft"]:
+            assert p not in paths
+            r = c.post(p, json={"text": "Hi"}, follow_redirects=False)
+            assert r.status_code == 307
+            assert r.headers.get("location") == "/api/gpt-draft"

--- a/tests/api/test_qa_recheck.py
+++ b/tests/api/test_qa_recheck.py
@@ -1,0 +1,48 @@
+import os
+from types import SimpleNamespace
+from fastapi.testclient import TestClient
+import contract_review_app.api.app as app_module
+from contract_review_app.api.app import app
+
+
+def _h():
+    return {"x-api-key": os.environ.get("API_KEY", "local-test-key-123"), "x-schema-version": "1.3"}
+
+
+def _patch_env(monkeypatch):
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "local-test-key-123")
+    def fake_qa(text, rules, timeout_s, profile="smart"):
+        return SimpleNamespace(meta={}, items=[])
+    monkeypatch.setattr(app_module, "LLM_SERVICE", SimpleNamespace(qa=fake_qa))
+    monkeypatch.setattr(app_module.LLM_CONFIG, "mode", "test", raising=False)
+    monkeypatch.setattr(app_module.LLM_CONFIG, "provider", "test", raising=False)
+
+
+def test_minimal_dict_rules_ok(monkeypatch):
+    _patch_env(monkeypatch)
+    with TestClient(app) as c:
+        r = c.post("/api/qa-recheck", json={"text": "hi", "rules": {}}, headers=_h())
+        assert r.status_code == 200
+
+
+def test_list_rules_ok_normalized(monkeypatch):
+    _patch_env(monkeypatch)
+    captured = {}
+    def fake_qa(text, rules, timeout_s, profile="smart"):
+        captured["rules"] = rules
+        return SimpleNamespace(meta={}, items=[])
+    monkeypatch.setattr(app_module, "LLM_SERVICE", SimpleNamespace(qa=fake_qa))
+    with TestClient(app) as c:
+        r = c.post("/api/qa-recheck", json={"text": "hi", "rules": [{"R1": "on"}]}, headers=_h())
+        assert r.status_code == 200
+        assert captured["rules"] == {"R1": "on"}
+
+
+def test_empty_text_422_with_details(monkeypatch):
+    _patch_env(monkeypatch)
+    with TestClient(app) as c:
+        r = c.post("/api/qa-recheck", json={"text": ""}, headers=_h())
+        assert r.status_code == 422
+        detail = r.json().get("detail")
+        assert isinstance(detail, list) and any("loc" in d and "msg" in d for d in detail)

--- a/tests/api/test_trace_and_report.py
+++ b/tests/api/test_trace_and_report.py
@@ -1,0 +1,31 @@
+import os
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+
+def _h():
+    return {"x-api-key": os.environ.get("API_KEY", "local-test-key-123"), "x-schema-version": "1.3"}
+
+
+def _patch(monkeypatch):
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "local-test-key-123")
+
+
+def test_trace_after_analyze(monkeypatch):
+    _patch(monkeypatch)
+    with TestClient(app) as c:
+        r = c.post("/api/analyze", json={"text": "hi"}, headers=_h())
+        cid = r.headers.get("x-cid")
+        assert cid
+        r2 = c.get("/api/trace", headers=_h())
+        assert cid in r2.json()["cids"]
+        r3 = c.get(f"/api/report/{cid}.html", headers=_h())
+        assert r3.status_code == 200
+
+
+def test_report_404_unknown(monkeypatch):
+    _patch(monkeypatch)
+    with TestClient(app) as c:
+        r = c.get("/api/report/unknown.html", headers=_h())
+        assert r.status_code == 404

--- a/tests/integration/test_panel_selftest_like.py
+++ b/tests/integration/test_panel_selftest_like.py
@@ -1,0 +1,56 @@
+import importlib
+import os
+import sys
+from fastapi.testclient import TestClient
+
+
+def _build_client():
+    modules = [
+        "contract_review_app.api",
+        "contract_review_app.api.app",
+    ]
+    for m in modules:
+        sys.modules.pop(m, None)
+    os.environ["LLM_PROVIDER"] = "mock"
+    from contract_review_app.api import app as app_module
+    importlib.reload(app_module)
+    def fake_analyze(text: str):
+        return {
+            "analysis": {"issues": ["dummy"]},
+            "results": {},
+            "clauses": [],
+            "document": {"text": text},
+        }
+    app_module._analyze_document = fake_analyze
+    client = TestClient(app_module.app)
+    return client, modules
+
+
+def test_panel_selftest_like():
+    client, modules = _build_client()
+    try:
+        assert client.get("/api/llm/ping").status_code == 200
+        r = client.post("/api/analyze", json={"text": "Hi"})
+        assert r.status_code == 200
+        cid = r.headers.get("x-cid")
+        assert client.post("/api/gpt-draft", json={"text": "Hi"}).status_code == 200
+        assert client.post("/api/qa-recheck", json={"text": "hi", "rules": {}}).status_code == 200
+        assert (
+            client.post("/api/qa-recheck", json={"text": "hi", "rules": [{"R1": "on"}]})
+            .status_code
+            == 200
+        )
+        assert client.post("/api/suggest_edits", json={"text": "Hi"}).status_code == 200
+        assert (
+            client.post(
+                "/api/citation/resolve",
+                json={"citations": [{"instrument": "ACT", "section": "1"}]},
+            ).status_code
+            == 200
+        )
+        assert client.get("/api/trace").status_code == 200
+        assert client.get(f"/api/report/{cid}.html").status_code == 200
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+        os.environ.pop("LLM_PROVIDER", None)

--- a/tools/build_openapi.py
+++ b/tools/build_openapi.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import json
+import sys
+from pathlib import Path
+from fastapi.openapi.utils import get_openapi
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from contract_review_app.api.app import app
+
+
+def main() -> None:
+    schema = get_openapi(title=app.title, version=app.version, routes=app.routes)
+    out_path = ROOT / "openapi.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(schema, f, ensure_ascii=False, sort_keys=True, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add QaRecheckRequest DTO that normalizes rule formats and validates empty text
- expose citation resolver with one-of validation and singular path
- unify trace storage and regenerate deterministic openapi schema

## Testing
- `pytest tests/api/test_gpt_draft.py::test_minimal_body_ok -q`
- `pytest tests/api/test_analyze.py tests/api/test_qa_recheck.py tests/api/test_citation_resolver.py tests/api/test_trace_and_report.py tests/integration/test_panel_selftest_like.py -q`
- `python tools/build_openapi.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf09e92ecc8325ab13666fe64cd4da