### PR TITLE
chore(dev): add one-click local start script and smoke test; default mock LLM

### DIFF
--- a/ContractAI-Start.local.bat
+++ b/ContractAI-Start.local.bat
@@ -1,0 +1,42 @@
+@echo off
+setlocal enabledelayedexpansion
+cd /d "%~dp0"
+
+REM ---- venv ----
+if not exist .venv\Scripts\python.exe (
+  where py >nul 2>&1 && (py -3.11 -m venv .venv || py -3 -m venv .venv) || python -m venv .venv
+)
+call .venv\Scripts\activate
+
+python -m pip install -q -U pip wheel
+python -m pip install -q -r requirements.txt
+python -m pip install -q uvicorn[standard]
+
+REM ---- env ----
+set "API_KEY=local-test-key-123"
+set "LLM_PROVIDER=mock"
+
+REM ---- certs ----
+if not exist dev_certs mkdir dev_certs
+if not exist dev_certs\cert.pem (
+  if exist C:\certs\dev.crt copy /y C:\certs\dev.crt dev_certs\cert.pem >nul
+)
+if not exist dev_certs\key.pem (
+  if exist C:\certs\dev.key copy /y C:\certs\dev.key dev_certs\key.pem >nul
+)
+if not exist dev_certs\cert.pem (
+  echo [dev] generating self-signed certs...
+  python gen_dev_cert.py
+  if exist C:\certs\dev.crt copy /y C:\certs\dev.crt dev_certs\cert.pem >nul
+  if exist C:\certs\dev.key copy /y C:\certs\dev.key dev_certs\key.pem >nul
+)
+
+REM ---- start server in separate window ----
+start "ContractAI API" cmd /k ^
+  python -m uvicorn contract_review_app.api.app:app ^
+    --host 127.0.0.1 --port 9443 ^
+    --ssl-certfile dev_certs\cert.pem --ssl-keyfile dev_certs\key.pem
+
+REM ---- open panel ----
+timeout /t 2 >nul
+start "" https://localhost:9443/panel/panel_selftest.html?v=dev

--- a/tools/dev_smoke.ps1
+++ b/tools/dev_smoke.ps1
@@ -1,0 +1,34 @@
+param([int]$TimeoutSec=40)
+$ErrorActionPreference="SilentlyContinue"
+
+# wait server
+$deadline = (Get-Date).AddSeconds($TimeoutSec)
+do {
+  $h = curl.exe -sk https://localhost:9443/health
+  if ($LASTEXITCODE -eq 0 -and ($h -match '"ok"' -or $h -match '"status"\s*:\s*"ok"')) { break }
+  Start-Sleep -Milliseconds 500
+} while ((Get-Date) -lt $deadline)
+
+if (-not $h) { Write-Error "Health check failed"; exit 1 }
+Write-Host "OK /health: $h"
+
+# analyze
+$SCHEMA="1.3"
+$BODY='{"text":"Hello","language":"en"}'
+$r = curl.exe -sk --http1.1 -H "Content-Type: application/json" -H "x-api-key: local-test-key-123" -H "x-schema-version: 1.3" -X POST --data $BODY https://localhost:9443/api/analyze
+if ($LASTEXITCODE -ne 0 -or ($r -notmatch '"status"\s*:\s*"ok"')) { Write-Error "/api/analyze failed: $r"; exit 2 }
+Write-Host "OK /api/analyze"
+
+# gpt-draft
+$BODY2='{"text":"Please rephrase","language":"en"}'
+$r2 = curl.exe -sk --http1.1 -H "Content-Type: application/json" -H "x-api-key: local-test-key-123" -H "x-schema-version: 1.3" -X POST --data $BODY2 https://localhost:9443/api/gpt-draft
+if ($LASTEXITCODE -ne 0 -or ($r2 -notmatch '"status"\s*:\s*"ok"')) { Write-Error "/api/gpt-draft failed: $r2"; exit 3 }
+Write-Host "OK /api/gpt-draft"
+
+# qa-recheck (минимум)
+$BODY3='{"text":"hello","rules":{}}'
+$r3 = curl.exe -sk --http1.1 -H "Content-Type: application/json" -H "x-api-key: local-test-key-123" -H "x-schema-version: 1.3" -X POST --data $BODY3 https://localhost:9443/api/qa-recheck
+if ($LASTEXITCODE -ne 0 -or ($r3 -notmatch '"status"\s*:\s*"ok"')) { Write-Error "/api/qa-recheck failed: $r3"; exit 4 }
+Write-Host "OK /api/qa-recheck"
+
+Write-Host "Smoke OK"


### PR DESCRIPTION
## Summary
- add one-click `ContractAI-Start.local.bat` for local dev using mock LLM
- provide `tools/dev_smoke.ps1` to check /health, /api/analyze, /api/gpt-draft, and /api/qa-recheck

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

## Instructions
Запуск: двойной клик по ContractAI-Start.local.bat; Проверка: powershell -ExecutionPolicy Bypass -File tools\dev_smoke.ps1

------
https://chatgpt.com/codex/tasks/task_e_68bf1337ed8c83258e717eec09df0188