### PR TITLE
Handle invalid UTF-8 in JSON body decoding

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1016,7 +1016,7 @@ async def add_response_headers(request: Request, call_next):
     if request.method.upper() in {"POST", "PUT", "PATCH"} and body:
         try:
             request.state.json = json.loads(body.decode("utf-8"))
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             cid = request.headers.get("x-cid") or compute_cid(request)
             return _problem_response(
                 400,


### PR DESCRIPTION
## Summary
- catch `UnicodeDecodeError` during JSON body parsing to return `bad_json`

## Testing
- `pytest tests/api/test_errors_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68c04c40b0e08325a23bf9d071be9e76