### PR TITLE
Add panel and API schema tests

### DIFF
--- a/contract_review_app/api/integrations.py
+++ b/contract_review_app/api/integrations.py
@@ -60,7 +60,7 @@ async def api_companies_search(payload: _CompanySearchIn, request: Request):
 
 
 @router.get("/companies/search")
-async def api_companies_search_get(q: str, items: int = 10, request: Request):
+async def api_companies_search_get(q: str, request: Request, items: int = 10):
     gate = _ch_gate()
     if gate:
         return gate

--- a/tests/api/test_happy_path.py
+++ b/tests/api/test_happy_path.py
@@ -1,0 +1,25 @@
+import os
+from fastapi.testclient import TestClient
+import respx
+from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
+from contract_review_app.integrations.companies_house import client as ch_client
+
+os.environ.setdefault('LLM_PROVIDER', 'mock')
+os.environ.setdefault('FEATURE_COMPANIES_HOUSE', '1')
+os.environ.setdefault('CH_API_KEY', 'x')
+ch_client.KEY = 'x'
+client = TestClient(app, headers={'x-schema-version': SCHEMA_VERSION})
+BASE = ch_client.BASE
+
+@respx.mock
+def test_end_to_end_happy_path():
+    respx.get(f'{BASE}/search/companies').respond(json={'items': []}, headers={'ETag': 'e1'})
+    r_analyze = client.post('/api/analyze', json={'text': 'hello world'})
+    assert r_analyze.status_code == 200
+    cid = r_analyze.headers.get('x-cid')
+    assert cid
+    r_summary = client.post('/api/summary', json={'cid': cid})
+    assert r_summary.status_code == 200
+    r_comp = client.post('/api/companies/search', json={'query': 'ACME'})
+    assert r_comp.status_code == 200

--- a/tests/api/test_openapi_schema.py
+++ b/tests/api/test_openapi_schema.py
@@ -1,0 +1,18 @@
+import os
+from fastapi.testclient import TestClient
+
+os.environ.setdefault('FEATURE_COMPANIES_HOUSE', '1')
+os.environ.setdefault('CH_API_KEY', 'x')
+
+from contract_review_app.api.app import app
+
+
+def test_openapi_contains_paths_and_models():
+    spec = TestClient(app).get('/openapi.json').json()
+    paths = spec['paths']
+    assert '/api/summary' in paths
+    assert '/api/gpt-draft' in paths
+    assert '/api/companies/search' in paths
+    schemas = spec['components']['schemas']
+    for name in ('SummaryIn', 'GptDraftIn', '_CompanySearchIn'):
+        assert name in schemas

--- a/tests/panel/test_postjson_headers.js
+++ b/tests/panel/test_postjson_headers.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const sandbox = {
+  console,
+  localStorage: {
+    _data: {},
+    getItem(k){ return this._data[k] || null; },
+    setItem(k,v){ this._data[k] = String(v); },
+    removeItem(k){ delete this._data[k]; }
+  },
+};
+sandbox.window = sandbox;
+
+const storeState = { apiKey: '', meta: null };
+sandbox.CAI = { Store: {
+  setApiKey: k => { storeState.apiKey = k; },
+  setMeta: m => { storeState.meta = m; },
+}};
+
+let lastReq;
+sandbox.fetch = async (url, opts = {}) => {
+  lastReq = opts;
+  return { json: async () => ({}), headers: { get: () => null }, status: 200 };
+};
+
+let code = fs.readFileSync(__dirname + '/../../word_addin_dev/app/assets/api-client.js', 'utf8');
+code = code.replace(/export\s+\{[\s\S]*?\};?/g, '');
+vm.runInNewContext(code, sandbox);
+
+(async () => {
+  sandbox.localStorage._data = { 'api_key': 'KEY_LS', 'schemaVersion': '1.2' };
+  await sandbox.postJson('/test', { a: 1 });
+  assert.strictEqual(lastReq.headers['x-api-key'], 'KEY_LS');
+  assert.strictEqual(lastReq.headers['x-schema-version'], '1.2');
+
+  sandbox.localStorage._data = {};
+  await sandbox.postJson('/test', { a: 1 });
+  assert.ok(!('x-api-key' in lastReq.headers));
+  assert.ok(!('x-schema-version' in lastReq.headers));
+
+  await sandbox.postJson('/test', { a: 1 }, { apiKey: 'OVERRIDE', schemaVersion: '3.0' });
+  assert.strictEqual(lastReq.headers['x-api-key'], 'OVERRIDE');
+  assert.strictEqual(lastReq.headers['x-schema-version'], '3.0');
+  assert.strictEqual(sandbox.localStorage.getItem('api_key'), 'OVERRIDE');
+  assert.strictEqual(storeState.apiKey, 'OVERRIDE');
+
+  console.log('postJson header tests ok');
+})();


### PR DESCRIPTION
## Summary
- add Jest-style test to verify postJson adds API key and schema headers
- check OpenAPI schema exposes summary, draft, and companies endpoints
- add end-to-end FastAPI test for analyze, summary, and companies search
- fix companies search function signature so module imports cleanly

## Testing
- `node tests/panel/test_postjson_headers.js`
- `pytest tests/api/test_openapi_schema.py tests/api/test_happy_path.py tests/api/test_companies_endpoints.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68c05f51215483258261380c0b3713a8