### PR TITLE
fix: allow minimal analyze request

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -827,6 +827,22 @@ class AnalyzeRequest(BaseModel):
             raise ValueError("text is empty")
         return v
 
+    @field_validator("language", mode="before")
+    @classmethod
+    def _default_language(cls, v: str | None) -> str:
+        """Normalize language, falling back to the default."""
+        if not v or not str(v).strip():
+            return "en-GB"
+        return str(v)
+
+    @field_validator("mode", "risk", mode="before")
+    @classmethod
+    def _blank_to_none(cls, v: Optional[str]) -> Optional[str]:
+        """Treat empty strings as missing values."""
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
+
 
 class AnalyzeResponse(BaseModel):
     status: str

--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -35,6 +35,21 @@ class AnalyzeRequest(_DTOBase):
     mode: str | None = None
     risk: str | None = None
 
+    @field_validator("language", mode="before")
+    @classmethod
+    def _default_language(cls, v: str | None) -> str:
+        """Ensure language has a sensible default."""
+        if not v or not v.strip():
+            return "en-GB"
+        return v
+
+    @field_validator("mode", "risk", mode="before")
+    @classmethod
+    def _blank_to_none(cls, v: str | None):
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
+
     @model_validator(mode="after")
     def _strip(self):
         txt = (self.text or "").strip()

--- a/contract_review_app/core/schemas.py
+++ b/contract_review_app/core/schemas.py
@@ -40,6 +40,7 @@ __all__ = [
     # inputs
     "AnalysisInput",
     "AnalyzeIn",
+    "AnalyzeRequest",
     # building blocks
     "Finding",
     "Diagnostic",
@@ -180,7 +181,7 @@ class AnalyzeIn(AppBaseModel):
 
     document_name: Optional[str] = None
     text: str
-    language: Optional[str] = None
+    language: str = "en-GB"
 
     # segment context (optional; used by pipeline/template selection)
     jurisdiction: Optional[str] = None
@@ -197,7 +198,15 @@ class AnalyzeIn(AppBaseModel):
         if not isinstance(self.text, str) or self.text.strip() == "":
             raise ValueError("AnalyzeIn.text must be a non-empty string")
         self.text = self.text.strip()
+        if not isinstance(self.language, str) or not self.language.strip():
+            self.language = "en-GB"
+        else:
+            self.language = self.language.strip()
         return self
+
+
+# Backwards compatibility alias
+AnalyzeRequest = AnalyzeIn
 
 
 # ============================================================================

--- a/tests/api/test_analyze_minimal.py
+++ b/tests/api/test_analyze_minimal.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+from hypothesis import given, strategies as st, settings
 
 from contract_review_app.api.app import app
 from contract_review_app.api.models import SCHEMA_VERSION
@@ -9,10 +10,23 @@ client = TestClient(app)
 def test_analyze_minimal():
     resp = client.post(
         "/api/analyze",
-        json={"text": "Hello", "language": "en"},
-        headers={"x-schema-version": SCHEMA_VERSION},
+        json={"text": "Hello"},
+        headers={"x-api-key": "local-test-key-123", "x-schema-version": SCHEMA_VERSION},
     )
     assert resp.status_code == 200
     assert resp.headers["x-schema-version"] == SCHEMA_VERSION
+    assert resp.headers.get("x-cid")
     data = resp.json()
     assert isinstance(data.get("analysis"), dict) and data["analysis"]
+
+
+@settings(deadline=None, max_examples=25)
+@given(st.text(min_size=1, max_size=100))
+def test_analyze_any_text(text):
+    resp = client.post(
+        "/api/analyze",
+        json={"text": text},
+        headers={"x-api-key": "local-test-key-123", "x-schema-version": SCHEMA_VERSION},
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("x-cid")


### PR DESCRIPTION
## Summary
- accept minimal payload for `/api/analyze` by normalizing optional fields
- default language to `en-GB` in core schemas and alias `AnalyzeRequest`
- test that any non-empty text returns 200 with an `x-cid` header

## Testing
- `pytest -q tests/api/test_analyze_minimal.py`
- `curl -sk -D headers.txt -H "Content-Type: application/json" -H "x-api-key: local-test-key-123" -H "x-schema-version: 1.4" -d '{"text":"Hello"}' https://localhost:9443/api/analyze`


------
https://chatgpt.com/codex/tasks/task_e_68c00bcf54008325bcf5aaf55d2923f6