### PR TITLE
feat: enforce schema headers and default language

### DIFF
--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -31,7 +31,7 @@ class AnalyzeRequest(_DTOBase):
     """
 
     text: str = Field(validation_alias=AliasChoices("text", "clause", "body"))
-    language: str = "en"
+    language: str = "en-GB"
     mode: str | None = None
     risk: str | None = None
 
@@ -103,6 +103,7 @@ class QARecheckIn(_DTOBase):
 
     text: str
     rules: Dict[str, Any] = Field(default_factory=dict)
+    language: str = "en-GB"
 
     @field_validator("text")
     @classmethod

--- a/openapi.json
+++ b/openapi.json
@@ -4726,6 +4726,385 @@
         }
       }
     },
+    "/api/corpus/search": {
+      "post": {
+        "summary": "Corpus Search",
+        "operationId": "corpus_search_api_corpus_search_post",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 10,
+              "title": "Page Size"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CorpusSearchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorpusSearchResponse"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Too Many Requests",
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error",
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "504": {
+            "description": "Gateway Timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/explain": {
+      "post": {
+        "summary": "Api Explain",
+        "operationId": "api_explain_api_explain_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExplainRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExplainResponse"
+                },
+                "examples": {
+                  "default": {
+                    "summary": "Example",
+                    "value": {}
+                  }
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "504": {
+            "description": "Gateway Timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/companies/search": {
       "post": {
         "tags": [
@@ -5847,6 +6226,7 @@
         "additionalProperties": false,
         "description": "Public request DTO for ``/api/analyze``.\n\nAccepts ``text`` as a required field while allowing legacy aliases\n``clause`` and ``body`` for backward compatibility. The aliases are\nfolded into ``text`` during validation so downstream logic only needs to\nhandle a single attribute.",
         "example": {
+          "language": "en-GB",
           "text": "Hello"
         },
         "properties": {
@@ -5856,7 +6236,7 @@
             "type": "string"
           },
           "language": {
-            "default": "en",
+            "default": "en-GB",
             "title": "Language",
             "type": "string"
           },
@@ -5910,6 +6290,114 @@
         ],
         "title": "AnalyzeResponse",
         "type": "object"
+      },
+      "Citation": {
+        "properties": {
+          "system": {
+            "type": "string",
+            "enum": [
+              "UK",
+              "UA",
+              "EU",
+              "INT"
+            ],
+            "title": "System",
+            "default": "UK"
+          },
+          "instrument": {
+            "type": "string",
+            "title": "Instrument"
+          },
+          "section": {
+            "type": "string",
+            "title": "Section"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "link": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "evidence": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Evidence"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "evidence_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "instrument",
+          "section"
+        ],
+        "title": "Citation",
+        "description": "Legal citation item; url is validated if present."
       },
       "CitationInput": {
         "additionalProperties": false,
@@ -6001,6 +6489,106 @@
         ],
         "title": "CitationResolveResponse"
       },
+      "CorpusSearchRequest": {
+        "properties": {
+          "q": {
+            "type": "string",
+            "title": "Q"
+          },
+          "k": {
+            "type": "integer",
+            "title": "K",
+            "default": 10
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "hybrid",
+              "bm25",
+              "vector"
+            ],
+            "title": "Method",
+            "default": "hybrid"
+          },
+          "jurisdiction": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Jurisdiction"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "act_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Act Code"
+          },
+          "section_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Section Code"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "q"
+        ],
+        "title": "CorpusSearchRequest"
+      },
+      "CorpusSearchResponse": {
+        "properties": {
+          "hits": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array",
+            "title": "Hits"
+          },
+          "paging": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Paging"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "hits"
+        ],
+        "title": "CorpusSearchResponse"
+      },
       "Coverage": {
         "properties": {
           "rules_total": {
@@ -6034,7 +6622,7 @@
           "language": {
             "type": "string",
             "title": "Language",
-            "default": "en"
+            "default": "en-GB"
           },
           "mode": {
             "type": "string",
@@ -6073,7 +6661,14 @@
         "required": [
           "text"
         ],
-        "title": "DraftIn"
+        "title": "DraftIn",
+        "example": {
+          "after_text": "",
+          "before_text": "",
+          "language": "en-GB",
+          "mode": "friendly",
+          "text": "Example clause."
+        }
       },
       "DraftOut": {
         "properties": {
@@ -6148,6 +6743,186 @@
         ],
         "title": "DraftOut"
       },
+      "Evidence": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "link": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "Evidence",
+        "description": "Supporting evidence snippet for a citation."
+      },
+      "ExplainRequest": {
+        "properties": {
+          "finding": {
+            "$ref": "#/components/schemas/Finding"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "citations": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Citation"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Citations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finding"
+        ],
+        "title": "ExplainRequest",
+        "description": "Request DTO for /api/explain."
+      },
+      "ExplainResponse": {
+        "properties": {
+          "reasoning": {
+            "type": "string",
+            "title": "Reasoning"
+          },
+          "citations": {
+            "items": {
+              "$ref": "#/components/schemas/Citation"
+            },
+            "type": "array",
+            "title": "Citations"
+          },
+          "evidence": {
+            "items": {
+              "$ref": "#/components/schemas/Evidence"
+            },
+            "type": "array",
+            "title": "Evidence"
+          },
+          "verification_status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "missing_citations",
+              "invalid"
+            ],
+            "title": "Verification Status",
+            "default": "ok"
+          },
+          "trace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trace"
+          },
+          "x_schema_version": {
+            "type": "string",
+            "title": "X Schema Version",
+            "default": "1.3"
+          }
+        },
+        "type": "object",
+        "required": [
+          "reasoning"
+        ],
+        "title": "ExplainResponse",
+        "description": "Response DTO for /api/explain."
+      },
+      "Finding": {
+        "$defs": {
+          "Span": {
+            "additionalProperties": false,
+            "properties": {
+              "start": {
+                "minimum": 0,
+                "title": "Start",
+                "type": "integer"
+              },
+              "end": {
+                "minimum": 0,
+                "title": "End",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "start",
+              "end"
+            ],
+            "title": "Span",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "span": {
+            "$ref": "#/components/schemas/Span"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "lang": {
+            "enum": [
+              "latin",
+              "cyrillic"
+            ],
+            "title": "Lang",
+            "type": "string"
+          }
+        },
+        "required": [
+          "span",
+          "text",
+          "lang"
+        ],
+        "title": "Finding",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -6201,6 +6976,34 @@
           "metrics"
         ],
         "title": "MetricsResponse"
+      },
+      "Paging": {
+        "properties": {
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "pages": {
+            "type": "integer",
+            "title": "Pages"
+          }
+        },
+        "type": "object",
+        "required": [
+          "page",
+          "page_size",
+          "total",
+          "pages"
+        ],
+        "title": "Paging"
       },
       "Perf": {
         "properties": {
@@ -6302,6 +7105,11 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Rules"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language",
+            "default": "en-GB"
           }
         },
         "additionalProperties": false,
@@ -6496,155 +7304,6 @@
         ],
         "title": "RuleMetric"
       },
-      "ValidationError": {
-        "properties": {
-          "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
-            "type": "array",
-            "title": "Location"
-          },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          }
-        },
-        "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError"
-      },
-      "Finding": {
-        "$defs": {
-          "Span": {
-            "additionalProperties": false,
-            "properties": {
-              "start": {
-                "minimum": 0,
-                "title": "Start",
-                "type": "integer"
-              },
-              "end": {
-                "minimum": 0,
-                "title": "End",
-                "type": "integer"
-              }
-            },
-            "required": [
-              "start",
-              "end"
-            ],
-            "title": "Span",
-            "type": "object"
-          }
-        },
-        "additionalProperties": false,
-        "properties": {
-          "span": {
-            "$ref": "#/components/schemas/Span"
-          },
-          "text": {
-            "title": "Text",
-            "type": "string"
-          },
-          "lang": {
-            "enum": [
-              "latin",
-              "cyrillic"
-            ],
-            "title": "Lang",
-            "type": "string"
-          }
-        },
-        "required": [
-          "span",
-          "text",
-          "lang"
-        ],
-        "title": "Finding",
-        "type": "object"
-      },
-      "Span": {
-        "additionalProperties": false,
-        "properties": {
-          "start": {
-            "minimum": 0,
-            "title": "Start",
-            "type": "integer"
-          },
-          "end": {
-            "minimum": 0,
-            "title": "End",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "start",
-          "end"
-        ],
-        "title": "Span",
-        "type": "object"
-      },
-      "Segment": {
-        "$defs": {
-          "Span": {
-            "additionalProperties": false,
-            "properties": {
-              "start": {
-                "minimum": 0,
-                "title": "Start",
-                "type": "integer"
-              },
-              "end": {
-                "minimum": 0,
-                "title": "End",
-                "type": "integer"
-              }
-            },
-            "required": [
-              "start",
-              "end"
-            ],
-            "title": "Span",
-            "type": "object"
-          }
-        },
-        "additionalProperties": false,
-        "properties": {
-          "span": {
-            "$ref": "#/components/schemas/Span"
-          },
-          "lang": {
-            "enum": [
-              "latin",
-              "cyrillic"
-            ],
-            "title": "Lang",
-            "type": "string"
-          }
-        },
-        "required": [
-          "span",
-          "lang"
-        ],
-        "title": "Segment",
-        "type": "object"
-      },
       "SearchHit": {
         "$defs": {
           "Span": {
@@ -6774,6 +7433,165 @@
           "span"
         ],
         "title": "SearchHit",
+        "type": "object"
+      },
+      "Span-Input": {
+        "properties": {
+          "start": {
+            "type": "integer",
+            "title": "Start",
+            "default": 0
+          },
+          "length": {
+            "type": "integer",
+            "title": "Length",
+            "default": 0
+          },
+          "page": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page"
+          },
+          "block": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Block"
+          }
+        },
+        "type": "object",
+        "title": "Span",
+        "description": "Text location anchor for UI annotations and cross-checks (absolute coords)."
+      },
+      "Span-Output": {
+        "properties": {
+          "start": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Start"
+          },
+          "end": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "End"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "title": "Span"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "Span": {
+        "additionalProperties": false,
+        "properties": {
+          "start": {
+            "minimum": 0,
+            "title": "Start",
+            "type": "integer"
+          },
+          "end": {
+            "minimum": 0,
+            "title": "End",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "start",
+          "end"
+        ],
+        "title": "Span",
+        "type": "object"
+      },
+      "Segment": {
+        "$defs": {
+          "Span": {
+            "additionalProperties": false,
+            "properties": {
+              "start": {
+                "minimum": 0,
+                "title": "Start",
+                "type": "integer"
+              },
+              "end": {
+                "minimum": 0,
+                "title": "End",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "start",
+              "end"
+            ],
+            "title": "Span",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "span": {
+            "$ref": "#/components/schemas/Span"
+          },
+          "lang": {
+            "enum": [
+              "latin",
+              "cyrillic"
+            ],
+            "title": "Lang",
+            "type": "string"
+          }
+        },
+        "required": [
+          "span",
+          "lang"
+        ],
+        "title": "Segment",
         "type": "object"
       }
     },

--- a/tests/panel/test_panel_flows.py
+++ b/tests/panel/test_panel_flows.py
@@ -1,9 +1,18 @@
 from pathlib import Path
+import os
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
 
 
 client = TestClient(app)
+
+
+def _headers():
+    headers = {"x-schema-version": "1.3"}
+    flag = os.getenv("FEATURE_REQUIRE_API_KEY", "").strip().lower()
+    if flag in {"1", "true", "yes", "on", "enabled"}:
+        headers["x-api-key"] = os.getenv("API_KEY", "")
+    return headers
 
 
 def _apply_ops(text: str, ops):
@@ -17,7 +26,11 @@ def test_panel_end_to_end_flow():
     # Step 1: analyze mini NDA
     fixture = Path(__file__).resolve().parents[1] / "fixtures" / "nda_mini.txt"
     text = fixture.read_text(encoding="utf-8")
-    r = client.post("/api/analyze", json={"text": text})
+    r = client.post(
+        "/api/analyze",
+        json={"text": text, "language": "en-GB"},
+        headers=_headers(),
+    )
     assert r.status_code == 200
     findings = r.json()["analysis"]["findings"]
     assert findings
@@ -33,15 +46,25 @@ def test_panel_end_to_end_flow():
     assert valid >= 1
 
     # Step 2: draft
-    payload = {"text": "Ping", "mode": "friendly", "before_text": "", "after_text": ""}
-    r = client.post("/api/gpt-draft", json=payload)
+    payload = {
+        "text": "Ping",
+        "mode": "friendly",
+        "before_text": "",
+        "after_text": "",
+        "language": "en-GB",
+    }
+    r = client.post("/api/gpt-draft", json=payload, headers=_headers())
     assert r.status_code == 200
     data = r.json()
     assert data.get("proposed_text", "").strip() != ""
 
     # Step 3: suggest edits
     original = "bad clause"
-    r = client.post("/api/suggest_edits", json={"text": original})
+    r = client.post(
+        "/api/suggest_edits",
+        json={"text": original, "language": "en-GB"},
+        headers=_headers(),
+    )
     assert r.status_code == 200
     sugg = r.json()
     proposed = sugg.get("proposed_text", "")

--- a/tests/panel/test_qa_recheck_dto.py
+++ b/tests/panel/test_qa_recheck_dto.py
@@ -2,6 +2,7 @@ import pytest
 from types import SimpleNamespace
 from fastapi.testclient import TestClient
 import contract_review_app.api.app as app_module
+import os
 
 
 @pytest.fixture()
@@ -18,10 +19,14 @@ def client(monkeypatch):
 
 
 def test_recheck_minimal_ok(client):
+    headers = {"x-schema-version": "1.3"}
+    flag = os.getenv("FEATURE_REQUIRE_API_KEY", "").strip().lower()
+    if flag in {"1", "true", "yes", "on", "enabled"}:
+        headers["x-api-key"] = os.getenv("API_KEY", "")
     r = client.post(
         "/api/qa-recheck",
-        json={"text": "clause text", "rules": {}},
-        headers={"x-schema-version": "1.3"},
+        json={"text": "clause text", "rules": {}, "language": "en-GB"},
+        headers=headers,
     )
     assert r.status_code == 200
     data = r.json()
@@ -30,10 +35,14 @@ def test_recheck_minimal_ok(client):
 
 
 def test_recheck_empty_text_422(client):
+    headers = {"x-schema-version": "1.3"}
+    flag = os.getenv("FEATURE_REQUIRE_API_KEY", "").strip().lower()
+    if flag in {"1", "true", "yes", "on", "enabled"}:
+        headers["x-api-key"] = os.getenv("API_KEY", "")
     r = client.post(
         "/api/qa-recheck",
-        json={"text": "", "rules": {}},
-        headers={"x-schema-version": "1.3"},
+        json={"text": "", "rules": {}, "language": "en-GB"},
+        headers=headers,
     )
     assert r.status_code == 422
     detail = r.json().get("detail")


### PR DESCRIPTION
## Summary
- check required API headers via middleware
- default panel request language to `en-GB` across DTOs
- align QA recheck endpoint and OpenAPI spec

## Testing
- `python -m pytest -q tests/panel/test_panel_flows.py`
- `python -m pytest -q tests/openapi/test_openapi_examples.py`
- `python -m pytest -q tests/api/test_analyze_minimal.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfc2c1da6883259f2c3642c4254711