### PR TITLE
Remove legacy draft route aliases and clean OpenAPI spec

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -2377,7 +2377,7 @@ async def health_alias():
 
 @app.post("/analyze", dependencies=[Depends(_require_api_key)])
 def analyze_alias(req: AnalyzeRequest, request: Request):
-    return api_analyze(req, request)
+    return api_analyze(request, req)
 
 
 @router.post("/suggest_edits", dependencies=[Depends(_require_api_key)])
@@ -2390,33 +2390,6 @@ async def suggest_edits_alias(
 @app.get("/llm/ping")
 def llm_ping_alias():
     return llm_ping()
-
-
-@router.post(
-    "/api/gpt/draft",
-    include_in_schema=False,
-    dependencies=[Depends(_require_api_key)],
-)
-async def gpt_draft_slash_redirect():
-    return Response(status_code=307, headers={"Location": "/api/gpt-draft"})
-
-
-@router.post(
-    "/api/gpt_draft",
-    include_in_schema=False,
-    dependencies=[Depends(_require_api_key)],
-)
-async def gpt_draft_underscore_redirect():
-    return Response(status_code=307, headers={"Location": "/api/gpt-draft"})
-
-
-@router.post(
-    "/gpt-draft",
-    include_in_schema=False,
-    dependencies=[Depends(_require_api_key)],
-)
-async def gpt_draft_plain_redirect():
-    return Response(status_code=307, headers={"Location": "/api/gpt-draft"})
 
 
 @router.post("/api/calloff/validate", dependencies=[Depends(_require_api_key)])
@@ -2532,11 +2505,6 @@ async def api_citation_resolve(
         latency_ms=_now_ms() - t0,
     )
     return resp_model
-
-
-@app.post("/api/citations/resolve", include_in_schema=False)
-async def api_citations_resolve_redirect():
-    return Response(status_code=307, headers={"Location": "/api/citation/resolve"})
 
 
 @app.on_event("startup")

--- a/contract_review_app/gpt/gpt_draft_api.py
+++ b/contract_review_app/gpt/gpt_draft_api.py
@@ -245,18 +245,3 @@ def api_gpt_draft_gptdto(payload: Dict[str, Any], response: Response) -> GPTDraf
         title=None,
         verification_status=redrafted.get("verification_status"),
     )
-
-
-@router.post("/api/gpt/draft", include_in_schema=False)
-def api_gpt_draft_redirect():
-    return Response(status_code=307, headers={"Location": "/api/gpt-draft"})
-
-
-@router.post("/api/gpt_draft", include_in_schema=False)
-def api_gpt_draft_redirect_uscore():
-    return Response(status_code=307, headers={"Location": "/api/gpt-draft"})
-
-
-@router.post("/gpt-draft", include_in_schema=False)
-def api_gpt_draft_redirect_plain():
-    return Response(status_code=307, headers={"Location": "/api/gpt-draft"})

--- a/contract_review_app/tests/api/test_openapi_errors_contract.py
+++ b/contract_review_app/tests/api/test_openapi_errors_contract.py
@@ -22,7 +22,7 @@ def test_problem_detail_component():
 def test_problem_detail_responses():
     client = _build_client()
     schema = client.get("/openapi.json").json()
-    for path in ["/api/analyze", "/api/gpt-draft", "/api/citations/resolve"]:
+    for path in ["/api/analyze", "/api/gpt-draft", "/api/citation/resolve"]:
         post = schema["paths"][path]["post"]
         ref_500 = post["responses"]["500"]["content"]["application/json"]["schema"][
             "$ref"

--- a/openapi.json
+++ b/openapi.json
@@ -4573,6 +4573,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "additionalProperties": true,
                 "type": "object",
                 "title": "Payload"
               }
@@ -5734,6 +5735,7 @@
             "type": "string"
           },
           "analysis": {
+            "additionalProperties": true,
             "title": "Analysis",
             "type": "object"
           }
@@ -5934,6 +5936,7 @@
                 "type": "array"
               },
               {
+                "additionalProperties": true,
                 "type": "object"
               }
             ],
@@ -5948,6 +5951,7 @@
             "title": "After Text"
           },
           "diff": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Diff"
           },
@@ -6106,6 +6110,7 @@
           "extra": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -6130,6 +6135,7 @@
             "title": "Text"
           },
           "rules": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Rules"
           }
@@ -6156,6 +6162,7 @@
           "meta": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -6550,6 +6557,7 @@
           "meta": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {

--- a/tests/api/test_gpt_draft.py
+++ b/tests/api/test_gpt_draft.py
@@ -1,5 +1,4 @@
 import os
-import os
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
 
@@ -17,13 +16,11 @@ def test_minimal_body_ok(monkeypatch):
         assert r.json().get("status") == "ok"
 
 
-def test_legacy_route_redirects_or_hidden():
+def test_no_legacy_routes():
     with TestClient(app) as c:
         spec = c.get("/openapi.json").json()
         paths = spec["paths"].keys()
         assert "/api/gpt-draft" in paths
         for p in ["/api/gpt/draft", "/api/gpt_draft", "/gpt-draft"]:
             assert p not in paths
-            r = c.post(p, json={"text": "Hi"}, follow_redirects=False)
-            assert r.status_code == 307
-            assert r.headers.get("location") == "/api/gpt-draft"
+            assert c.post(p, json={"text": "Hi"}).status_code == 404

--- a/tests/api/test_openapi_clean.py
+++ b/tests/api/test_openapi_clean.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+
+def test_no_duplicate_paths_or_operation_ids():
+    spec = TestClient(app).get("/openapi.json").json()
+    paths = set(spec["paths"].keys())
+    assert "/api/gpt/draft" not in paths
+    assert "/api/gpt_draft" not in paths
+    assert "/gpt-draft" not in paths
+    assert "/api/citations/resolve" not in paths
+    ids = [op.get("operationId") for p in spec["paths"].values() for op in p.values() if "operationId" in op]
+    assert len(ids) == len(set(ids))

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
 
 client = TestClient(app)
@@ -38,12 +39,5 @@ def test_gpt_draft_ok():
     payload = {"text": "Draft confidentiality clause"}
     r = client.post("/api/gpt-draft", json=payload)
     assert r.status_code == 200
-    r2 = client.post("/api/gpt/draft", json=payload, follow_redirects=False)
-    assert r2.status_code == 307
-    assert r2.headers["location"] == "/api/gpt-draft"
-    r3 = client.post("/gpt-draft", json=payload, follow_redirects=False)
-    assert r3.status_code == 307
-    assert r3.headers["location"] == "/api/gpt-draft"
-    r4 = client.post("/api/gpt_draft", json=payload, follow_redirects=False)
-    assert r4.status_code == 307
-    assert r4.headers["location"] == "/api/gpt-draft"
+    for p in ["/api/gpt/draft", "/gpt-draft", "/api/gpt_draft"]:
+        assert client.post(p, json=payload).status_code == 404


### PR DESCRIPTION
## Summary
- drop legacy gpt-draft aliases and plural citation resolver path
- ensure only canonical `/api/gpt-draft` and `/api/citation/resolve` endpoints remain
- add test to assert OpenAPI contains no duplicate paths or operationIds

## Testing
- `python scripts/gen_openapi.py`
- `pytest tests/api/test_openapi_clean.py tests/api/test_gpt_draft.py tests/test_routes_smoke.py contract_review_app/tests/api/test_openapi_errors_contract.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf184d2be08325b35f5eff210a36b6