### PR TITLE
fix: restore clipboard fallback on Word insert failure

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -587,14 +587,16 @@ function wireUI() {
 g.wireUI = g.wireUI || wireUI;
 
 async function onInsertIntoWord() {
+  const dst = $(Q.proposed);
+  const txt = (dst?.value || "").trim();
+  if (!txt) { notifyWarn("No draft to insert"); return; }
   try {
-    const dst = $(Q.proposed);
-    const txt = (dst?.value || "").trim();
-    if (!txt) { notifyWarn("No draft to insert"); return; }
     await insertIntoWord(txt);
     notifyOk("Inserted into Word");
   } catch (e) {
     console.error(e);
+    await navigator.clipboard?.writeText(txt).catch(() => {});
+    notifyWarn("Insert failed; draft copied to clipboard");
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve clipboard fallback when Word insertion errors occur

## Testing
- ⚠️ `npm run build:panel` (ModuleNotFoundError: No module named 'bump_build')
- ⚠️ `pytest -q` (KeyboardInterrupt, multiple collection errors)


------
https://chatgpt.com/codex/tasks/task_e_68c14c659cc48325bc92d628ac87fef5