### PR TITLE
Add minimal panel and OpenAPI tests

### DIFF
--- a/tests/panel/test_corpus_search.py
+++ b/tests/panel/test_corpus_search.py
@@ -1,0 +1,41 @@
+import sys
+import types
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    orig_app = sys.modules.pop("contract_review_app.api.app", None)
+    orig_cs = sys.modules.get("contract_review_app.api.corpus_search")
+
+    router = APIRouter(prefix="/api/corpus")
+
+    @router.post("/search")
+    def search(body: dict):
+        return {"hits": []}
+
+    fake_cs = types.ModuleType("contract_review_app.api.corpus_search")
+    fake_cs.router = router
+    sys.modules["contract_review_app.api.corpus_search"] = fake_cs
+
+    import contract_review_app.api.app as app_module
+
+    client = TestClient(app_module.app)
+    yield client
+
+    if orig_app is not None:
+        sys.modules["contract_review_app.api.app"] = orig_app
+    else:
+        sys.modules.pop("contract_review_app.api.app", None)
+
+    if orig_cs is not None:
+        sys.modules["contract_review_app.api.corpus_search"] = orig_cs
+    else:
+        sys.modules.pop("contract_review_app.api.corpus_search", None)
+
+
+def test_corpus_search_ok(client):
+    r = client.post("/api/corpus/search", json={"q": "x"})
+    assert r.status_code == 200

--- a/tests/panel/test_explain.py
+++ b/tests/panel/test_explain.py
@@ -1,0 +1,42 @@
+import sys
+import types
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    orig_app = sys.modules.pop("contract_review_app.api.app", None)
+    orig_ex = sys.modules.get("contract_review_app.api.explain")
+
+    router = APIRouter(prefix="/api")
+
+    @router.post("/explain")
+    def explain(body: dict):
+        return {"status": "ok"}
+
+    fake_ex = types.ModuleType("contract_review_app.api.explain")
+    fake_ex.router = router
+    sys.modules["contract_review_app.api.explain"] = fake_ex
+
+    import contract_review_app.api.app as app_module
+
+    client = TestClient(app_module.app)
+    yield client
+
+    if orig_app is not None:
+        sys.modules["contract_review_app.api.app"] = orig_app
+    else:
+        sys.modules.pop("contract_review_app.api.app", None)
+
+    if orig_ex is not None:
+        sys.modules["contract_review_app.api.explain"] = orig_ex
+    else:
+        sys.modules.pop("contract_review_app.api.explain", None)
+
+
+def test_explain_ok(client):
+    payload = {"finding": {"span": {"start": 0, "end": 1}, "text": "x", "lang": "latin"}}
+    r = client.post("/api/explain", json=payload)
+    assert r.status_code == 200

--- a/tests/panel/test_redlines_client.py
+++ b/tests/panel/test_redlines_client.py
@@ -1,0 +1,18 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_redlines_client_sends_two_fields():
+    api_path = Path(__file__).resolve().parents[2] / 'word_addin_dev' / 'app' / 'assets' / 'api-client.js'
+    script = f"""
+    global.window = {{}};
+    const mod = await import('file://{api_path.as_posix()}');
+    const calls = [];
+    global.window.postJson = (url, body) => {{ calls.push([url, body]); return Promise.resolve({{}}); }};
+    await mod.postRedlines('a', 'b');
+    console.log(JSON.stringify(calls));
+    """
+    result = subprocess.run(['node', '--input-type=module', '-e', script], capture_output=True, text=True, check=True)
+    calls = json.loads(result.stdout.strip())
+    assert calls == [["/api/panel/redlines", {"before_text": "a", "after_text": "b"}]]

--- a/tests/panel/test_redlines_dto.py
+++ b/tests/panel/test_redlines_dto.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+def test_redlines_minimal_ok():
+    payload = {"before_text": "a", "after_text": "b"}
+    r = client.post("/api/panel/redlines", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("status") == "ok"
+    assert isinstance(data.get("diff_unified"), str)
+    assert isinstance(data.get("diff_html"), str)


### PR DESCRIPTION
## Summary
- add DTO test for panel redlines endpoint
- ensure frontend postRedlines sends expected payload
- stub corpus search and explain routes for basic 200 responses

## Testing
- `pytest tests/panel/test_redlines_dto.py tests/panel/test_redlines_client.py tests/panel/test_corpus_search.py tests/panel/test_explain.py tests/openapi/test_openapi_valid.py tests/openapi/test_openapi_ops.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf392452b883258f17bddb1261182e