### PR TITLE
Allow selftest to run without API headers

### DIFF
--- a/word_addin_dev/app/selftest.js
+++ b/word_addin_dev/app/selftest.js
@@ -80,7 +80,11 @@ function loadBase(){
 }
 
 function saveApiKey(){
-  try{ const v=document.getElementById("apiKeyInput").value.trim(); localStorage.setItem(API_KEY_STORAGE, v);}catch{}
+  try{
+    const v=document.getElementById("apiKeyInput").value.trim();
+    localStorage.setItem(API_KEY_STORAGE, v);
+    CAI.Store?.setApiKey?.(v);
+  }catch{}
 }
 function loadApiKey(){
   let v="";
@@ -238,10 +242,10 @@ async function callEndpoint({name, method, path, body, dynamicPathFn}) {
       let k = document.getElementById("apiKeyInput").value.trim();
       let s = document.getElementById("schemaInput").value.trim();
       if (!k) {
-        k = origKey || (CAI.Store?.get?.().apiKey) || "";
+        k = origKey || "";
       }
       if (!s) {
-        s = origSchema || (CAI.Store?.get?.().schemaVersion) || "";
+        s = origSchema || "";
       }
       if (k) {
         localStorage.setItem(API_KEY_STORAGE, k);


### PR DESCRIPTION
## Summary
- clear CAI.Store when saving API key so cleared fields remove stored key
- skip CAI.Store fallback when API key or schema inputs are blank

## Testing
- `pre-commit run --files word_addin_dev/app/selftest.js`
- `node tests/panel/test_selftest_build.js`
- `node tests/panel/test_llm_banner.js`
- `node tests/panel/test_selftest_call.js`
- `pytest tests/panel/test_panel_urls.py`


------
https://chatgpt.com/codex/tasks/task_e_68c140273344832582ac9c9b314cd813