### PR TITLE
panel: fix qa recheck request payload

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -110,8 +110,9 @@ async function apiAnalyze(text) {
 async function apiGptDraft(text, mode = "friendly", extra = {}) {
   return req("/api/gpt-draft", { method: "POST", body: { text, mode, ...extra }, key: "gpt-draft" });
 }
-async function apiQaRecheck(text, rules = []) {
-  return req("/api/qa-recheck", { method: "POST", body: { text, rules }, key: "qa-recheck" });
+async function apiQaRecheck(text, rules = {}) {
+  const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
+  return req("/api/qa-recheck", { method: "POST", body: { text, rules: dict }, key: "qa-recheck" });
 }
 async function postRedlines(before_text, after_text) {
   const fn = window.postJson || postJson;

--- a/tests/panel/test_qa_recheck_dto.py
+++ b/tests/panel/test_qa_recheck_dto.py
@@ -1,0 +1,41 @@
+import pytest
+from types import SimpleNamespace
+from fastapi.testclient import TestClient
+import contract_review_app.api.app as app_module
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    monkeypatch.setattr(app_module.LLM_CONFIG, "provider", "test", raising=False)
+    monkeypatch.setattr(app_module.LLM_CONFIG, "mode", "test", raising=False)
+    monkeypatch.setattr(app_module.LLM_CONFIG, "valid", True, raising=False)
+
+    def fake_qa(text, rules, timeout_s, profile="smart"):
+        return SimpleNamespace(meta={}, items=[{"code": "A"}])
+
+    monkeypatch.setattr(app_module, "LLM_SERVICE", SimpleNamespace(qa=fake_qa))
+    return TestClient(app_module.app)
+
+
+def test_recheck_minimal_ok(client):
+    r = client.post(
+        "/api/qa-recheck",
+        json={"text": "clause text", "rules": {}},
+        headers={"x-schema-version": "1.3"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("status") == "ok"
+    assert "qa" in data
+
+
+def test_recheck_empty_text_422(client):
+    r = client.post(
+        "/api/qa-recheck",
+        json={"text": "", "rules": {}},
+        headers={"x-schema-version": "1.3"},
+    )
+    assert r.status_code == 422
+    detail = r.json().get("detail")
+    assert isinstance(detail, list)
+    assert any("text is empty" in (d.get("msg") or "") for d in detail)

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -110,8 +110,9 @@ async function apiAnalyze(text) {
 async function apiGptDraft(text, mode = "friendly", extra = {}) {
   return req("/api/gpt-draft", { method: "POST", body: { text, mode, ...extra }, key: "gpt-draft" });
 }
-async function apiQaRecheck(text, rules = []) {
-  return req("/api/qa-recheck", { method: "POST", body: { text, rules }, key: "qa-recheck" });
+async function apiQaRecheck(text, rules = {}) {
+  const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
+  return req("/api/qa-recheck", { method: "POST", body: { text, rules: dict }, key: "qa-recheck" });
 }
 async function postRedlines(before_text, after_text) {
   const fn = window.postJson || postJson;

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -152,8 +152,9 @@ export async function apiGptDraft(text: string, mode = 'friendly', extra: any = 
   return req('/api/gpt-draft', { method: 'POST', body: { text, mode, ...extra }, key: 'gpt-draft' });
 }
 
-export async function apiQaRecheck(text: string, rules: any[] = []) {
-  return req('/api/qa-recheck', { method: 'POST', body: { text, rules }, key: 'qa-recheck' });
+export async function apiQaRecheck(text: string, rules: any = {}) {
+  const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
+  return req('/api/qa-recheck', { method: 'POST', body: { text, rules: dict }, key: 'qa-recheck' });
 }
 
 export async function postRedlines(before_text: string, after_text: string) {

--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -13,6 +13,16 @@ async function getWholeDocText(): Promise<string> {
   });
 }
 
+/** Выделенный текст (клаузула) */
+async function getSelectedText(): Promise<string> {
+  return await Word.run(async ctx => {
+    const sel = ctx.document.getSelection();
+    sel.load('text');
+    await ctx.sync();
+    return (sel.text || '').trim();
+  });
+}
+
 async function postJson(path: string, body: any): Promise<Response> {
   const resp = await fetch(`${backend}${path}`, {
     method: 'POST',
@@ -46,9 +56,9 @@ async function onAnalyzeDoc(e: Event) {
 /** QA Recheck — без правил (для smoke) */
 async function onQARecheck(e: Event) {
   e.preventDefault();
-  const text = await getWholeDocText();
-  if (!text) { notify.warn('В документе нет текста'); return; }
-  const resp = await postJson('/api/qa-recheck', { text, rules: [] });
+  const text = await getSelectedText();
+  if (!text) { notify.warn('Select clause text first'); return; }
+  const resp = await postJson('/api/qa-recheck', { text, rules: {} });
   const js = await resp.json();
   notify.ok(`QA: HTTP ${resp.status}`);
   console.log('QA resp:', js);


### PR DESCRIPTION
## Summary
- ensure QA recheck sends selected text and rules object
- normalise rules to dict in panel API client
- cover QA recheck DTO with tests for valid and empty text

## Testing
- `pytest tests/panel/test_qa_recheck_dto.py::test_recheck_minimal_ok tests/panel/test_qa_recheck_dto.py::test_recheck_empty_text_422 -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf29db74148325b319aa746a3fd420