### PR TITLE
Fix /api/summary POST JSON handling and add tests

### DIFF
--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -150,6 +150,25 @@ class QARecheckOut(_DTOBase):
     meta: Dict[str, Any] | None = None
 
 
+class SummaryIn(_DTOBase):
+    """Input model for ``/api/summary``.
+
+    Exactly one of ``cid`` or ``hash`` must be provided.
+    """
+
+    cid: str | None = None
+    hash: str | None = None
+
+    @model_validator(mode="after")
+    def _one_of(cls, values):  # type: ignore[override]
+        if (values.cid is None) == (values.hash is None):
+            raise HTTPException(
+                status_code=422,
+                detail="Provide exactly one of cid or hash",
+            )
+        return values
+
+
 class CitationInput(_DTOBase):
     instrument: str
     section: str

--- a/contract_review_app/tests/test_api_summary_schema.py
+++ b/contract_review_app/tests/test_api_summary_schema.py
@@ -2,11 +2,15 @@ import json
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app, SCHEMA_VERSION
 
-client = TestClient(app)
+client = TestClient(app, headers={"x-schema-version": SCHEMA_VERSION})
 
 def test_summary_has_status_and_schema_version():
-    payload = {"text":"This Agreement shall be governed by the laws of England and Wales."}
-    r = client.post("/api/summary", json=payload)
+    payload = {"text": "This Agreement shall be governed by the laws of England and Wales."}
+    r_analyze = client.post("/api/analyze", json=payload)
+    assert r_analyze.status_code == 200
+    cid = r_analyze.headers.get("x-cid")
+    assert cid
+    r = client.post("/api/summary", json={"cid": cid})
     assert r.status_code == 200
     assert r.headers.get("x-schema-version") == SCHEMA_VERSION
     data = r.json()

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -182,7 +182,11 @@ def test_analyze_x_cid_deterministic():
 
 
 def test_summary_endpoint():
-    r = client.post("/api/summary", json={"text": "hello"})
+    r_analyze = client.post("/api/analyze", json={"text": "hello"})
+    assert r_analyze.status_code == 200
+    cid = r_analyze.headers.get("x-cid")
+    assert cid
+    r = client.post("/api/summary", json={"cid": cid})
     assert r.status_code == 200
     assert r.json().get("summary")
 

--- a/tests/api/test_summary_post.py
+++ b/tests/api/test_summary_post.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _create_client():
+    modules = [
+        "contract_review_app.api",
+        "contract_review_app.api.app",
+        "contract_review_app.api.orchestrator",
+        "contract_review_app.gpt.service",
+        "contract_review_app.gpt.clients.mock_client",
+    ]
+    for m in modules:
+        sys.modules.pop(m, None)
+    os.environ.setdefault("LLM_PROVIDER", "mock")
+    from contract_review_app.api import app as app_module
+
+    importlib.reload(app_module)
+    from contract_review_app.api.models import SCHEMA_VERSION
+
+    client = TestClient(app_module.app, headers={"x-schema-version": SCHEMA_VERSION})
+    return client, modules
+
+
+@pytest.fixture()
+def client():
+    client, modules = _create_client()
+    try:
+        yield client
+    finally:
+        for m in modules:
+            sys.modules.pop(m, None)
+
+
+def test_summary_post_by_cid_ok(client):
+    r_analyze = client.post("/api/analyze", json={"text": "hello world"})
+    assert r_analyze.status_code == 200
+    cid = r_analyze.headers.get("x-cid")
+    assert cid
+    r_post = client.post("/api/summary", json={"cid": cid})
+    assert r_post.status_code == 200
+    assert r_post.json().get("summary")
+
+
+def test_summary_post_bad_body(client):
+    r = client.post("/api/summary", json={})
+    assert r.status_code == 422
+    detail = r.json().get("detail")
+    msg = "".join(d.get("msg", "") for d in detail) if isinstance(detail, list) else str(detail)
+    assert "cid" in msg and "hash" in msg
+
+
+def test_summary_post_both_fields(client):
+    r = client.post("/api/summary", json={"cid": "a", "hash": "b"})
+    assert r.status_code == 422
+    detail = r.json().get("detail")
+    msg = "".join(d.get("msg", "") for d in detail) if isinstance(detail, list) else str(detail)
+    assert "one" in msg.lower() or "only" in msg.lower()


### PR DESCRIPTION
## Summary
- add `SummaryIn` pydantic model requiring exactly one of `cid` or `hash`
- rewrite `/api/summary` POST to parse `SummaryIn` and fetch cached summary
- add tests for summary POST and update existing tests to new contract

## Testing
- `pytest tests/api/test_summary_post.py -W ignore`
- `pytest tests/api/test_endpoints.py::test_summary_endpoint -W ignore`
- `pytest tests/test_doc_type_api.py::test_summary_returns_doc_type_and_confidence tests/test_doc_type_api.py::test_analyze_returns_type_confidence_and_candidates -W ignore`
- `pytest contract_review_app/tests/api/test_api_summary_type.py::test_api_summary_returns_type -W ignore`
- `pytest contract_review_app/tests/test_api_summary_schema.py::test_summary_has_status_and_schema_version -W ignore`
- `pytest tests/api/test_summary_flow.py::test_summary_flow -W ignore`
- (fail) `pytest contract_review_app/tests/test_api_summary.py::test_summary_endpoint_nda -W ignore`

------
https://chatgpt.com/codex/tasks/task_e_68c036a8951c83258ee8d95aa6c83b27