### PR TITLE
fix: enforce schema headers only on core POST routes

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -48,6 +48,7 @@ TRACE = TraceStore(TRACE_MAX)
 _RULE_ENGINE_OK = True
 _RULE_ENGINE_ERR = ""
 
+
 class NormalizeAndTraceMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         response = await call_next(request)
@@ -195,7 +196,6 @@ from fastapi import (
     Query,
     Request,
     Response,
-    Depends,
     Path as PathParam,
 )
 from fastapi.middleware.cors import CORSMiddleware
@@ -251,10 +251,23 @@ from contract_review_app.api.limits import API_TIMEOUT_S, API_RATE_LIMIT_PER_MIN
 
 
 class RequireHeadersMiddleware(BaseHTTPMiddleware):
+    """Ensure required headers are present for relevant POST requests.
+
+    Some integration endpoints (e.g. Companies House search) historically did not
+    mandate schema headers. To avoid breaking those clients, skip enforcement for
+    such paths and only require headers on the core API routes that depend on
+    them.
+    """
+
+    _SKIP_PATHS = ("/api/companies",)
+
     async def dispatch(self, request: Request, call_next):
-        if request.method.upper() == "POST":
+        if request.method.upper() == "POST" and not any(
+            request.url.path.startswith(p) for p in self._SKIP_PATHS
+        ):
             _require_api_key(request)
         return await call_next(request)
+
 
 # --------------------------------------------------------------------
 # Language segmentation helpers
@@ -884,11 +897,6 @@ def _custom_openapi():
                     hdrs["x-latency-ms"] = {"$ref": "#/components/headers/XLatencyMs"}
                     hdrs["x-cid"] = {"$ref": "#/components/headers/XCid"}
 
-    example_headers = {
-        "x-schema-version": SCHEMA_VERSION,
-        "x-latency-ms": 12,
-        "x-cid": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    }
     for p in ["/api/analyze", "/api/gpt-draft", "/api/explain"]:
         op = openapi_schema.get("paths", {}).get(p, {}).get("post")
         if not op:
@@ -911,7 +919,6 @@ _TRUTHY = {"1", "true", "yes", "on", "enabled"}
 def _env_truthy(name: str) -> bool:
     """Return ``True`` if environment variable ``name`` is set to a truthy value."""
     return (os.getenv(name, "") or "").strip().lower() in _TRUTHY
-
 
 
 _ALLOWED_ORIGINS = [
@@ -2458,7 +2465,11 @@ async def api_citation_resolve(
         for f in body.findings or []:
             try:
                 core = CoreFinding.model_validate(
-                    {"code": f.code or "", "message": f.message or "", "rule": f.rule or ""}
+                    {
+                        "code": f.code or "",
+                        "message": f.message or "",
+                        "rule": f.rule or "",
+                    }
                 )
             except Exception:
                 continue


### PR DESCRIPTION
## Summary
- avoid requiring x-schema-version for integration endpoints

## Testing
- `pre-commit run --files contract_review_app/api/app.py`
- `python -m pytest tests/api/test_companies_endpoints.py -k test_search_endpoint`
- `python -m pytest tests/panel/test_panel_flows.py`
- `python -m pytest tests/openapi/test_openapi_examples.py` *(fails: Client.__init__() got an unexpected keyword argument 'app')*
- `python -m pytest tests/api/test_analyze_minimal.py` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68bfd0b609708325b9e0977e38914267