### PR TITLE
feat: bump panel build token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Thumbs.db
 # Test fixtures
 tests/analysis/*.docx
 tests/analysis/*.pdf
+contract_review_app/contract_review_app/static/panel/.build-token

--- a/bump_build.py
+++ b/bump_build.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Utility for bumping cache-buster build token.
+
+This script generates a build token of the form ``build-YYYYMMDD-HHMMSS`` and
+injects it into static assets that contain the ``__BUILD_TS__`` placeholder.  The
+current token is also written to ``contract_review_app/contract_review_app/static/panel/.build-token``
+so that other tooling can reference the most recent build identifier.
+
+The implementation is intentionally lightweight – it only performs a plain text
+replacement and skips files that cannot be decoded as UTF-8.  It is suitable for
+both manual execution and invocation from tests.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+import re
+
+ROOT = Path(__file__).resolve().parent
+TOKEN_FILE = ROOT / "contract_review_app" / "contract_review_app" / "static" / "panel" / ".build-token"
+PLACEHOLDER = "__BUILD_TS__"
+TOKEN_PATTERN = re.compile(r"build-\d{8}-\d{6}|__BUILD_TS__")
+
+
+def _iter_files(paths: Iterable[Path]) -> Iterable[Path]:
+    """Yield files under provided paths."""
+    for base in paths:
+        if base.is_file():
+            yield base
+        elif base.is_dir():
+            for path in base.rglob("*"):
+                if path.is_file():
+                    yield path
+
+
+def bump_build(root: Path | None = None) -> str:
+    """Generate a new build token and inject it into static files.
+
+    Parameters
+    ----------
+    root:
+        Optional repository root.  Defaults to the directory containing this
+        module.
+
+    Returns
+    -------
+    str
+        The generated build token.
+    """
+
+    repo = root or ROOT
+    token = datetime.utcnow().strftime("build-%Y%m%d-%H%M%S")
+
+    targets = [repo / "word_addin_dev", repo / "contract_review_app" / "contract_review_app" / "static" / "panel"]
+    for path in _iter_files(targets):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if TOKEN_PATTERN.search(text):
+            path.write_text(TOKEN_PATTERN.sub(token, text), encoding="utf-8")
+
+    TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+    TOKEN_FILE.write_text(token, encoding="utf-8")
+
+    return token
+
+
+if __name__ == "__main__":
+    bump_build()

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build:panel": "python tools/build_panel.py"
+  },
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/tests/panel/test_cache_buster.py
+++ b/tests/panel/test_cache_buster.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from bump_build import bump_build
+
+
+def test_build_token_injected(tmp_path):
+    token = bump_build()
+
+    assert re.fullmatch(r"build-\d{8}-\d{6}", token)
+
+    manifest = Path("word_addin_dev/manifest.xml").read_text(encoding="utf-8")
+    assert f"b={token}" in manifest
+
+    token_file = Path("contract_review_app/contract_review_app/static/panel/.build-token")
+    assert token_file.read_text(encoding="utf-8").strip() == token

--- a/tools/build_panel.py
+++ b/tools/build_panel.py
@@ -1,0 +1,39 @@
+"""Build script for panel static assets.
+
+This script is intended to be invoked from ``npm run build:panel``.  It bumps
+the build token (replacing ``__BUILD_TS__`` placeholders) and then copies the
+panel artefacts from ``word_addin_dev`` into
+``contract_review_app/contract_review_app/static/panel``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+from bump_build import bump_build
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "word_addin_dev"
+DEST = ROOT / "contract_review_app" / "contract_review_app" / "static" / "panel"
+
+FILES = [
+    "taskpane.html",
+    "taskpane.bundle.js",
+    "panel_selftest.html",
+]
+
+
+def main() -> None:
+    bump_build(ROOT)
+
+    DEST.mkdir(parents=True, exist_ok=True)
+    for name in FILES:
+        shutil.copy2(SRC / name, DEST / name)
+
+    # Copy assets directory
+    shutil.copytree(SRC / "app" / "assets", DEST / "app" / "assets", dirs_exist_ok=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to generate cache-busting build token and inject into panel assets
- create build helper that copies panel artefacts and wires npm `build:panel`
- ensure build token file is ignored and covered by test

## Testing
- `python -m pytest -q --maxfail=0 --disable-warnings tests/panel/test_cache_buster.py tests/codex/test_trace_and_export.py tests/panel/test_qa_recheck_dto.py tests/panel/test_citation_resolve.py tests/openapi/test_openapi_valid.py tests/openapi/test_openapi_ops.py contract_review_app/tests/api/test_app_contract.py` *(fails: assert 400 == 200)*


------
https://chatgpt.com/codex/tasks/task_e_68bf362080c4832580656152c4f9aade