### PR TITLE
fix(launcher): free 9443 before start; honor User env; echo provider; pause on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,40 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Run tests
         run: pytest -q
+  smoke-start:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - name: Install
+        run: |
+          python -m venv .venv
+          .\.venv\Scripts\pip install -r requirements-dev.txt
+      - name: Set fake Azure env (User)
+        shell: pwsh
+        run: |
+          [Environment]::SetEnvironmentVariable("AZURE_OPENAI_API_KEY","test-key-1234567890","User")
+          [Environment]::SetEnvironmentVariable("AZURE_OPENAI_ENDPOINT","https://example.openai.azure.com/","User")
+          [Environment]::SetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT","gpt-4o-mini","User")
+          [Environment]::SetEnvironmentVariable("AZURE_OPENAI_API_VERSION","2024-08-01-preview","User")
+          [Environment]::SetEnvironmentVariable("LLM_PROVIDER","azure","User")
+      - name: Free 9443 (parasitic server)
+        shell: pwsh
+        run: |
+          Get-NetTCPConnection -LocalPort 9443 -State Listen -ErrorAction SilentlyContinue |
+            % { try { Stop-Process -Id $_.OwningProcess -Force } catch {} }
+      - name: Start via launcher (timeout 20s)
+        run: |
+          start "" cmd /c ".\ContractAI-Start.bat"
+          powershell -NoProfile -Command ^
+            "$i=0; while($i -lt 20){ try{ (Invoke-WebRequest https://localhost:9443/health -UseBasicParsing -SkipCertificateCheck).Content | Out-Null; break }catch{}; Start-Sleep 1; $i++ }"
+      - name: Check provider
+        shell: pwsh
+        run: |
+          $j = curl.exe -sk https://localhost:9443/health | ConvertFrom-Json
+          if ($j.llm.provider -ne "azure") { throw "provider is $($j.llm.provider)" }
+      - name: Kill server
+        shell: pwsh
+        run: |
+          Get-Process uvicorn -ErrorAction SilentlyContinue | Stop-Process -Force

--- a/ContractAI-Start.bat
+++ b/ContractAI-Start.bat
@@ -3,22 +3,31 @@ setlocal
 rem ===== ContractAI unified launcher =====
 pushd "%~dp0"
 
-rem 1) Подтягиваем User ENV (если не заданы в этом процессе)
+rem Free 9443 before start
+for /f %%P in ('powershell -NoProfile -Command ^
+  "(Get-NetTCPConnection -LocalPort 9443 -State Listen -ErrorAction SilentlyContinue).OwningProcess"') do set PID=%%P
+if defined PID powershell -NoProfile -Command "try{Stop-Process -Id %PID% -Force}catch{}"
+powershell -NoProfile -Command "Get-Process uvicorn -ErrorAction SilentlyContinue | Stop-Process -Force"
+
+rem Import User environment variables
 for %%V in (LLM_PROVIDER AZURE_OPENAI_API_KEY AZURE_OPENAI_ENDPOINT AZURE_OPENAI_DEPLOYMENT AZURE_OPENAI_API_VERSION) do (
-  if not defined %%V (
-    for /f "tokens=2,*" %%A in ('reg query "HKCU\Environment" /v %%V 2^>nul') do set "%%V=%%B"
-  )
+  for /f "usebackq tokens=* delims=" %%A in (`powershell -NoProfile -Command ^
+    "[Environment]::GetEnvironmentVariable('%%V','User')"`) do set %%V=%%A
 )
 
-rem 2) Автовыбор провайдера: есть Azure-ключ -> azure, иначе mock
-if not defined LLM_PROVIDER (
-  if defined AZURE_OPENAI_API_KEY (set "LLM_PROVIDER=azure") else (set "LLM_PROVIDER=mock")
-)
+rem Auto-select provider when key exists
+if not "%AZURE_OPENAI_API_KEY%"=="" if "%LLM_PROVIDER%"=="" set LLM_PROVIDER=azure
 
-rem 3) Глушим висящий uvicorn (если есть)
-taskkill /im uvicorn.exe /f >nul 2>&1
+rem Show config and key length
+for /f %%K in ('powershell -NoProfile -Command ^
+  "$k=[Environment]::GetEnvironmentVariable('AZURE_OPENAI_API_KEY','User'); if($k){$k.Length}else{0}"') do set KEYLEN=%%K
+echo LLM_PROVIDER=%LLM_PROVIDER%  KEYLEN=%KEYLEN%
 
-rem 4) Запуск uvicorn в ЭТОМ ЖЕ окне (унаследует ENV)
-set "PY=%~dp0.venv\Scripts\python.exe"
+rem Launch uvicorn
+set PY=%CD%\.venv\Scripts\python.exe
 "%PY%" -m uvicorn contract_review_app.api.app:app --host 127.0.0.1 --port 9443 ^
   --ssl-certfile C:\certs\dev.crt --ssl-keyfile C:\certs\dev.key
+if errorlevel 1 (
+  echo Uvicorn exited with error %ERRORLEVEL% (port busy or other error).
+  pause
+)


### PR DESCRIPTION
## Summary
- free port 9443 and kill stale uvicorn instances before launch
- load Azure keys from user environment and display provider with key length
- add Windows smoke-start workflow to exercise launcher and verify Azure provider

## Testing
- `pre-commit run --files ContractAI-Start.bat .github/workflows/ci.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openapi_spec_validator')*


------
https://chatgpt.com/codex/tasks/task_e_68c02a8827d0832593ee2342840068bb