### PR TITLE
Stabilize panel network handling and auto headers

### DIFF
--- a/contract_review_app/frontend/common/http.ts
+++ b/contract_review_app/frontend/common/http.ts
@@ -1,0 +1,35 @@
+export type HeadersMap = Record<string, string>;
+const LS = { API_KEY: 'api_key', SCHEMA: 'schema_version' } as const;
+
+export function getStoredKey(): string {
+  return localStorage.getItem(LS.API_KEY) ?? '';
+}
+export function getStoredSchema(): string {
+  return localStorage.getItem(LS.SCHEMA) ?? '';
+}
+export function setStoredSchema(v: string) {
+  if (v) localStorage.setItem(LS.SCHEMA, v);
+}
+
+export async function postJSON<T>(url: string, body: unknown, extra: HeadersMap = {}): Promise<T> {
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+    'x-api-key': getStoredKey(),
+    'x-schema-version': getStoredSchema(),
+    ...extra,
+  };
+  const r = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  const respSchema = r.headers.get('x-schema-version');
+  if (respSchema) setStoredSchema(respSchema);
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const data = (await r.json()) as T & { schema?: string };
+  if (data?.schema) setStoredSchema(data.schema);
+  return data;
+}
+
+export async function getHealth(base: string) {
+  const r = await fetch(`${base}/health`, { method: 'GET' });
+  const j = await r.json().catch(() => ({}));
+  if (j?.schema) setStoredSchema(j.schema);
+  return j;
+}

--- a/contract_review_app/frontend/common/safe.ts
+++ b/contract_review_app/frontend/common/safe.ts
@@ -1,0 +1,10 @@
+export function asArray<T = any>(v: any): T[] {
+  return Array.isArray(v) ? (v as T[]) : [];
+}
+export function asString(v: any, d = ''): string {
+  return typeof v === 'string' ? v : d;
+}
+export function asNumber(v: any, d = 0): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}

--- a/contract_review_app/frontend/tsconfig.json
+++ b/contract_review_app/frontend/tsconfig.json
@@ -7,5 +7,5 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "include": ["draft_panel"]
+  "include": ["draft_panel", "common"]
 }


### PR DESCRIPTION
## Summary
- add shared safe and http helpers for resilient data and auto header management
- refactor React draft panel with FSM, error boundary, and Word insertion support
- simplify Word taskpane networking with shared helpers and dev-key fallback

## Testing
- `npm --prefix contract_review_app/frontend run build`
- `node tests/panel/test_postjson_headers.js`


------
https://chatgpt.com/codex/tasks/task_e_68c14680577c832593dba54733643166