### PR TITLE
feat: enforce api key and schema headers

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -177,6 +177,30 @@ Search responses now expose additional context for each chunk:
 These rely on the offset map stored in `corpus_chunks` and help clients
 highlight matches in the original text.
 
+# Block B7 — API key & schema headers
+
+## Summary
+
+Protected API endpoints now share a dependency that validates request headers.
+When `FEATURE_REQUIRE_API_KEY` is truthy, callers must supply `x-api-key`
+matching the `API_KEY` value or receive a **401** response. In all cases the
+`x-schema-version` header is mandatory and must equal `1.3`; otherwise the
+server returns **400**.
+
+## How to verify
+
+```bash
+export FEATURE_REQUIRE_API_KEY=1
+export API_KEY=local-test-key-123
+curl -i -X POST localhost:8000/api/analyze -H 'Content-Type: application/json' \
+  -H 'x-schema-version: 1.3' -d '{"text":"hi"}'
+curl -i -X POST localhost:8000/api/analyze -H 'Content-Type: application/json' \
+  -H 'x-api-key: local-test-key-123' -d '{"text":"hi"}'
+```
+
+The first call (missing API key) yields `401`, while the second (missing
+schema) yields `400`.
+
 # Block B8-S1 — Unified API error format
 
 ## Summary

--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -181,6 +181,7 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 from fastapi.openapi.utils import get_openapi
 from .error_handlers import register_error_handlers
 from .headers import apply_std_headers, compute_cid
+from .auth import require_api_key_and_schema as _require_api_key
 from .mw_utils import capture_response, normalize_status_if_json
 from .models import (
     CitationInput,
@@ -877,8 +878,6 @@ def _env_truthy(name: str) -> bool:
     return (os.getenv(name, "") or "").strip().lower() in _TRUTHY
 
 
-FEATURE_REQUIRE_API_KEY = _env_truthy("FEATURE_REQUIRE_API_KEY")
-API_KEY = os.getenv("API_KEY", "")
 
 _ALLOWED_ORIGINS = [
     o.strip()
@@ -911,12 +910,6 @@ app.add_middleware(
         "x-usage-total",
     ],
 )
-
-
-def _require_api_key(request: Request) -> None:
-    if FEATURE_REQUIRE_API_KEY:
-        if request.headers.get("x-api-key") != API_KEY:
-            raise HTTPException(status_code=401, detail="missing or invalid api key")
 
 
 # ---- Trace middleware and store ------------------------------------

--- a/contract_review_app/api/auth.py
+++ b/contract_review_app/api/auth.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from fastapi import HTTPException, Request
+
+from .models import SCHEMA_VERSION
+
+_TRUTHY = {"1", "true", "yes", "on", "enabled"}
+
+
+def _env_truthy(name: str) -> bool:
+    return (os.getenv(name, "") or "").strip().lower() in _TRUTHY
+
+
+def require_api_key_and_schema(request: Request) -> None:
+    """Validate required request headers.
+
+    ``x-api-key`` must match ``API_KEY`` when ``FEATURE_REQUIRE_API_KEY`` is
+    truthy. ``x-schema-version`` is always required and must equal the
+    current ``SCHEMA_VERSION`` (``1.3``)."""
+    if _env_truthy("FEATURE_REQUIRE_API_KEY"):
+        api_key = os.getenv("API_KEY", "")
+        if request.headers.get("x-api-key") != api_key:
+            raise HTTPException(status_code=401, detail="missing or invalid api key")
+
+    schema = request.headers.get("x-schema-version")
+    if not schema:
+        raise HTTPException(status_code=400, detail="x-schema-version header is required")
+    if schema != SCHEMA_VERSION:
+        raise HTTPException(status_code=400, detail="unsupported schema version")

--- a/contract_review_app/api/dsar.py
+++ b/contract_review_app/api/dsar.py
@@ -1,22 +1,14 @@
-from __future__ import annotations
-
 import json
-import os
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Request, Response, Depends
+from fastapi import APIRouter, HTTPException, Response, Depends
 
 from contract_review_app.security.secure_store import secure_read
+from .auth import require_api_key_and_schema
 
-API_KEY = os.getenv("API_KEY", "")
 _DATA_DIR = Path(__file__).resolve().parents[2] / "var" / "dsar"
 
 router = APIRouter(prefix="/api/dsar")
-
-
-def _check_api_key(request: Request) -> None:
-    if request.headers.get("x-api-key") != API_KEY:
-        raise HTTPException(status_code=401, detail="missing or invalid api key")
 
 
 def _verify_token(token: str) -> None:
@@ -24,7 +16,7 @@ def _verify_token(token: str) -> None:
         raise HTTPException(status_code=401, detail="invalid token")
 
 
-@router.get("/access", dependencies=[Depends(_check_api_key)])
+@router.get("/access", dependencies=[Depends(require_api_key_and_schema)])
 async def dsar_access(identifier: str, token: str):
     _verify_token(token)
     path = _DATA_DIR / f"{identifier}.json"
@@ -37,7 +29,7 @@ async def dsar_access(identifier: str, token: str):
     return data
 
 
-@router.post("/erasure", dependencies=[Depends(_check_api_key)])
+@router.post("/erasure", dependencies=[Depends(require_api_key_and_schema)])
 async def dsar_erasure(identifier: str, token: str):
     _verify_token(token)
     path = _DATA_DIR / f"{identifier}.json"
@@ -49,7 +41,7 @@ async def dsar_erasure(identifier: str, token: str):
     return {"status": "ok"}
 
 
-@router.get("/export", dependencies=[Depends(_check_api_key)])
+@router.get("/export", dependencies=[Depends(require_api_key_and_schema)])
 async def dsar_export(identifier: str, token: str):
     _verify_token(token)
     path = _DATA_DIR / f"{identifier}.json"

--- a/tests/api/test_auth_and_headers.py
+++ b/tests/api/test_auth_and_headers.py
@@ -1,0 +1,17 @@
+import os
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+
+def test_missing_api_key_401(monkeypatch):
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY","1")
+    with TestClient(app) as c:
+        r = c.post("/api/analyze", json={"text":"Hi"}, headers={"x-schema-version":"1.3"})
+        assert r.status_code == 401
+
+
+def test_missing_schema_version_400(monkeypatch):
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY","1"); monkeypatch.setenv("API_KEY","local-test-key-123")
+    with TestClient(app) as c:
+        r = c.post("/api/analyze", json={"text":"Hi"}, headers={"x-api-key":"local-test-key-123"})
+        assert r.status_code == 400

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -21,7 +21,7 @@ def test_api_key_auth(monkeypatch):
     r = client.post("/api/suggest_edits", json=payload)
     assert r.status_code == 401
 
-    headers = {"x-api-key": "secret"}
+    headers = {"x-api-key": "secret", "x-schema-version": "1.3"}
     assert client.post("/api/analyze", json=payload, headers=headers).status_code == 200
     assert (
         client.post(

--- a/tests/security/test_api_key_auth_b5.py
+++ b/tests/security/test_api_key_auth_b5.py
@@ -7,11 +7,13 @@ client = TestClient(app_module.app)
 def test_api_key_required(monkeypatch):
     monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
     monkeypatch.setenv("API_KEY", "secret")
-    app_module.FEATURE_REQUIRE_API_KEY = True
-    app_module.API_KEY = "secret"
 
     r = client.post("/api/analyze", json={"text": "hi"})
     assert r.status_code == 401
 
-    r = client.post("/api/analyze", json={"text": "hi"}, headers={"x-api-key": "secret"})
+    r = client.post(
+        "/api/analyze",
+        json={"text": "hi"},
+        headers={"x-api-key": "secret", "x-schema-version": "1.3"},
+    )
     assert r.status_code == 200

--- a/tests/security/test_dsar_endpoints.py
+++ b/tests/security/test_dsar_endpoints.py
@@ -29,7 +29,7 @@ def test_dsar_endpoints(tmp_path, monkeypatch):
     params = {"identifier": "user@example.com", "token": "t"}
     # missing api key
     assert client.get("/api/dsar/access", params=params).status_code == 401
-    headers = {"x-api-key": "secret"}
+    headers = {"x-api-key": "secret", "x-schema-version": "1.3"}
     r = client.get("/api/dsar/access", params=params, headers=headers)
     assert r.status_code == 200
     assert "user@example.com" not in r.text

--- a/tests/security/test_explain_api_key.py
+++ b/tests/security/test_explain_api_key.py
@@ -19,5 +19,9 @@ def test_api_key_required(monkeypatch):
     monkeypatch.setenv("API_KEY", "secret")
     resp = client.post("/api/explain", json=REQ)
     assert resp.status_code == 401
-    resp2 = client.post("/api/explain", headers={"x-api-key": "secret"}, json=REQ)
+    resp2 = client.post(
+        "/api/explain",
+        headers={"x-api-key": "secret", "x-schema-version": "1.3"},
+        json=REQ,
+    )
     assert resp2.status_code == 200


### PR DESCRIPTION
## Summary
- add shared dependency validating `x-api-key` and `x-schema-version`
- enforce header check across dsar and explain routes
- document header enforcement and add tests

## Testing
- `pytest tests/api/test_auth_and_headers.py tests/security/test_api_key_auth.py tests/security/test_api_key_auth_b5.py tests/security/test_dsar_endpoints.py tests/security/test_explain_api_key.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1f1338e48325a5d539cfc51fc0e2