### PR TITLE
feat: attach headers and add panel self-test

### DIFF
--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -58,6 +58,7 @@
     <button id="pingBtn">Ping LLM</button>
     <span class="small">Saved in localStorage. Both headers are required.</span>
     <span id="schemaWarn" class="small err" style="display:none;"></span>
+    <div id="hdrWarn" class="small err" style="display:none;">Set API key &amp; schema (Save Headers)</div>
   </div>
 
   <div class="row">

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -144,6 +144,8 @@
 
   <div class="row muted">Endpoints: <code>/health</code> · <code>/api/analyze</code> · <code>/api/gpt-draft</code> · <code>/api/qa-recheck</code></div>
 
+  <div id="hdrWarn" style="display:none;background:#b30000;color:#fff;padding:6px;margin:8px 0;border-radius:4px;">Set API key &amp; schema (Save Headers)</div>
+
   <div class="row card">
     <div class="row"><input id="backendUrl" placeholder="https://localhost:9443" /></div>
     <div class="row flex">


### PR DESCRIPTION
## Summary
- attach API key and schema headers from localStorage
- wire panel and self-test to use new analyze, summary, and draft payloads
- show banner and disable buttons until headers are set

## Testing
- `pre-commit run --files word_addin_dev/app/assets/api-client.ts word_addin_dev/app/assets/api-client.js word_addin_dev/app/assets/taskpane.ts word_addin_dev/app/selftest.js word_addin_dev/panel_selftest.html word_addin_dev/taskpane.bundle.js word_addin_dev/taskpane.html`
- `pytest` *(fails: 122 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c058b28b9083259fbc754ce9c14128