### PR TITLE
Check virtual environment in startup scripts

### DIFF
--- a/tools/Start_ContractAI.ps1
+++ b/tools/Start_ContractAI.ps1
@@ -14,6 +14,12 @@ $ErrorActionPreference = "Stop"
 $repo = Split-Path -Parent $MyInvocation.MyCommand.Path
 cd $repo
 
+$pyExe = Join-Path $repo ".venv\Scripts\python.exe"
+if (!(Test-Path $pyExe)) {
+  Write-Host "Python virtual environment not found. Please run `python -m venv .venv` and install requirements." -ForegroundColor Red
+  exit 1
+}
+
 # 0) чистий старт
 taskkill /IM WINWORD.EXE /F 2>$null
 Remove-Item "$env:LOCALAPPDATA\Microsoft\Office\16.0\Wef\*" -Recurse -Force -EA SilentlyContinue

--- a/tools/start_oneclick.ps1
+++ b/tools/start_oneclick.ps1
@@ -19,6 +19,14 @@ function Write-Log {
     try { "$ts $Message" | Out-File -FilePath $logFile -Append -Encoding UTF8 } catch {}
 }
 
+$pyExe = Join-Path $repo '.venv\Scripts\python.exe'
+if (!(Test-Path $pyExe)) {
+    $msg = "Python virtual environment not found. Please run `python -m venv .venv` and install requirements."
+    Write-Log "[ERR] $msg"
+    Write-Host $msg -ForegroundColor Red
+    exit 1
+}
+
 function Load-DotEnv {
     param([string]$Path)
     if (!(Test-Path $Path)) { Write-Log "[WARN] .env not found"; return }


### PR DESCRIPTION
## Summary
- ensure start_oneclick.ps1 and Start_ContractAI.ps1 verify `.venv\Scripts\python.exe` exists
- log and display a helpful message when the virtual environment is missing

## Testing
- `pre-commit run --files tools/start_oneclick.ps1 tools/Start_ContractAI.ps1`
- `pytest -q` *(fails: fastapi.exceptions.HTTPException 400)*

------
https://chatgpt.com/codex/tasks/task_e_68c0202a25d4832597a23fa59a398b2e