### PR TITLE
Simplify header check in taskpane

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -20,16 +20,9 @@ const Q = {
 let lastCid: string = "";
 
 function ensureHeaders(): boolean {
-  const apiKey = getApiKeyFromStore();
-  const schema = getSchemaFromStore();
-  const ok = !!apiKey && !!schema;
-  const warn = document.getElementById('hdrWarn');
-  if (warn) warn.style.display = ok ? 'none' : 'block';
-  ['#btnAnalyze', '#btnQARecheck', '#btnGetAIDraft'].forEach(sel => {
-    const b = document.querySelector(sel) as HTMLButtonElement | null;
-    if (b) b.disabled = !ok;
-  });
-  return ok;
+  getApiKeyFromStore();
+  getSchemaFromStore();
+  return true;
 }
 
 function slot(id: string, role: string): HTMLElement | null {

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -143,9 +143,6 @@
   </div>
 
   <div class="row muted">Endpoints: <code>/health</code> · <code>/api/analyze</code> · <code>/api/gpt-draft</code> · <code>/api/qa-recheck</code></div>
-
-  <div id="hdrWarn" style="display:none;background:#b30000;color:#fff;padding:6px;margin:8px 0;border-radius:4px;">Set API key &amp; schema (Save Headers)</div>
-
   <div class="row card">
     <div class="row"><input id="backendUrl" placeholder="https://localhost:9443" /></div>
     <div class="row flex">


### PR DESCRIPTION
## Summary
- Always return true in `ensureHeaders` and remove UI warning logic
- Drop obsolete hdrWarn block from taskpane panel
- Rebuild taskpane bundle

## Testing
- `npx esbuild word_addin_dev/app/assets/taskpane.ts --bundle --outfile=word_addin_dev/taskpane.bundle.js --format=iife --platform=browser`
- `python -m tools.build_panel` (no output)
- `pre-commit run --files word_addin_dev/app/assets/taskpane.ts word_addin_dev/taskpane.html`


------
https://chatgpt.com/codex/tasks/task_e_68c087d8a3188325be70756203250b7c