### PR TITLE
Add elevation checks to ContractAI startup scripts

### DIFF
--- a/tools/ContractAI-Start.bat
+++ b/tools/ContractAI-Start.bat
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+
+:: Relaunch with elevated privileges if not already running as admin
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Requesting administrative privileges...
+    powershell -NoProfile -Command "Start-Process -FilePath '%~f0' -ArgumentList '%*' -Verb RunAs"
+    exit /b
+)
+
+cd /d "%~dp0"
+powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File Start_ContractAI.ps1 %*
+
+endlocal
+


### PR DESCRIPTION
## Summary
- Add admin-elevation relaunch logic to tools/ContractAI-Start.bat
- Guard Start_ContractAI.ps1 with Assert-Elevated and better error handling

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68c01aaf3b588325ac2d838572b0b59f