### PR TITLE
feat: gate Companies House by env vars

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -30,6 +30,7 @@ from contract_review_app.core.privacy import redact_pii, scrub_llm_output
 from contract_review_app.core.audit import audit
 from contract_review_app.security.secure_store import secure_write
 from contract_review_app.core.trace import TraceStore, compute_cid
+from contract_review_app.config import CH_ENABLED
 
 
 log = logging.getLogger("contract_ai")
@@ -1504,6 +1505,7 @@ async def health() -> JSONResponse:
             "timeout_s": LLM_CONFIG.timeout_s,
         },
         "provider": PROVIDER_META,
+        "ch": {"enabled": CH_ENABLED},
         "endpoints": ["/api/analyze", "/api/gpt-draft", "/api/explain"],
     }
     status_code = 200

--- a/contract_review_app/config.py
+++ b/contract_review_app/config.py
@@ -2,6 +2,14 @@
 # Canonical clause keywords (ALL LOWERCASE). Kept broad enough for robust recall.
 # Matching/normalization is handled downstream by intake/patterns.py.
 
+import os
+
+
+FEATURE_COMPANIES_HOUSE = os.getenv("FEATURE_COMPANIES_HOUSE", "")
+CH_API_KEY = os.getenv("CH_API_KEY") or os.getenv("COMPANIES_HOUSE_API_KEY", "")
+CH_ENABLED = FEATURE_COMPANIES_HOUSE in {"1", "true", "True"} and CH_API_KEY != ""
+
+
 CLAUSE_KEYWORDS = {
     # Core
     "definitions": [

--- a/contract_review_app/integrations/companies_house/client.py
+++ b/contract_review_app/integrations/companies_house/client.py
@@ -8,7 +8,7 @@ import httpx
 from contract_review_app.core.audit import audit
 
 BASE = os.getenv("COMPANIES_HOUSE_BASE", "https://api.company-information.service.gov.uk")
-KEY = os.getenv("COMPANIES_HOUSE_API_KEY", "")
+KEY = os.getenv("CH_API_KEY") or os.getenv("COMPANIES_HOUSE_API_KEY", "")
 TIMEOUT_S = float(os.getenv("CH_TIMEOUT_S", "8"))
 
 _CACHE: Dict[str, Dict[str, Any]] = {}

--- a/tests/api/test_ch_gate.py
+++ b/tests/api/test_ch_gate.py
@@ -1,0 +1,55 @@
+import importlib
+from fastapi.testclient import TestClient
+import respx
+import httpx
+
+
+def make_client(monkeypatch, flag="1", key="k"):
+    if flag is not None:
+        monkeypatch.setenv("FEATURE_COMPANIES_HOUSE", flag)
+    else:
+        monkeypatch.delenv("FEATURE_COMPANIES_HOUSE", raising=False)
+    if key is not None:
+        monkeypatch.setenv("CH_API_KEY", key)
+    else:
+        monkeypatch.delenv("CH_API_KEY", raising=False)
+    monkeypatch.setenv("FEATURE_INTEGRATIONS", "1")
+    import contract_review_app.config as cfg
+    import contract_review_app.integrations.companies_house.client as ch_client
+    import contract_review_app.api.integrations as integrations
+    import contract_review_app.api.app as app_module
+    importlib.reload(cfg)
+    importlib.reload(ch_client)
+    importlib.reload(integrations)
+    importlib.reload(app_module)
+    client = TestClient(app_module.app)
+    return client, ch_client
+
+
+def _expect_503(client):
+    r = client.post("/api/companies/search", json={"q": "AC"})
+    assert r.status_code == 503
+    assert r.json()["error"] == "companies_house_disabled"
+    r2 = client.get("/api/companies/1")
+    assert r2.status_code == 503
+    assert r2.json()["error"] == "companies_house_disabled"
+
+
+def test_gate_disabled_no_flag(monkeypatch):
+    client, _ = make_client(monkeypatch, flag="0", key="x")
+    _expect_503(client)
+
+
+def test_gate_disabled_no_key(monkeypatch):
+    client, _ = make_client(monkeypatch, flag="1", key=None)
+    _expect_503(client)
+
+
+@respx.mock
+def test_search_ok(monkeypatch):
+    client, ch_client = make_client(monkeypatch, flag="1", key="x")
+    BASE = ch_client.BASE
+    respx.get(f"{BASE}/search/companies").respond(json={"items": []}, headers={"ETag": "s1"})
+    r = client.post("/api/companies/search", json={"q": "ACME"})
+    assert r.status_code == 200
+    assert r.json()["items"] == []

--- a/tests/api/test_companies_endpoints.py
+++ b/tests/api/test_companies_endpoints.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 os.environ.setdefault("FEATURE_INTEGRATIONS", "1")
 os.environ.setdefault("FEATURE_COMPANIES_HOUSE", "1")
-os.environ.setdefault("COMPANIES_HOUSE_API_KEY", "x")
+os.environ.setdefault("CH_API_KEY", "x")
 
 import contract_review_app.api.app as app_module
 from contract_review_app.integrations.companies_house import client as ch_client
@@ -36,8 +36,23 @@ def test_profile_endpoint():
 
 def test_disabled(monkeypatch):
     monkeypatch.setenv("FEATURE_COMPANIES_HOUSE", "0")
-    r = client.post("/api/companies/search", json={"q": "A"})
+    import importlib
+    import contract_review_app.config as cfg
+    import contract_review_app.api.integrations as integrations
+    import contract_review_app.integrations.companies_house.client as ch_client
+    import contract_review_app.api.app as app_module
+    importlib.reload(cfg)
+    importlib.reload(ch_client)
+    importlib.reload(integrations)
+    importlib.reload(app_module)
+    local_client = TestClient(app_module.app)
+    r = local_client.post("/api/companies/search", json={"q": "A"})
     assert r.status_code == 503
+    monkeypatch.setenv("FEATURE_COMPANIES_HOUSE", "1")
+    importlib.reload(cfg)
+    importlib.reload(ch_client)
+    importlib.reload(integrations)
+    importlib.reload(app_module)
 
 
 @respx.mock


### PR DESCRIPTION
## Summary
- derive CH_ENABLED from FEATURE_COMPANIES_HOUSE and CH_API_KEY
- return clear 503 errors when Companies House integration disabled
- expose Companies House status in /health and add tests

## Testing
- `pytest tests/api/test_ch_gate.py --disable-warnings`
- `pytest tests/api/test_companies_endpoints.py --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68c04d323e248325bce8989e8b126beb