### PR TITLE
Add i18n scanning script and CI check

### DIFF
--- a/.github/workflows/i18n-lint.yml
+++ b/.github/workflows/i18n-lint.yml
@@ -1,0 +1,15 @@
+name: i18n-lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  i18n-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+            python-version: '3.x'
+      - run: python tools/i18n_scan.py

--- a/README.md
+++ b/README.md
@@ -79,3 +79,13 @@ Exit code `0` means all hard requirements pass, while `2` indicates at least one
 ```bash
 pytest tests/insurance -q
 ```
+
+## i18n inventory
+
+To list any Cyrillic characters in source paths run:
+
+```bash
+rg -n --pcre2 "[\p{Cyrillic}]" contract_review_app core word_addin_dev | tee i18n_inventory.txt
+```
+
+The generated `i18n_inventory.txt` should be empty in a clean repository.

--- a/tests/i18n/test_i18n_scan.py
+++ b/tests/i18n/test_i18n_scan.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+from pathlib import Path
+
+def run_scan(target: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, 'tools/i18n_scan.py', str(target)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_detects_cyrillic(tmp_path: Path):
+    p = tmp_path / 'bad.txt'
+    p.write_text('hello\nпривет')
+    proc = run_scan(tmp_path)
+    assert proc.returncode == 1
+    assert 'bad.txt' in proc.stdout
+
+
+def test_scan_is_deterministic(tmp_path: Path):
+    p = tmp_path / 'bad.txt'
+    p.write_text('привет')
+    first = run_scan(tmp_path)
+    second = run_scan(tmp_path)
+    assert first.stdout == second.stdout

--- a/tools/i18n_scan.py
+++ b/tools/i18n_scan.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Simple i18n scanner.
+
+Searches for any non-ASCII or Cyrillic characters in given directories.
+Exits with code 1 if any such characters are found.
+
+Usage: python tools/i18n_scan.py [PATH ...]
+If no paths are provided, defaults to contract_review_app/, word_addin_dev/, core/rules/
+The following directory names are ignored anywhere in the path:
+  tests/, samples/, docs/, i18n/fixtures/
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+CYRILLIC_RE = re.compile(r"[\u0400-\u04FF]")
+NON_ASCII_RE = re.compile(r"[^\x00-\x7F]")
+DEFAULT_PATHS = ["contract_review_app", "word_addin_dev", "core/rules"]
+EXCLUDE_PARTS = {"tests", "samples", "docs"}
+# special prefix to exclude like i18n/fixtures
+EXCLUDE_PREFIXES = [Path("i18n/fixtures")]
+
+
+def _is_excluded(path: Path) -> bool:
+    parts = set(path.parts)
+    if parts & EXCLUDE_PARTS:
+        return True
+    for pref in EXCLUDE_PREFIXES:
+        try:
+            path.relative_to(pref)
+            return True
+        except Exception:
+            continue
+    return False
+
+
+def _scan_file(path: Path) -> List[Tuple[int, int, str]]:
+    issues: List[Tuple[int, int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return issues
+    for lineno, line in enumerate(text.splitlines(), 1):
+        # find first offending char to report; collect all though
+        for col, ch in enumerate(line, 1):
+            if CYRILLIC_RE.match(ch) or NON_ASCII_RE.match(ch):
+                issues.append((lineno, col, ch))
+    return issues
+
+
+def _scan_paths(paths: Iterable[Path]) -> List[str]:
+    findings: List[str] = []
+    for root in sorted(set(paths)):
+        if not root.exists():
+            continue
+        if root.is_file():
+            iterable = [root]
+        else:
+            iterable = sorted(p for p in root.rglob("*") if p.is_file())
+        for file in iterable:
+            if _is_excluded(file):
+                continue
+            issues = _scan_file(file)
+            for lineno, col, ch in issues:
+                findings.append(f"{file}:{lineno}:{col}:{ch}")
+    return findings
+
+
+def main(argv: List[str]) -> int:
+    paths = [Path(p) for p in argv] if argv else [Path(p) for p in DEFAULT_PATHS]
+    findings = _scan_paths(paths)
+    for line in findings:
+        print(line)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add i18n_scan tool to detect Cyrillic or non-ASCII characters
- document repository-wide Cyrillic scan command
- run i18n scanner in GitHub Actions
- test scanner detection and deterministic output

## Testing
- `pytest tests/i18n/test_i18n_scan.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf313ca8fc83259bd25cb1cea0b379