### PR TITLE
Refresh OpenAPI schema and expand client APIs

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -843,7 +843,6 @@ def _custom_openapi():
         content.setdefault("examples", {})["default"] = {
             "summary": "Example",
             "value": {},
-            "headers": example_headers,
         }
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -114,6 +114,14 @@ async function apiQaRecheck(text, rules = {}) {
   const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
   return req("/api/qa-recheck", { method: "POST", body: { text, rules: dict }, key: "qa-recheck" });
 }
+async function apiSummary(text, mode = "live") {
+  return req("/api/summary", { method: "POST", body: { text, mode }, key: "summary" });
+}
+async function apiSuggestEdits(text, findings = []) {
+  const body = { text };
+  if (Array.isArray(findings) && findings.length) body.findings = findings;
+  return req("/api/suggest_edits", { method: "POST", body, key: "suggest_edits" });
+}
 async function postRedlines(before_text, after_text) {
   const fn = window.postJson || postJson;
   return fn("/api/panel/redlines", { before_text, after_text });
@@ -132,6 +140,8 @@ export {
   apiGptDraft,
   apiHealth,
   apiQaRecheck,
+  apiSummary,
+  apiSuggestEdits,
   postRedlines,
   postCitationResolve,
   applyMetaToBadges,

--- a/openapi.json
+++ b/openapi.json
@@ -174,12 +174,7 @@
                 "examples": {
                   "default": {
                     "summary": "Example",
-                    "value": {},
-                    "headers": {
-                      "x-schema-version": "1.3",
-                      "x-latency-ms": 12,
-                      "x-cid": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    }
+                    "value": {}
                   }
                 }
               }
@@ -930,6 +925,179 @@
         }
       }
     },
+    "/api/trace/{cid}.html": {
+      "get": {
+        "summary": "Get Trace Suffix",
+        "operationId": "get_trace_suffix_api_trace__cid__html_get",
+        "parameters": [
+          {
+            "name": "cid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests",
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error",
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "504": {
+            "description": "Gateway Timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/trace/{cid}": {
       "get": {
         "summary": "Get Trace",
@@ -941,6 +1109,7 @@
             "required": true,
             "schema": {
               "type": "string",
+              "pattern": "^[A-Za-z0-9\\-:]{3,64}$",
               "title": "Cid"
             }
           }
@@ -3399,12 +3568,7 @@
                 "examples": {
                   "default": {
                     "summary": "Example",
-                    "value": {},
-                    "headers": {
-                      "x-schema-version": "1.3",
-                      "x-latency-ms": 12,
-                      "x-cid": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    }
+                    "value": {}
                   }
                 }
               }

--- a/tests/openapi/test_openapi_examples.py
+++ b/tests/openapi/test_openapi_examples.py
@@ -1,0 +1,10 @@
+import json
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+def test_examples_roundtrip():
+    client = TestClient(app)
+    live = client.get('/openapi.json').json()
+    with open('openapi.json') as f:
+        saved = json.load(f)
+    assert live == saved

--- a/tests/openapi/test_openapi_ops.py
+++ b/tests/openapi/test_openapi_ops.py
@@ -1,0 +1,11 @@
+import json
+
+def test_operation_ids_unique():
+    with open('openapi.json') as f:
+        spec = json.load(f)
+    ids = []
+    for path_item in spec.get('paths', {}).values():
+        for op in path_item.values():
+            if isinstance(op, dict) and op.get('operationId'):
+                ids.append(op['operationId'])
+    assert len(ids) == len(set(ids))

--- a/tests/openapi/test_openapi_valid.py
+++ b/tests/openapi/test_openapi_valid.py
@@ -1,0 +1,7 @@
+import json
+from openapi_spec_validator import validate_spec
+
+def test_openapi_is_valid():
+    with open('openapi.json') as f:
+        spec = json.load(f)
+    validate_spec(spec)

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -114,6 +114,14 @@ async function apiQaRecheck(text, rules = {}) {
   const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
   return req("/api/qa-recheck", { method: "POST", body: { text, rules: dict }, key: "qa-recheck" });
 }
+async function apiSummary(text, mode = "live") {
+  return req("/api/summary", { method: "POST", body: { text, mode }, key: "summary" });
+}
+async function apiSuggestEdits(text, findings = []) {
+  const body = { text };
+  if (Array.isArray(findings) && findings.length) body.findings = findings;
+  return req("/api/suggest_edits", { method: "POST", body, key: "suggest_edits" });
+}
 async function postRedlines(before_text, after_text) {
   const fn = window.postJson || postJson;
   return fn("/api/panel/redlines", { before_text, after_text });
@@ -132,6 +140,8 @@ export {
   apiGptDraft,
   apiHealth,
   apiQaRecheck,
+  apiSummary,
+  apiSuggestEdits,
   postRedlines,
   postCitationResolve,
   applyMetaToBadges,


### PR DESCRIPTION
## Summary
- regenerate OpenAPI schema from FastAPI and remove invalid example headers
- add summary and suggest_edits helpers to API client
- add tests validating spec and operation IDs

## Testing
- `pytest tests/openapi/test_openapi_valid.py::test_openapi_is_valid -q`
- `pytest tests/openapi/test_openapi_ops.py::test_operation_ids_unique -q`
- `pytest tests/openapi/test_openapi_examples.py::test_examples_roundtrip -q`
- `node tests/panel/test_selftest_call.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf3325519c832581dd07ac3c2954e2