### PR TITLE
Translate governing-law rule messages to English

### DIFF
--- a/contract_review_app/legal_rules/rules/governing_law.py
+++ b/contract_review_app/legal_rules/rules/governing_law.py
@@ -27,11 +27,11 @@ def analyze(inp: AnalysisInput) -> AnalysisOutput:
             sev = "critical"
         msg = "No explicit governing law statement"
         if has_law_words:
-            msg += " (без явного застосовного права)"
+            msg += " (lacking explicit applicable law)"
         elif has_jur_words:
-            msg += " (не вдалося однозначно ідентифікувати)"
+            msg += " (could not be clearly identified)"
         else:
-            msg += " (відсутня або неявна)"
+            msg += " (missing or implicit)"
         findings.append(mk_finding("GLAW_MISSING", msg, sev))
     else:
         if not re.search(LAW_RE, text, flags=re.I):
@@ -43,7 +43,13 @@ def analyze(inp: AnalysisInput) -> AnalysisOutput:
                 )
             )
         else:
-            findings.append(mk_finding("GLAW_REF", "посилання на право визначено", "info"))
+            findings.append(
+                mk_finding(
+                    "GLAW_REF",
+                    "Reference to governing law specified",
+                    "info",
+                )
+            )
         # Jurisdiction clause is optional; no finding if absent
 
     out = make_output(rule_name, inp, findings, "Governing Law", "Governing Law")

--- a/contract_review_app/tests/legal_rules/test_governing_law_unit.py
+++ b/contract_review_app/tests/legal_rules/test_governing_law_unit.py
@@ -17,9 +17,11 @@ def test_ok_england_and_wales_with_conflict_exclusion():
     assert out.status in {
         "OK",
         "WARN",
-    }  # має бути OK; якщо знайдено середні зауваження — WARN
+    }  # should be OK; WARN if medium-severity findings are present
     assert out.status == "OK"
-    assert any("посилання на право" in f.message.lower() for f in out.findings)
+    assert any(
+        "reference to governing law" in f.message.lower() for f in out.findings
+    )
     assert out.diagnostics.get("rule") == gl.RULE_NAME
     assert len(out.diagnostics.get("citations", [])) > 0
 
@@ -32,11 +34,11 @@ def test_warn_jurisdiction_only_no_governing_law():
     out = gl.analyze(_mk_input(txt))
 
     assert out.status == "WARN"
-    # має бути зауваження про відсутність явного права
+    # should warn about missing explicit governing law
     issues = " | ".join(f.message.lower() for f in out.findings)
     assert (
-        "без явного застосовного права" in issues
-        or "не вдалося однозначно ідентифікувати" in issues
+        "lacking explicit applicable law" in issues
+        or "could not be clearly identified" in issues
     )
 
 
@@ -45,6 +47,6 @@ def test_fail_no_clause_at_all():
     out = gl.analyze(_mk_input(txt))
 
     assert out.status == "FAIL"
-    assert any("відсутня або неявна" in f.message.lower() for f in out.findings)
-    # підказки/рекомендації повинні бути
+    assert any("missing or implicit" in f.message.lower() for f in out.findings)
+    # recommendations should be present
     assert len(out.recommendations) >= 1


### PR DESCRIPTION
## Summary
- Convert Ukrainian messages in governing-law rule to English while preserving detection regex
- Update unit tests to expect English governing-law outputs

## Testing
- `PYTHONPATH=$PWD pytest contract_review_app/tests/legal_rules/test_governing_law.py contract_review_app/tests/legal_rules/test_governing_law_unit.py contract_review_app/tests/legal_rules/test_governing_law_property.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1643664dc83258a35ff71e3bfa10c