### PR TITLE
fix: remove invalid TS casts in self-test JS

### DIFF
--- a/word_addin_dev/app/selftest.js
+++ b/word_addin_dev/app/selftest.js
@@ -115,9 +115,9 @@ function checkHeaders(){
   const warn = document.getElementById('hdrWarn');
   if (warn) warn.style.display = ok ? 'none' : 'inline';
   const ids = ['runAllBtn','pingBtn'];
-  ids.forEach(id => { const b = document.getElementById(id) as HTMLButtonElement | null; if (b) b.disabled = !ok; });
+  ids.forEach(id => { const b = document.getElementById(id); if (b && 'disabled' in b) b.disabled = !ok; });
   const tests = document.getElementById('testsBtns');
-  if (tests) Array.from(tests.querySelectorAll('button')).forEach(b => { (b as HTMLButtonElement).disabled = !ok; });
+  if (tests) Array.from(tests.querySelectorAll('button')).forEach(b => { b.disabled = !ok; });
 }
 function setJSON(elId, obj){
   const el = document.getElementById(elId);


### PR DESCRIPTION
## Summary
- drop TypeScript-style casts from panel self-test script to avoid SyntaxError in browsers

## Testing
- `pre-commit run --files word_addin_dev/app/selftest.js`
- `pytest` *(fails: Interrupted 123 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c05cdb30d083258fde694e40bf6aaa