### PR TITLE
feat: enforce panel header requirements

### DIFF
--- a/word_addin_dev/app/src/panel/api-client.ts
+++ b/word_addin_dev/app/src/panel/api-client.ts
@@ -1,0 +1,18 @@
+export async function postJson(path: string, body: unknown) {
+  const apiBase = (document.getElementById('backendUrl') as HTMLInputElement)?.value || 'https://localhost:9443';
+  const apiKey = localStorage.getItem('x-api-key') || '';
+  const schema = localStorage.getItem('x-schema-version') || '';
+
+  if (!apiKey || !schema) throw new Error('MISSING_HEADERS');
+
+  const res = await fetch(`${apiBase}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'x-schema-version': schema
+    },
+    body: JSON.stringify(body)
+  });
+  return res;
+}

--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -1,7 +1,7 @@
 import { notify } from '../../assets/notifier';
-import { metaFromResponse, applyMetaToBadges } from '../../assets/api-client';
+import { postJson } from './api-client';
 
-const backend = (window as any).CAI?.Store?.getBase?.() || 'https://localhost:9443';
+let lastCid = '';
 
 /** Достаём целиком текст документа Word */
 async function getWholeDocText(): Promise<string> {
@@ -23,63 +23,82 @@ async function getSelectedText(): Promise<string> {
   });
 }
 
-async function postJson(path: string, body: any): Promise<Response> {
-  const resp = await fetch(`${backend}${path}`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  applyMetaToBadges(metaFromResponse(resp));
-  return resp;
+function getLastCid(): string | null {
+  return lastCid || null;
 }
 
-/** Кнопка Test — пинг модели */
-async function onTest(e: Event) {
-  e.preventDefault();
-  const resp = await postJson('/api/gpt-draft', { text: 'Ping draft', mode: 'friendly' });
-  const js = await resp.json();
-  notify.ok(`LLM: HTTP ${resp.status}`);
-  console.log('GPT-DRAFT resp:', js);
+function ensureHeadersSetOrBlock() {
+  const apiKey = localStorage.getItem('x-api-key') || '';
+  const schema = localStorage.getItem('x-schema-version') || '';
+  const ok = !!apiKey && !!schema;
+
+  const btns = document.querySelectorAll<HTMLButtonElement>('[data-needs-headers="1"]');
+  btns.forEach(b => b.disabled = !ok);
+
+  const banner = document.getElementById('headers-missing-banner');
+  if (banner) banner.classList.toggle('hidden', ok);
 }
 
-/** Analyze(doc) */
-async function onAnalyzeDoc(e: Event) {
-  e.preventDefault();
+document.addEventListener('DOMContentLoaded', ensureHeadersSetOrBlock);
+window.addEventListener('storage', ensureHeadersSetOrBlock);
+
+async function handleResponse(res: Response, label: string) {
+  const js = await res.json().catch(() => ({}));
+  const cid = res.headers.get('x-cid');
+  if (cid) lastCid = cid;
+  notify.ok(`${label}: HTTP ${res.status}`);
+  console.log(`${label} resp:`, js);
+}
+
+// Analyze whole doc
+async function doAnalyzeWholeDoc() {
   const text = await getWholeDocText();
-  if (!text) { notify.warn('В документе нет текста'); return; }
-  const resp = await postJson('/api/analyze', { text, mode: 'live' });
-  const js = await resp.json();
-  notify.ok(`ANALYZE: HTTP ${resp.status}`);
-  console.log('ANALYZE resp:', js);
+  const res = await postJson('/api/analyze', { text });
+  await handleResponse(res, 'Analyze');
 }
 
-/** QA Recheck — без правил (для smoke) */
-async function onQARecheck(e: Event) {
-  e.preventDefault();
-  const text = await getSelectedText();
-  if (!text) { notify.warn('Select clause text first'); return; }
-  const resp = await postJson('/api/qa-recheck', { text, rules: {} });
-  const js = await resp.json();
-  notify.ok(`QA: HTTP ${resp.status}`);
-  console.log('QA resp:', js);
+// Draft using GPT
+async function doGptDraft(clauseText: string) {
+  const cid = getLastCid();
+  if (!cid) throw new Error('NO_CID');
+  const res = await postJson('/api/gpt-draft', { cid, clause: clauseText, mode: 'friendly' });
+  await handleResponse(res, 'GPT Draft');
+}
+
+// Summary for last CID
+async function doSummary() {
+  const cid = getLastCid();
+  const res = await postJson('/api/summary', { cid });
+  await handleResponse(res, 'Summary');
+}
+
+async function doQARecheck(text: string) {
+  const res = await postJson('/api/qa-recheck', { text, rules: {} });
+  await handleResponse(res, 'QA');
 }
 
 function bindClick(sel: string, fn: (e: Event) => void) {
   const b = document.querySelector(sel) as HTMLButtonElement | null;
   if (!b) return;
   b.addEventListener('click', fn);
-  b.classList.remove('btn-grey');
   b.disabled = false;
 }
 
-/** Инициализация строго после Office.onReady */
 Office.onReady().then(() => {
-  // backend base может задаваться из store; резерв — localhost
-  if ((window as any).CAI?.Store?.setBase) {
-    (window as any).CAI.Store.setBase('https://localhost:9443');
-  }
-  bindClick('#btnTest', onTest);
-  bindClick('#btnAnalyzeDoc', onAnalyzeDoc);
-  bindClick('#btnQARecheck', onQARecheck);
+  bindClick('#btnAnalyze', async e => { e.preventDefault(); await doAnalyzeWholeDoc(); });
+  bindClick('#btnSummary', async e => { e.preventDefault(); await doSummary(); });
+  bindClick('#btnSuggest', async e => {
+    e.preventDefault();
+    const clause = await getSelectedText();
+    if (!clause) { notify.warn('Select clause text first'); return; }
+    await doGptDraft(clause);
+  });
+  bindClick('#btnQA', async e => {
+    e.preventDefault();
+    const text = await getSelectedText();
+    if (!text) { notify.warn('Select clause text first'); return; }
+    await doQARecheck(text);
+  });
   notify.info('Panel init OK');
+  ensureHeadersSetOrBlock();
 });

--- a/word_addin_dev/app/src/panel/taskpane.html
+++ b/word_addin_dev/app/src/panel/taskpane.html
@@ -11,16 +11,19 @@ body{font-family:Segoe UI,Arial,sans-serif;margin:10px;}
 textarea{width:100%;height:120px;}
 button{margin:4px 4px 4px 0;}
 pre{background:#f0f0f0;padding:8px;border-radius:4px;white-space:pre-wrap;}
+.warning{padding:6px;background:#fff3cd;border:1px solid #ffeeba;margin:8px 0;}
+.hidden{display:none;}
 </style>
 </head>
 <body>
 <div id="health">?</div>
+<div id="headers-missing-banner" class="warning">Set API key & schema via "Save Headers".</div>
 <textarea id="input" placeholder="Enter text..."></textarea>
 <div>
-<button id="btnAnalyze">Analyze</button>
-<button id="btnSummary">Summary</button>
-<button id="btnSuggest">Suggest</button>
-<button id="btnQA">QA</button>
+<button id="btnAnalyze" data-needs-headers="1">Analyze</button>
+<button id="btnSummary" data-needs-headers="1">Summary</button>
+<button id="btnSuggest" data-needs-headers="1">Suggest</button>
+<button id="btnQA" data-needs-headers="1">QA</button>
 </div>
 <pre id="output"></pre>
 <div id="suggestions"></div>
@@ -45,7 +48,7 @@ pre{background:#f0f0f0;padding:8px;border-radius:4px;white-space:pre-wrap;}
 <script type="module" src="taskpane.bundle.js"></script>
 <script nomodule>
   document.body.innerHTML =
-    '<div style=\"padding:12px;color:#f66\">Your runtime is too old for ES modules. Please update your browser.</div>';
+    '<div style="padding:12px;color:#f66">Your runtime is too old for ES modules. Please update your browser.</div>';
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enforce required API headers in panel `postJson`
- block panel actions until headers set and add missing-header banner
- wire analyze, draft, summary, and QA calls through stricter client

## Testing
- `pre-commit run --files word_addin_dev/app/src/panel/api-client.ts word_addin_dev/app/src/panel/index.ts word_addin_dev/app/src/panel/taskpane.html`
- `node tests/panel/test_postjson_headers.js`
- `npm run build:panel` *(fails: ModuleNotFoundError: No module named 'bump_build')*
- `pytest` *(fails: 126 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c06178ec4883259be543ef7ed691a6