### PR TITLE
feat: paginate findings and Word insertion

### DIFF
--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -212,7 +212,7 @@
     <div class="flex">
       <button id="btnUseWholeDoc">Use whole doc →</button>
       <button id="btnAnalyze">Analyze</button>
-      <button id="btnInsertIntoWord" class="btn" style="display:none">Insert result into Word</button>
+      <button id="btnInsertIntoWord" class="btn">Insert result into Word</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Paginate findings in the React draft panel with Load more paging
- Insert generated draft into Word using Office.js with clipboard fallback
- Expose Word insert button in taskpane and wire to new helper

## Testing
- ⚠️ `npm run build:panel` (missing module bump_build)
- ⚠️ `pytest -q` (101 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68c148a0c8cc8325a301df82d4fe2eea