### PR TITLE
fix: read headers from existing storage keys

### DIFF
--- a/word_addin_dev/app/src/panel/api-client.ts
+++ b/word_addin_dev/app/src/panel/api-client.ts
@@ -1,7 +1,8 @@
 export async function postJson(path: string, body: unknown) {
   const apiBase = (document.getElementById('backendUrl') as HTMLInputElement)?.value || 'https://localhost:9443';
-  const apiKey = localStorage.getItem('x-api-key') || '';
-  const schema = localStorage.getItem('x-schema-version') || '';
+  // headers are persisted in localStorage keys `api_key` and `schemaVersion`
+  const apiKey = localStorage.getItem('api_key') || '';
+  const schema = localStorage.getItem('schemaVersion') || '';
 
   if (!apiKey || !schema) throw new Error('MISSING_HEADERS');
 

--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -28,8 +28,9 @@ function getLastCid(): string | null {
 }
 
 function ensureHeadersSetOrBlock() {
-  const apiKey = localStorage.getItem('x-api-key') || '';
-  const schema = localStorage.getItem('x-schema-version') || '';
+  // existing panel code stores credentials under `api_key` and `schemaVersion`
+  const apiKey = localStorage.getItem('api_key') || '';
+  const schema = localStorage.getItem('schemaVersion') || '';
   const ok = !!apiKey && !!schema;
 
   const btns = document.querySelectorAll<HTMLButtonElement>('[data-needs-headers="1"]');


### PR DESCRIPTION
## Summary
- pull API key and schema from existing `api_key`/`schemaVersion` storage entries
- document source of persisted header values

## Testing
- `pre-commit run --files word_addin_dev/app/src/panel/api-client.ts word_addin_dev/app/src/panel/index.ts word_addin_dev/app/src/panel/taskpane.html`
- `node tests/panel/test_postjson_headers.js`
- `npm run build:panel` *(fails: ModuleNotFoundError: No module named 'bump_build')*
- `pytest` *(fails: 126 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c06347c65c83259493698782d8eea1