### PR TITLE
Add citation resolve client and tests

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -118,6 +118,14 @@ async function postRedlines(before_text, after_text) {
   const fn = window.postJson || postJson;
   return fn("/api/panel/redlines", { before_text, after_text });
 }
+async function postCitationResolve({ findings, citations }) {
+  const hasF = Array.isArray(findings) && findings.length > 0;
+  const hasC = Array.isArray(citations) && citations.length > 0;
+  if (hasF === hasC) throw new Error('Provide exactly one of findings or citations');
+  const fn = window.postJson || postJson;
+  return fn('/api/citation/resolve', hasF ? { findings } : { citations });
+}
+window.postCitationResolve = postCitationResolve;
 export {
   postJson,
   apiAnalyze,
@@ -125,6 +133,7 @@ export {
   apiHealth,
   apiQaRecheck,
   postRedlines,
+  postCitationResolve,
   applyMetaToBadges,
   metaFromResponse,
   parseFindings

--- a/tests/panel/test_citation_resolve.py
+++ b/tests/panel/test_citation_resolve.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_ok_findings_only():
+    payload = {"findings": [{"message": "gdpr"}]}
+    r = client.post("/api/citation/resolve", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["citations"], "expected citations returned"
+
+
+def test_ok_citations_only():
+    payload = {"citations": [{"instrument": "Act", "section": "1"}]}
+    r = client.post("/api/citation/resolve", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["citations"][0]["instrument"] == "Act"
+
+
+def test_fail_both_or_none_400():
+    both = {
+        "findings": [{"message": "gdpr"}],
+        "citations": [{"instrument": "Act", "section": "1"}],
+    }
+    r1 = client.post("/api/citation/resolve", json=both)
+    r2 = client.post("/api/citation/resolve", json={})
+    assert r1.status_code == 400
+    assert r2.status_code == 400

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -118,6 +118,14 @@ async function postRedlines(before_text, after_text) {
   const fn = window.postJson || postJson;
   return fn("/api/panel/redlines", { before_text, after_text });
 }
+async function postCitationResolve({ findings, citations }) {
+  const hasF = Array.isArray(findings) && findings.length > 0;
+  const hasC = Array.isArray(citations) && citations.length > 0;
+  if (hasF === hasC) throw new Error('Provide exactly one of findings or citations');
+  const fn = window.postJson || postJson;
+  return fn('/api/citation/resolve', hasF ? { findings } : { citations });
+}
+window.postCitationResolve = postCitationResolve;
 export {
   postJson,
   apiAnalyze,
@@ -125,6 +133,7 @@ export {
   apiHealth,
   apiQaRecheck,
   postRedlines,
+  postCitationResolve,
   applyMetaToBadges,
   metaFromResponse,
   parseFindings


### PR DESCRIPTION
## Summary
- add `postCitationResolve` to panel API client with XOR validation
- expose resolve citations test button in panel self-test
- cover citation resolver endpoint with panel tests

## Testing
- `pre-commit run --files word_addin_dev/app/assets/api-client.js contract_review_app/contract_review_app/static/panel/app/assets/api-client.js word_addin_dev/app/selftest.js tests/panel/test_citation_resolve.py`
- `node tests/panel/test_selftest_call.js`
- `pytest tests/panel/test_citation_resolve.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf2cbd26cc8325aee8866c55c85ffe