### PR TITLE
chore: remove header guard from panel

### DIFF
--- a/word_addin_dev/app/build-20250826-1403/taskpane.html
+++ b/word_addin_dev/app/build-20250826-1403/taskpane.html
@@ -11,22 +11,43 @@ body{font-family:Segoe UI,Arial,sans-serif;margin:10px;}
 textarea{width:100%;height:120px;}
 button{margin:4px 4px 4px 0;}
 pre{background:#f0f0f0;padding:8px;border-radius:4px;white-space:pre-wrap;}
+.warning{padding:6px;background:#fff3cd;border:1px solid #ffeeba;margin:8px 0;}
+.hidden{display:none;}
 </style>
 </head>
 <body>
 <div id="health">?</div>
 <textarea id="input" placeholder="Enter text..."></textarea>
 <div>
-<button id="btnAnalyze">Analyze</button>
-<button id="btnSummary">Summary</button>
-<button id="btnSuggest">Suggest</button>
-<button id="btnQA">QA</button>
+<button id="btnAnalyze" data-needs-headers="1">Analyze</button>
+<button id="btnSummary" data-needs-headers="1">Summary</button>
+<button id="btnSuggest" data-needs-headers="1">Suggest</button>
+<button id="btnQA" data-needs-headers="1">QA</button>
 </div>
 <pre id="output"></pre>
+<div id="suggestions"></div>
+<template id="sugg-item">
+  <div class="sugg-item" data-id="">
+    <div class="sugg-head">
+      <span class="rule"></span>
+      <span class="sev"></span>
+      <span class="badge status"></span>
+    </div>
+    <div class="sugg-body">
+      <div class="before"></div>
+      <div class="after"></div>
+    </div>
+    <div class="sugg-actions">
+      <button class="btn-apply">Apply (tracked)</button>
+      <button class="btn-accept">Accept</button>
+      <button class="btn-reject">Reject</button>
+    </div>
+  </div>
+</template>
 <script type="module" src="taskpane.bundle.js"></script>
 <script nomodule>
   document.body.innerHTML =
-    '<div style=\"padding:12px;color:#f66\">Your runtime is too old for ES modules. Please update your browser.</div>';
+    '<div style="padding:12px;color:#f66">Your runtime is too old for ES modules. Please update your browser.</div>';
 </script>
 </body>
 </html>

--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -27,22 +27,6 @@ function getLastCid(): string | null {
   return lastCid || null;
 }
 
-function ensureHeadersSetOrBlock() {
-  // existing panel code stores credentials under `api_key` and `schemaVersion`
-  const apiKey = localStorage.getItem('api_key') || '';
-  const schema = localStorage.getItem('schemaVersion') || '';
-  const ok = !!apiKey && !!schema;
-
-  const btns = document.querySelectorAll<HTMLButtonElement>('[data-needs-headers="1"]');
-  btns.forEach(b => b.disabled = !ok);
-
-  const banner = document.getElementById('headers-missing-banner');
-  if (banner) banner.classList.toggle('hidden', ok);
-}
-
-document.addEventListener('DOMContentLoaded', ensureHeadersSetOrBlock);
-window.addEventListener('storage', ensureHeadersSetOrBlock);
-
 async function handleResponse(res: Response, label: string) {
   const js = await res.json().catch(() => ({}));
   const cid = res.headers.get('x-cid');
@@ -101,5 +85,4 @@ Office.onReady().then(() => {
     await doQARecheck(text);
   });
   notify.info('Panel init OK');
-  ensureHeadersSetOrBlock();
 });

--- a/word_addin_dev/app/src/panel/taskpane.html
+++ b/word_addin_dev/app/src/panel/taskpane.html
@@ -17,7 +17,6 @@ pre{background:#f0f0f0;padding:8px;border-radius:4px;white-space:pre-wrap;}
 </head>
 <body>
 <div id="health">?</div>
-<div id="headers-missing-banner" class="warning">Set API key & schema via "Save Headers".</div>
 <textarea id="input" placeholder="Enter text..."></textarea>
 <div>
 <button id="btnAnalyze" data-needs-headers="1">Analyze</button>


### PR DESCRIPTION
## Summary
- drop header gating logic from the Word panel
- remove unused banner referencing missing headers

## Testing
- `npx esbuild word_addin_dev/app/src/panel/index.ts --bundle --outfile=word_addin_dev/app/build-20250826-1403/taskpane.bundle.js --format=iife --platform=browser` *(fails: No matching export)*
- `python -m tools.build_panel`
- `pytest` *(fails: ModuleNotFoundError: No module named 'openapi_spec_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68c089b3890c832588481c524e1e9c73