### PR TITLE
Normalize JSON error handling and ensure diagnostic responses

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1016,7 +1016,7 @@ async def add_response_headers(request: Request, call_next):
     if request.method.upper() in {"POST", "PUT", "PATCH"} and body:
         try:
             request.state.json = json.loads(body.decode("utf-8"))
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             cid = request.headers.get("x-cid") or compute_cid(request)
             return _problem_response(
                 400,


### PR DESCRIPTION
## Summary
- catch `UnicodeDecodeError` alongside `json.JSONDecodeError` so malformed UTF-8 bodies return `bad_json`

## Testing
- `pytest -q tests/api/test_errors_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68c04f79c29c832580da4d110a62def5