### PR TITLE
Handle invalid gpt-draft payloads

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -203,7 +203,8 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+from fastapi.exceptions import RequestValidationError
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError, field_validator
 from fastapi.openapi.utils import get_openapi
 from .error_handlers import register_error_handlers
 from .headers import apply_std_headers
@@ -2466,7 +2467,10 @@ async def gpt_draft(request: Request):
             headers,
         )
 
-    inp = GptDraftIn.model_validate(raw)
+    try:
+        inp = GptDraftIn.model_validate(raw)
+    except ValidationError as exc:
+        raise RequestValidationError(exc.errors()) from exc
     if not TRACE.get(inp.cid):
         problem = ProblemDetail(title="cid not found", status=404, detail="cid not found")
         return JSONResponse(problem.model_dump(), status_code=404)

--- a/tests/api/test_llm_mock_endpoints.py
+++ b/tests/api/test_llm_mock_endpoints.py
@@ -28,3 +28,10 @@ def test_llm_mock_endpoints():
     assert r1.status_code == 200
     r2 = client.post("/api/suggest_edits", json={"text": "Hi", "findings": []})
     assert r2.status_code == 200
+
+
+def test_llm_mock_invalid_gpt_draft_payload():
+    client = _create_client()
+    resp = client.post("/api/gpt-draft", json={"cid": "only"})
+    assert resp.status_code == 422
+    assert isinstance(resp.json().get("detail"), list)


### PR DESCRIPTION
## Summary
- raise RequestValidationError on invalid gpt-draft payloads to preserve 422 responses
- add regression test for malformed gpt-draft requests

## Testing
- `pytest -q tests/panel/test_core_selftest_e2e.py tests/panel/test_panel_flows.py tests/api/test_analyze_minimal.py tests/api/test_trace_report_flow.py tests/api/test_summary_flow.py tests/api/test_llm_mock_endpoints.py tests/rules/test_yaml_rules_valid.py` *(fails: AssertionError: ['Any'] != ['Any'])*
- `pytest -q tests/api/test_llm_mock_endpoints.py`


------
https://chatgpt.com/codex/tasks/task_e_68c18ee3c2988325890f3a7517373d0a