### PR TITLE
Fix middleware header mutation for local requests

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -269,7 +269,7 @@ class RequireHeadersMiddleware(BaseHTTPMiddleware):
         if "x-schema-version" not in request.headers:
             client_host = request.client.host if request.client else ""
             if client_host in {"127.0.0.1", "::1", "localhost"}:
-                headers = MutableHeaders(request.scope)
+                headers = MutableHeaders(scope=request.scope)
                 headers.append("x-schema-version", SCHEMA_VERSION)
 
         if request.method.upper() == "POST" and not any(


### PR DESCRIPTION
## Summary
- pass request scope to `MutableHeaders` so local requests get default schema header

## Testing
- `python - <<'PY'
from starlette.middleware.base import BaseHTTPMiddleware
from starlette.requests import Request
from starlette.datastructures import MutableHeaders
from starlette.responses import Response
from contract_review_app.api.models import SCHEMA_VERSION
import asyncio

class RequireHeadersMiddleware(BaseHTTPMiddleware):
    _SKIP_PATHS = ("/api/companies",)
    async def dispatch(self, request: Request, call_next):
        if "x-schema-version" not in request.headers:
            client_host = request.client.host if request.client else ""
            if client_host in {"127.0.0.1", "::1", "localhost"}:
                headers = MutableHeaders(scope=request.scope)
                headers.append("x-schema-version", SCHEMA_VERSION)
        return await call_next(request)

async def call_next(request):
    return Response('ok')

scope = {'type': 'http','method': 'GET','path': '/api/health','headers': [],'client': ('127.0.0.1', 1234)}
request = Request(scope)
resp = asyncio.run(RequireHeadersMiddleware(None).dispatch(request, call_next))
print('resp status', resp.status_code)
PY`
- `PYTHONPATH=. pytest contract_review_app/tests/test_api_health_schema.py -q`
- `PYTHONPATH=. pytest contract_review_app/tests/api/test_api_headers.py -q` *(fails: expected 422 but got 400)*

------
https://chatgpt.com/codex/tasks/task_e_68c075cc1c108325ad1feadfd3cceba5