### PR TITLE
Refine gpt-draft input and improve company search diagnostics

### DIFF
--- a/contract_review_app/api/error_handlers.py
+++ b/contract_review_app/api/error_handlers.py
@@ -14,6 +14,12 @@ def register_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(RequestValidationError)
     async def _handle_validation_error(request: Request, exc: RequestValidationError):
         """Return pydantic validation details untouched."""
+        body = await request.body()
+        logger.warning(
+            "validation error: size=%s content_type=%s",
+            len(body or b""),
+            request.headers.get("content-type"),
+        )
         detail = exc.errors()
         for err in detail:
             ctx = err.get("ctx")

--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -108,6 +108,14 @@ class AnalyzeResponse(_DTOBase):
     schema_version: str | None = None
 
 
+class GptDraftIn(_DTOBase):
+    """Input model for ``/api/gpt-draft``."""
+
+    cid: str
+    clause: str
+    mode: Literal["friendly", "neutral", "strict"] | None = None
+
+
 class QARecheckIn(_DTOBase):
     """Input model for ``/api/qa-recheck``.
 

--- a/contract_review_app/tests/api/test_api_headers.py
+++ b/contract_review_app/tests/api/test_api_headers.py
@@ -12,11 +12,20 @@ client = TestClient(app)
 
 @pytest.mark.parametrize("path", ["/api/analyze", "/api/gpt-draft"])
 def test_std_headers_present_and_valid(path):
-    payload1 = {"text": "hello"}
-    payload2 = {"text": "world"}
-    r1 = client.post(path, json=payload1)
-    r2 = client.post(path, json=payload1)
-    r3 = client.post(path, json=payload2)
+    if path == "/api/analyze":
+        payload1 = {"text": "hello"}
+        payload2 = {"text": "world"}
+        r1 = client.post(path, json=payload1)
+        r2 = client.post(path, json=payload1)
+        r3 = client.post(path, json=payload2)
+    else:
+        cid1 = client.post("/api/analyze", json={"text": "hello"}).headers["x-cid"]
+        cid2 = client.post("/api/analyze", json={"text": "world"}).headers["x-cid"]
+        payload1 = {"cid": cid1, "clause": "hello"}
+        payload2 = {"cid": cid2, "clause": "world"}
+        r1 = client.post(path, json=payload1)
+        r2 = client.post(path, json=payload1)
+        r3 = client.post(path, json=payload2)
     assert r1.headers["x-cid"] == r2.headers["x-cid"]
     assert r1.headers["x-cid"] != r3.headers["x-cid"]
     assert r1.headers["x-schema-version"] == SCHEMA_VERSION

--- a/contract_review_app/tests/api/test_gpt_draft_endpoint.py
+++ b/contract_review_app/tests/api/test_gpt_draft_endpoint.py
@@ -5,7 +5,9 @@ client = TestClient(app)
 
 
 def test_gpt_draft_returns_text_and_headers():
-    r = client.post("/api/gpt-draft", json={"text": "Example clause."})
+    r_an = client.post("/api/analyze", json={"text": "Example clause."})
+    cid = r_an.headers.get("x-cid")
+    r = client.post("/api/gpt-draft", json={"cid": cid, "clause": "Example clause."})
     assert r.status_code == 200
     data = r.json()
     assert data["status"] == "ok"

--- a/tests/api/test_companies_endpoints.py
+++ b/tests/api/test_companies_endpoints.py
@@ -19,11 +19,13 @@ os.environ["FEATURE_COMPANIES_HOUSE"] = "1"
 @respx.mock
 def test_search_endpoint():
     respx.get(f"{BASE}/search/companies").respond(json={"items": []}, headers={"ETag": "s1"})
-    r = client.post("/api/companies/search", json={"q": "ACME"})
+    r = client.post("/api/companies/search", json={"query": "ACME"})
     assert r.status_code == 200
     assert r.json()["items"] == []
     assert r.headers.get("ETag") == "s1"
     assert r.headers.get("x-cache") == "miss"
+    r2 = client.get("/api/companies/search", params={"q": "ACME"})
+    assert r2.status_code == 200
 
 
 @respx.mock
@@ -46,7 +48,7 @@ def test_disabled(monkeypatch):
     importlib.reload(integrations)
     importlib.reload(app_module)
     local_client = TestClient(app_module.app)
-    r = local_client.post("/api/companies/search", json={"q": "A"})
+    r = local_client.post("/api/companies/search", json={"query": "A"})
     assert r.status_code == 503
     monkeypatch.setenv("FEATURE_COMPANIES_HOUSE", "1")
     importlib.reload(cfg)

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -192,7 +192,9 @@ def test_summary_endpoint():
 
 
 def test_gpt_draft_endpoint():
-    r = client.post("/api/gpt-draft", json={"text": "sample", "clause_type": "clause"})
+    r_an = client.post("/api/analyze", json={"text": "sample"})
+    cid = r_an.headers.get("x-cid")
+    r = client.post("/api/gpt-draft", json={"cid": cid, "clause": "sample"})
     assert r.status_code == 200
 
 

--- a/tests/api/test_llm_endpoints_integration.py
+++ b/tests/api/test_llm_endpoints_integration.py
@@ -31,6 +31,8 @@ def client():
 
 
 def test_endpoints_ok(client):
-    assert client.post("/api/gpt-draft", json={"prompt": "hi"}).status_code == 200
+    r = client.post("/api/analyze", json={"text": "hi"})
+    cid = r.headers.get("x-cid")
+    assert client.post("/api/gpt-draft", json={"cid": cid, "clause": "hi"}).status_code == 200
     assert client.post("/api/suggest_edits", json={"text": "hi"}).status_code == 200
     assert client.post("/api/qa-recheck", json={"text": "hi"}).status_code == 200

--- a/tests/integration/test_panel_selftest_like.py
+++ b/tests/integration/test_panel_selftest_like.py
@@ -33,7 +33,7 @@ def test_panel_selftest_like():
         r = client.post("/api/analyze", json={"text": "Hi"})
         assert r.status_code == 200
         cid = r.headers.get("x-cid")
-        assert client.post("/api/gpt-draft", json={"text": "Hi"}).status_code == 200
+        assert client.post("/api/gpt-draft", json={"cid": cid, "clause": "Hi"}).status_code == 200
         assert client.post("/api/qa-recheck", json={"text": "hi", "rules": {}}).status_code == 200
         assert (
             client.post("/api/qa-recheck", json={"text": "hi", "rules": [{"R1": "on"}]})

--- a/tests/panel/test_cache_headers_v2.py
+++ b/tests/panel/test_cache_headers_v2.py
@@ -25,4 +25,6 @@ def test_analyze_cache_headers():
 
 
 def test_gpt_draft_cache_headers():
-    _check_etag_flow("/api/gpt-draft", {"text": "hello", "mode": "friendly"})
+    r = client.post("/api/analyze", json={"text": "hello"})
+    cid = r.headers.get("x-cid")
+    _check_etag_flow("/api/gpt-draft", {"cid": cid, "clause": "hello", "mode": "friendly"})

--- a/tests/panel/test_panel_flows.py
+++ b/tests/panel/test_panel_flows.py
@@ -47,13 +47,8 @@ def test_panel_end_to_end_flow():
     assert valid >= 1
 
     # Step 2: draft
-    payload = {
-        "text": "Ping",
-        "mode": "friendly",
-        "before_text": "",
-        "after_text": "",
-        "language": "en-GB",
-    }
+    cid = r.headers.get("x-cid")
+    payload = {"cid": cid, "clause": "Ping", "mode": "friendly"}
     r = client.post("/api/gpt-draft", json=payload, headers=_headers())
     assert r.status_code == 200
     data = r.json()

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -17,17 +17,19 @@ def test_api_key_auth(monkeypatch):
 
     r = client.post("/api/analyze", json=payload)
     assert r.status_code == 401
-    r = client.post("/api/gpt-draft", json={"text": "Ping", "mode": "friendly"})
+    r = client.post("/api/gpt-draft", json={"cid": "x", "clause": "Ping", "mode": "friendly"})
     assert r.status_code == 401
     r = client.post("/api/suggest_edits", json=payload)
     assert r.status_code == 401
 
     headers = {"x-api-key": "secret", "x-schema-version": SCHEMA_VERSION}
-    assert client.post("/api/analyze", json=payload, headers=headers).status_code == 200
+    r_an = client.post("/api/analyze", json=payload, headers=headers)
+    assert r_an.status_code == 200
+    cid = r_an.headers.get("x-cid")
     assert (
         client.post(
             "/api/gpt-draft",
-            json={"text": "Ping", "mode": "friendly"},
+            json={"cid": cid, "clause": "Ping", "mode": "friendly"},
             headers=headers,
         ).status_code
         == 200

--- a/tests/security/test_audit_log.py
+++ b/tests/security/test_audit_log.py
@@ -20,7 +20,8 @@ def test_audit_events_written(tmp_path):
 
     r1 = client.post("/api/analyze", json={"text": "Hello"})
     assert r1.status_code == 200
-    r2 = client.post("/api/gpt-draft", json={"text": "Draft clause"})
+    cid = r1.headers.get("x-cid")
+    r2 = client.post("/api/gpt-draft", json={"cid": cid, "clause": "Draft clause"})
     assert r2.status_code == 200
     r3 = client.post("/api/suggest_edits", json={"text": "Hello"})
     assert r3.status_code == 200

--- a/tests/security/test_privacy_redaction_b5.py
+++ b/tests/security/test_privacy_redaction_b5.py
@@ -9,7 +9,9 @@ def test_privacy_redaction_and_scrub():
         "Contact John Smith at john@example.com or +44 1234 567890. "
         "NI AB123456C."
     )
-    r = client.post("/api/gpt-draft", json={"text": text, "mode": "friendly"})
+    r_an = client.post("/api/analyze", json={"text": text})
+    cid = r_an.headers.get("x-cid")
+    r = client.post("/api/gpt-draft", json={"cid": cid, "clause": text, "mode": "friendly"})
     assert r.status_code == 200
     data = r.json()
     sensitive = ["John Smith", "john@example.com", "+44 1234 567890", "AB123456C"]

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -36,7 +36,9 @@ def test_suggest_ok():
 
 
 def test_gpt_draft_ok():
-    payload = {"text": "Draft confidentiality clause"}
+    r_an = client.post("/api/analyze", json={"text": "Hi"})
+    cid = r_an.headers.get("x-cid")
+    payload = {"cid": cid, "clause": "Draft confidentiality clause"}
     r = client.post("/api/gpt-draft", json=payload)
     assert r.status_code == 200
     for p in ["/api/gpt/draft", "/gpt-draft", "/api/gpt_draft"]:


### PR DESCRIPTION
## Summary
- add `GptDraftIn` model and use it in `/api/gpt-draft`
- expand Companies House search to support GET and POST with clearer errors
- expose Companies House key length in `/health` and log schema error context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68c05be38df48325becbe973fcdf9ea6