### PR TITLE
feat: default analysis language

### DIFF
--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -30,7 +30,7 @@ class AnalyzeRequest(_DTOBase):
     """
 
     text: str = Field(validation_alias=AliasChoices("text", "clause", "body"))
-    language: str | None = None
+    language: str = "en"
     mode: str | None = None
     risk: str | None = None
 


### PR DESCRIPTION
## Summary
- default analyze request language to English so text-only payloads are valid

## Testing
- `pytest tests/api/test_analyze.py -q`
- `pytest tests/api/test_analyze_minimal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf10e5ae0c8325bd35ed150e61865a