### PR TITLE
Allow medium mode for GPT draft requests

### DIFF
--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -1,7 +1,14 @@
 from typing import Any, Dict, List, Literal
 
 from fastapi import HTTPException
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator, field_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+    field_validator,
+)
 
 from contract_review_app.core.schemas import AppBaseModel
 
@@ -113,7 +120,7 @@ class GptDraftIn(_DTOBase):
 
     cid: str
     clause: str
-    mode: Literal["friendly", "neutral", "strict"] | None = None
+    mode: Literal["friendly", "neutral", "medium", "strict"] | None = None
 
 
 class QARecheckIn(_DTOBase):


### PR DESCRIPTION
## Summary
- accept `mode="medium"` in `GptDraftIn`
- normalize `medium`/`neutral` modes to standard style in drafting pipeline

## Testing
- `pre-commit run --files contract_review_app/api/models.py contract_review_app/gpt/gpt_draft.py`
- `pytest -q` *(fails: assert 500 == 200, etc.)*
- `python tools/doctor.py --out /tmp/doctor_out.txt` *(fails: AZURE_OPENAI_API_KEY is missing or looks like a placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68c0619abbac832582631690fcddbdd0