### PR TITLE
feat: centralize header defaults

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -76,7 +76,7 @@ async function postJson(path, body, opts = {}) {
     } catch {
     }
     try {
-      return localStorage.getItem("schemaVersion") || "";
+      return localStorage.getItem("schema_version") || "";
     } catch {
       return "";
     }
@@ -103,7 +103,7 @@ async function req(path, { method = "GET", body = null, key = path } = {}) {
     const store = window.CAI?.Store?.get?.() || {};
     const apiKey = store.apiKey || localStorage.getItem("api_key");
     if (apiKey) headers["x-api-key"] = apiKey;
-    const schema = store.schemaVersion || localStorage.getItem("schemaVersion");
+    const schema = store.schemaVersion || localStorage.getItem("schema_version");
     if (schema) headers["x-schema-version"] = schema;
   } catch {
   }

--- a/contract_review_app/contract_review_app/static/panel/app/assets/bootstrap.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/bootstrap.js
@@ -1,10 +1,10 @@
 export async function bootstrapHeaders() {
   // DEV ONLY: auto-populate schema and API key
-  if (!localStorage.getItem('schemaVersion')) {
+  if (!localStorage.getItem('schema_version')) {
     try {
       const h = await fetch('/health').then(r => r.json());
       if (h && h.schema) {
-        localStorage.setItem('schemaVersion', String(h.schema));
+        localStorage.setItem('schema_version', String(h.schema));
       }
     } catch {}
   }

--- a/contract_review_app/contract_review_app/static/panel/app/assets/store.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/store.js
@@ -5,7 +5,7 @@
     baseUrl: localStorage.getItem("backendUrl") || DEFAULT_BASE,
     risk:    localStorage.getItem("risk") || "medium",
     apiKey:  localStorage.getItem("api_key") || "",
-    schemaVersion: localStorage.getItem("schemaVersion") || "",
+    schemaVersion: localStorage.getItem("schema_version") || "",
     lastCid: null,
     meta: { cid:"", cache:"", latencyMs:0, schema:"", provider:"", model:"", llm_mode:"", usage:"" },
     last: { analyze:null, summary:null, draft:null, suggest:null }
@@ -13,7 +13,7 @@
   function setBase(u){ S.baseUrl = u; try { localStorage.setItem("backendUrl", u); } catch {} }
   function setRisk(r){ S.risk = r; try { localStorage.setItem("risk", r); } catch {} }
   function setApiKey(k){ S.apiKey = k; try { localStorage.setItem("api_key", k); } catch {} }
-  function setSchemaVersion(v){ S.schemaVersion = v; try { localStorage.setItem("schemaVersion", v); } catch {} }
+  function setSchemaVersion(v){ S.schemaVersion = v; try { localStorage.setItem("schema_version", v); } catch {} }
   function setMeta(m){
     S.meta = { ...S.meta, ...m };
     if (m && m.cid) S.lastCid = m.cid;

--- a/contract_review_app/contract_review_app/static/panel/app/selftest.js
+++ b/contract_review_app/contract_review_app/static/panel/app/selftest.js
@@ -4,7 +4,7 @@
 // ---------------------- helpers ----------------------
 const LS_KEY = "panel:backendUrl";
 const API_KEY_STORAGE = "api_key";
-const SCHEMA_STORAGE = "schemaVersion";
+const SCHEMA_STORAGE = "schema_version";
 const DRAFT_PATH = "/api/gpt-draft";
 const SAMPLE = "Governing law: England and Wales.";
 let clientCid = genCid();

--- a/contract_review_app/contract_review_app/static/panel/taskpane.bundle.js
+++ b/contract_review_app/contract_review_app/static/panel/taskpane.bundle.js
@@ -77,7 +77,7 @@
       } catch {
       }
       try {
-        return localStorage.getItem("schemaVersion") || "";
+        return localStorage.getItem("schema_version") || "";
       } catch {
         return "";
       }
@@ -104,7 +104,7 @@
       const store = window.CAI?.Store?.get?.() || {};
       const apiKey = store.apiKey || localStorage.getItem("api_key");
       if (apiKey) headers["x-api-key"] = apiKey;
-      const schema = store.schemaVersion || localStorage.getItem("schemaVersion");
+      const schema = store.schemaVersion || localStorage.getItem("schema_version");
       if (schema) headers["x-schema-version"] = schema;
     } catch {
     }
@@ -147,8 +147,8 @@
       if (localStorage.getItem("api_key") === null) {
         localStorage.setItem("api_key", DEFAULT_API_KEY);
       }
-      if (localStorage.getItem("schemaVersion") === null) {
-        localStorage.setItem("schemaVersion", DEFAULT_SCHEMA);
+      if (localStorage.getItem("schema_version") === null) {
+        localStorage.setItem("schema_version", DEFAULT_SCHEMA);
       }
     } catch {
     }
@@ -169,14 +169,14 @@
   }
   function getSchemaFromStore() {
     try {
-      return localStorage.getItem("schemaVersion") || DEFAULT_SCHEMA;
+      return localStorage.getItem("schema_version") || DEFAULT_SCHEMA;
     } catch {
       return DEFAULT_SCHEMA;
     }
   }
   function setSchemaVersion(v) {
     try {
-      localStorage.setItem("schemaVersion", v);
+      localStorage.setItem("schema_version", v);
     } catch {
     }
   }
@@ -233,23 +233,31 @@
   var lastCid = "";
   function ensureHeaders() {
     try {
+      if (!localStorage.getItem("api_key")) {
+        try {
+          new URL(window.location.href);
+          localStorage.setItem("api_key", "local-test-key-123");
+        } catch {}
+      }
+      if (!localStorage.getItem("schema_version")) {
+        try {
+          localStorage.setItem("schema_version", "1.4");
+        } catch {}
+      }
       const store = globalThis.CAI?.Store?.get?.() || {};
       const apiKey = store.apiKey || getApiKeyFromStore();
       const schema = store.schemaVersion || getSchemaFromStore();
       if (apiKey) {
         try {
           localStorage.setItem("api_key", apiKey);
-        } catch {
-        }
+        } catch {}
       }
       if (schema) {
         try {
-          localStorage.setItem("schemaVersion", schema);
-        } catch {
-        }
+          localStorage.setItem("schema_version", schema);
+        } catch {}
       }
-    } catch {
-    }
+    } catch {}
     return true;
   }
   function slot(id, role) {

--- a/contract_review_app/frontend/common/http.ts
+++ b/contract_review_app/frontend/common/http.ts
@@ -11,6 +11,19 @@ export function setStoredSchema(v: string) {
   if (v) localStorage.setItem(LS.SCHEMA, v);
 }
 
+export function ensureHeadersSet() {
+  try {
+    if (!localStorage.getItem(LS.API_KEY)) {
+      localStorage.setItem(LS.API_KEY, 'local-test-key-123');
+    }
+    if (!localStorage.getItem(LS.SCHEMA)) {
+      localStorage.setItem(LS.SCHEMA, '1.4');
+    }
+  } catch {
+    // ignore
+  }
+}
+
 export async function postJSON<T>(url: string, body: unknown, extra: HeadersMap = {}): Promise<T> {
   const headers: HeadersInit = {
     'Content-Type': 'application/json',

--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { asArray } from '../common/safe';
-import { postJSON, getHealth } from '../common/http';
+import { postJSON, getHealth, ensureHeadersSet } from '../common/http';
 
 const DEFAULT_BACKEND = 'http://127.0.0.1:9000';
 const LS_KEY = 'contract_ai_backend';
@@ -54,9 +54,7 @@ const DraftAssistantPanel: React.FC = () => {
   const [findingsLimit, setFindingsLimit] = useState(PAGE_SIZE);
 
   useEffect(() => {
-    if (!localStorage.getItem('api_key')) {
-      try { new URL(window.location.href); localStorage.setItem('api_key', 'local-test-key-123'); } catch {}
-    }
+    ensureHeadersSet();
     const base = getBackend().replace(/\/+$/, '');
     getHealth(base).then(j => {
       setBackendOk(true);

--- a/tests/panel/test_postjson_headers.js
+++ b/tests/panel/test_postjson_headers.js
@@ -30,7 +30,7 @@ code = code.replace(/export\s+\{[\s\S]*?\};?/g, '');
 vm.runInNewContext(code, sandbox);
 
 (async () => {
-  sandbox.localStorage._data = { 'api_key': 'KEY_LS', 'schemaVersion': '1.2' };
+  sandbox.localStorage._data = { 'api_key': 'KEY_LS', 'schema_version': '1.2' };
   await sandbox.postJson('/test', { a: 1 });
   assert.strictEqual(lastReq.headers['x-api-key'], 'KEY_LS');
   assert.strictEqual(lastReq.headers['x-schema-version'], '1.2');

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -76,7 +76,7 @@ async function postJson(path, body, opts = {}) {
     } catch {
     }
     try {
-      return localStorage.getItem("schemaVersion") || "";
+      return localStorage.getItem("schema_version") || "";
     } catch {
       return "";
     }
@@ -103,7 +103,7 @@ async function req(path, { method = "GET", body = null, key = path } = {}) {
     const store = window.CAI?.Store?.get?.() || {};
     const apiKey = store.apiKey || localStorage.getItem("api_key");
     if (apiKey) headers["x-api-key"] = apiKey;
-    const schema = store.schemaVersion || localStorage.getItem("schemaVersion");
+    const schema = store.schemaVersion || localStorage.getItem("schema_version");
     if (schema) headers["x-schema-version"] = schema;
   } catch {
   }

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -105,7 +105,7 @@ export async function postJson(path: string, body: any, opts: { apiKey?: string;
       const storeSchema = (window as any).CAI?.Store?.get?.()?.schemaVersion;
       if (storeSchema) return storeSchema;
     } catch {}
-    try { return localStorage.getItem('schemaVersion') || ''; } catch { return ''; }
+    try { return localStorage.getItem('schema_version') || ''; } catch { return ''; }
   })();
   if (schemaVersion) headers['x-schema-version'] = schemaVersion;
   const http = await fetch(url, {
@@ -129,7 +129,7 @@ async function req(path: string, { method='GET', body=null, key=path }: { method
     const store = (window as any).CAI?.Store?.get?.() || {};
     const apiKey = store.apiKey || localStorage.getItem('api_key');
     if (apiKey) headers['x-api-key'] = apiKey;
-    const schema = store.schemaVersion || localStorage.getItem('schemaVersion');
+    const schema = store.schemaVersion || localStorage.getItem('schema_version');
     if (schema) headers['x-schema-version'] = schema;
   } catch {}
 

--- a/word_addin_dev/app/assets/bootstrap.js
+++ b/word_addin_dev/app/assets/bootstrap.js
@@ -1,10 +1,10 @@
 export async function bootstrapHeaders() {
   // DEV ONLY: auto-populate schema and API key
-  if (!localStorage.getItem('schemaVersion')) {
+  if (!localStorage.getItem('schema_version')) {
     try {
       const h = await fetch('/health').then(r => r.json());
       if (h && h.schema) {
-        localStorage.setItem('schemaVersion', String(h.schema));
+        localStorage.setItem('schema_version', String(h.schema));
       }
     } catch {}
   }

--- a/word_addin_dev/app/assets/bootstrap.ts
+++ b/word_addin_dev/app/assets/bootstrap.ts
@@ -1,10 +1,10 @@
 export async function bootstrapHeaders() {
   // DEV ONLY: auto-populate schema and API key
-  if (!localStorage.getItem('schemaVersion')) {
+  if (!localStorage.getItem('schema_version')) {
     try {
       const h = await fetch('/health').then(r => r.json());
       if (h && h.schema) {
-        localStorage.setItem('schemaVersion', String(h.schema));
+        localStorage.setItem('schema_version', String(h.schema));
       }
     } catch {}
   }

--- a/word_addin_dev/app/assets/store.js
+++ b/word_addin_dev/app/assets/store.js
@@ -5,7 +5,7 @@
     baseUrl: localStorage.getItem("backendUrl") || DEFAULT_BASE,
     risk:    localStorage.getItem("risk") || "medium",
     apiKey:  localStorage.getItem("api_key") || "",
-    schemaVersion: localStorage.getItem("schemaVersion") || "",
+    schemaVersion: localStorage.getItem("schema_version") || "",
     lastCid: null,
     meta: { cid:"", cache:"", latencyMs:0, schema:"", provider:"", model:"", llm_mode:"", usage:"" },
     last: { analyze:null, summary:null, draft:null, suggest:null }
@@ -13,7 +13,7 @@
   function setBase(u){ S.baseUrl = u; try { localStorage.setItem("backendUrl", u); } catch {} }
   function setRisk(r){ S.risk = r; try { localStorage.setItem("risk", r); } catch {} }
   function setApiKey(k){ S.apiKey = k; try { localStorage.setItem("api_key", k); } catch {} }
-  function setSchemaVersion(v){ S.schemaVersion = v; try { localStorage.setItem("schemaVersion", v); } catch {} }
+  function setSchemaVersion(v){ S.schemaVersion = v; try { localStorage.setItem("schema_version", v); } catch {} }
   function setMeta(m){
     S.meta = { ...S.meta, ...m };
     if (m && m.cid) S.lastCid = m.cid;

--- a/word_addin_dev/app/assets/store.ts
+++ b/word_addin_dev/app/assets/store.ts
@@ -6,8 +6,8 @@ function ensureDefaults(): void {
     if (localStorage.getItem("api_key") === null) {
       localStorage.setItem("api_key", DEFAULT_API_KEY);
     }
-    if (localStorage.getItem("schemaVersion") === null) {
-      localStorage.setItem("schemaVersion", DEFAULT_SCHEMA);
+    if (localStorage.getItem("schema_version") === null) {
+      localStorage.setItem("schema_version", DEFAULT_SCHEMA);
     }
   } catch {
     // ignore
@@ -34,7 +34,7 @@ export function setApiKey(k: string): void {
 
 export function getSchemaFromStore(): string {
   try {
-    return localStorage.getItem("schemaVersion") || DEFAULT_SCHEMA;
+    return localStorage.getItem("schema_version") || DEFAULT_SCHEMA;
   } catch {
     return DEFAULT_SCHEMA;
   }
@@ -42,7 +42,7 @@ export function getSchemaFromStore(): string {
 
 export function setSchemaVersion(v: string): void {
   try {
-    localStorage.setItem("schemaVersion", v);
+    localStorage.setItem("schema_version", v);
   } catch {
     // ignore
   }

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1,6 +1,6 @@
 import { applyMetaToBadges, parseFindings, AnalyzeFinding } from "./api-client";
 import { getApiKeyFromStore, getSchemaFromStore } from "./store";
-import { postJSON, getHealth, getStoredKey, getStoredSchema, setStoredSchema } from "../../../contract_review_app/frontend/common/http";
+import { postJSON, getHealth, getStoredKey, getStoredSchema, setStoredSchema, ensureHeadersSet } from "../../../contract_review_app/frontend/common/http";
 const g: any = globalThis as any;
 g.parseFindings = g.parseFindings || parseFindings;
 g.applyMetaToBadges = g.applyMetaToBadges || applyMetaToBadges;
@@ -27,10 +27,8 @@ function getBackend(): string {
 function ensureHeaders(): boolean {
   // Try to populate required headers from either CAI.Store or
   // localStorage but never block user actions if they are missing.
+  ensureHeadersSet();
   try {
-    if (!localStorage.getItem('api_key')) {
-      try { new URL(window.location.href); localStorage.setItem('api_key', 'local-test-key-123'); } catch {}
-    }
     const store = (globalThis as any).CAI?.Store?.get?.() || {};
     const apiKey = store.apiKey || getApiKeyFromStore();
     const schema = store.schemaVersion || getSchemaFromStore();
@@ -38,7 +36,7 @@ function ensureHeaders(): boolean {
       try { localStorage.setItem('api_key', apiKey); } catch {}
     }
     if (schema) {
-      try { localStorage.setItem('schemaVersion', schema); } catch {}
+      try { setStoredSchema(schema); } catch {}
     }
   } catch {
     // swallow errors – missing storage should not stop the flow

--- a/word_addin_dev/app/selftest.js
+++ b/word_addin_dev/app/selftest.js
@@ -4,7 +4,7 @@
 // ---------------------- helpers ----------------------
 const LS_KEY = "panel:backendUrl";
 const API_KEY_STORAGE = "api_key";
-const SCHEMA_STORAGE = "schemaVersion";
+const SCHEMA_STORAGE = "schema_version";
 const DRAFT_PATH = "/api/gpt-draft";
 const SAMPLE = "Governing law: England and Wales.";
 let clientCid = genCid();

--- a/word_addin_dev/app/src/panel/analyze.flow.spec.ts
+++ b/word_addin_dev/app/src/panel/analyze.flow.spec.ts
@@ -6,7 +6,7 @@ describe('analyze flow', () => {
     let captured: any = null
     ;(globalThis as any).document = { getElementById: () => ({ value: 'https://base' }) }
     ;(globalThis as any).localStorage = {
-      getItem: (k: string) => (k === 'api_key' ? 'KEY' : k === 'schemaVersion' ? '1.2' : '')
+      getItem: (k: string) => (k === 'api_key' ? 'KEY' : k === 'schema_version' ? '1.2' : '')
     }
     ;(globalThis as any).fetch = async (url: string, opts: any) => {
       captured = opts

--- a/word_addin_dev/app/src/panel/api-client.ts
+++ b/word_addin_dev/app/src/panel/api-client.ts
@@ -1,8 +1,8 @@
 export async function postJson(path: string, body: unknown) {
   const apiBase = (document.getElementById('backendUrl') as HTMLInputElement)?.value || 'https://localhost:9443';
-  // headers are persisted in localStorage keys `api_key` and `schemaVersion`
+  // headers are persisted in localStorage keys `api_key` and `schema_version`
   const apiKey = localStorage.getItem('api_key') || '';
-  const schema = localStorage.getItem('schemaVersion') || '';
+  const schema = localStorage.getItem('schema_version') || '';
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (apiKey) headers['x-api-key'] = apiKey;

--- a/word_addin_dev/app/src/panel/postJson.spec.ts
+++ b/word_addin_dev/app/src/panel/postJson.spec.ts
@@ -15,7 +15,7 @@ describe('postJson', () => {
     let captured: any = null
     ;(globalThis as any).document = { getElementById: () => ({ value: 'https://base' }) }
     ;(globalThis as any).localStorage = {
-      getItem: (k: string) => (k === 'api_key' ? 'KEY' : k === 'schemaVersion' ? '1.2' : '')
+      getItem: (k: string) => (k === 'api_key' ? 'KEY' : k === 'schema_version' ? '1.2' : '')
     }
     ;(globalThis as any).fetch = async (url: string, opts: any) => {
       captured = opts

--- a/word_addin_dev/taskpane.bundle.js
+++ b/word_addin_dev/taskpane.bundle.js
@@ -77,7 +77,7 @@
       } catch {
       }
       try {
-        return localStorage.getItem("schemaVersion") || "";
+        return localStorage.getItem("schema_version") || "";
       } catch {
         return "";
       }
@@ -104,7 +104,7 @@
       const store = window.CAI?.Store?.get?.() || {};
       const apiKey = store.apiKey || localStorage.getItem("api_key");
       if (apiKey) headers["x-api-key"] = apiKey;
-      const schema = store.schemaVersion || localStorage.getItem("schemaVersion");
+      const schema = store.schemaVersion || localStorage.getItem("schema_version");
       if (schema) headers["x-schema-version"] = schema;
     } catch {
     }
@@ -147,8 +147,8 @@
       if (localStorage.getItem("api_key") === null) {
         localStorage.setItem("api_key", DEFAULT_API_KEY);
       }
-      if (localStorage.getItem("schemaVersion") === null) {
-        localStorage.setItem("schemaVersion", DEFAULT_SCHEMA);
+      if (localStorage.getItem("schema_version") === null) {
+        localStorage.setItem("schema_version", DEFAULT_SCHEMA);
       }
     } catch {
     }
@@ -169,14 +169,14 @@
   }
   function getSchemaFromStore() {
     try {
-      return localStorage.getItem("schemaVersion") || DEFAULT_SCHEMA;
+      return localStorage.getItem("schema_version") || DEFAULT_SCHEMA;
     } catch {
       return DEFAULT_SCHEMA;
     }
   }
   function setSchemaVersion(v) {
     try {
-      localStorage.setItem("schemaVersion", v);
+      localStorage.setItem("schema_version", v);
     } catch {
     }
   }
@@ -233,23 +233,31 @@
   var lastCid = "";
   function ensureHeaders() {
     try {
+      if (!localStorage.getItem("api_key")) {
+        try {
+          new URL(window.location.href);
+          localStorage.setItem("api_key", "local-test-key-123");
+        } catch {}
+      }
+      if (!localStorage.getItem("schema_version")) {
+        try {
+          localStorage.setItem("schema_version", "1.4");
+        } catch {}
+      }
       const store = globalThis.CAI?.Store?.get?.() || {};
       const apiKey = store.apiKey || getApiKeyFromStore();
       const schema = store.schemaVersion || getSchemaFromStore();
       if (apiKey) {
         try {
           localStorage.setItem("api_key", apiKey);
-        } catch {
-        }
+        } catch {}
       }
       if (schema) {
         try {
-          localStorage.setItem("schemaVersion", schema);
-        } catch {
-        }
+          localStorage.setItem("schema_version", schema);
+        } catch {}
       }
-    } catch {
-    }
+    } catch {}
     return true;
   }
   function slot(id, role) {


### PR DESCRIPTION
## Summary
- add reusable `ensureHeadersSet` helper to seed default API key and schema version
- initialize headers via helper in Draft panel and Word add-in
- standardize localStorage to `schema_version` and update tests and bundles

## Testing
- `pytest tests/security/test_metrics_schema_name.py -q -rA`
- `node tests/panel/test_postjson_headers.js`
- `node tests/panel/test_selftest_call.js`


------
https://chatgpt.com/codex/tasks/task_e_68c15b6eb99083259f0d901a9e10f228