### PR TITLE
feat: relax schema header for localhost

### DIFF
--- a/contract_review_app/core/schemas.py
+++ b/contract_review_app/core/schemas.py
@@ -179,6 +179,8 @@ class AnalyzeIn(AppBaseModel):
     Adds optional segment context and output switches without breaking legacy.
     """
 
+    model_config = ConfigDict(extra="ignore")
+
     document_name: Optional[str] = None
     text: str
     language: str = "en-GB"
@@ -1151,7 +1153,9 @@ class SuggestEdit(AppBaseModel):
 
     @model_validator(mode="after")
     def _autofill_operations(self):
-        if self.operations is None and (self.insert is not None or self.delete is not None):
+        if self.operations is None and (
+            self.insert is not None or self.delete is not None
+        ):
             self.operations = ["replace"]
         return self
 


### PR DESCRIPTION
## Summary
- make AnalyzeIn tolerate extra fields
- default missing x-schema-version header on localhost requests

## Testing
- `pre-commit run --files contract_review_app/core/schemas.py contract_review_app/api/app.py`
- `pytest tests/api/test_auth_and_headers.py::test_missing_schema_version_400`
- `pytest tests/api/test_analyze_minimal.py::test_analyze_minimal`


------
https://chatgpt.com/codex/tasks/task_e_68c062d529ac83258f869a03b5d79e7a