### PR TITLE
feat: prompt for api key and schema version in self-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ After running an analysis the task pane displays the current CID. You can open
 **Export HTML/PDF**. The **Replay last** button re-sends the previous input to
 `/api/analyze`.
 
+## Panel Self-Test
+
+The file `word_addin_dev/panel_selftest.html` provides a small web page for
+checking the backend API. To run the self-test:
+
+1. Start the backend service.
+2. Open `panel_selftest.html` in a browser.
+3. Enter the backend URL, your API key (`x-api-key`) and the expected schema
+   version (`x-schema-version`, for example `1.4`).
+4. Click **Run All** or choose individual tests.
+
+Both headers are required for most API endpoints; requests without them will
+fail.
+
 ## API examples
 
 Sample request bodies for `/api/analyze` are included:

--- a/tests/panel/test_selftest_call.js
+++ b/tests/panel/test_selftest_call.js
@@ -10,6 +10,7 @@ const sandbox = {
       const el = { value: '', textContent: '', style:{}, className:'', addEventListener: () => {} };
       if (id === 'backendInput') el.value = 'https://localhost:9443';
       if (id === 'apiKeyInput') el.value = 'KEY123';
+      if (id === 'schemaInput') el.value = '1.0';
       return el;
     },
     querySelector: () => ({})

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -49,12 +49,14 @@
     <label for="backendInput">Backend URL:</label>
     <input id="backendInput" type="text" value="https://localhost:9443" class="mono" />
     <button id="saveBtn">Save</button>
-    <label for="apiKeyInput">API Key:</label>
-    <input id="apiKeyInput" type="text" class="mono" style="width:140px" />
-    <button id="saveKeyBtn">Save Key</button>
+    <label for="apiKeyInput">API Key (x-api-key):</label>
+    <input id="apiKeyInput" type="text" class="mono" style="width:140px" placeholder="required" />
+    <label for="schemaInput">Schema (x-schema-version):</label>
+    <input id="schemaInput" type="text" class="mono" style="width:80px" placeholder="1.4" />
+    <button id="saveKeyBtn">Save Headers</button>
     <button id="runAllBtn">Run All</button>
     <button id="pingBtn">Ping LLM</button>
-    <span class="small">Saved in localStorage</span>
+    <span class="small">Saved in localStorage. Both headers are required.</span>
   </div>
 
   <div class="row">


### PR DESCRIPTION
## Summary
- ask for API key and schema version before running self-test requests
- document how to run the self-test with required headers

## Testing
- `node tests/panel/test_selftest_call.js`
- `pytest tests/panel -q` *(fails: x-schema-version header is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe47fdb1c83259944254222d04492