### PR TITLE
feat(trace): record classifier outputs in trace

### DIFF
--- a/tests/trace/test_trace_contains_doctype_and_clauses.py
+++ b/tests/trace/test_trace_contains_doctype_and_clauses.py
@@ -1,0 +1,25 @@
+import os
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+
+def test_trace_contains_doctype_and_clauses():
+    os.environ.setdefault("LLM_PROVIDER", "mock")
+    client = TestClient(app)
+    text = (
+        "NON-DISCLOSURE AGREEMENT\n"
+        "Confidentiality. Each party agrees to keep all information confidential.\n"
+        "Governing Law. This agreement is governed by the laws of England.\n"
+    )
+    headers = {"x-schema-version": "1.3"}
+    resp = client.post("/api/analyze", json={"text": text}, headers=headers)
+    assert resp.status_code == 200
+    cid = resp.headers["x-cid"]
+    trace = client.get(f"/api/trace/{cid}").json()
+    classifiers = trace.get("classifiers")
+    assert classifiers is not None
+    assert classifiers.get("document_type") == "NDA"
+    assert "confidentiality" in classifiers.get("clause_types", [])
+    assert classifiers.get("active_rule_packs")
+    assert "language" in classifiers


### PR DESCRIPTION
## Summary
- include document type, clause types, active rule packs, confidence, and language in each trace entry
- add regression test ensuring `/api/trace/{cid}` exposes classifier data

## Testing
- `pytest tests/trace/test_trace_contains_doctype_and_clauses.py`
- `pytest -q -k "analyze and not llm"` *(fails: missing `x-schema-version` header -> 400 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3ea7f28c832591a15bd27cebf179