### PR TITLE
Add tests for invoice VAT rule filter behavior

### DIFF
--- a/tests/rules/pricing_invoicing/test_filter_rules_invoice.py
+++ b/tests/rules/pricing_invoicing/test_filter_rules_invoice.py
@@ -1,0 +1,22 @@
+from contract_review_app.legal_rules import loader
+
+
+def test_invoice_rule_excluded_without_invoice_clause():
+    text = "The parties agree to keep all information confidential and return materials upon request."
+    loader.load_rule_packs()
+    res = loader.filter_rules(text, doc_type="NDA", clause_types=["confidentiality"])
+    ids = {r["rule"]["id"] for r in res}
+    assert "P2.INVOICE_CONTENT_VAT" not in ids
+
+
+def test_invoice_rule_triggers_with_required_clause():
+    text = (
+        "Invoice must include VAT and reference the PO and GRN for payment processing."
+    )
+    loader.load_rule_packs()
+    res = loader.filter_rules(text, doc_type="MSA", clause_types=["invoice"])
+    fired_rules = {r["rule"]["id"]: r["matches"] for r in res}
+    assert "P2.INVOICE_CONTENT_VAT" in fired_rules
+    matches = fired_rules["P2.INVOICE_CONTENT_VAT"]
+    assert any("vat" in m.lower() for m in matches)
+    assert any("po" in m.lower() or "grn" in m.lower() for m in matches)


### PR DESCRIPTION
## Summary
- test filter_rules excludes P2.INVOICE_CONTENT_VAT when no invoice clause present
- test filter_rules triggers P2.INVOICE_CONTENT_VAT and records matched triggers when invoice clause text is provided

## Testing
- `pre-commit run --files tests/rules/pricing_invoicing/test_filter_rules_invoice.py`
- `pytest tests/rules/pricing_invoicing/test_filter_rules_invoice.py`


------
https://chatgpt.com/codex/tasks/task_e_68c189ef60ec8325954e284dcd0e9085