### PR TITLE
chore: handle optional params in rule filtering

### DIFF
--- a/contract_review_app/legal_rules/loader.py
+++ b/contract_review_app/legal_rules/loader.py
@@ -244,15 +244,16 @@ def loaded_packs() -> List[Dict[str, Any]]:
 
 
 def filter_rules(
-    text: str, doc_type: str, clause_types: Iterable[str]
+    text: str | None, doc_type: str | None, clause_types: Iterable[str] | None
 ) -> List[Dict[str, Any]]:
-    """Return rules matching ``doc_type``/``clause_types`` triggered by ``text``.
+    """Return rules triggered by ``text`` and constrained by scope.
 
-    The returned list contains dictionaries with the original rule under the
-    ``"rule"`` key and a list of matched trigger strings under ``"matches"``.
+    Parameters are case-insensitive and may be ``None``. The returned list
+    contains dictionaries with the original rule under the ``"rule"`` key and
+    a list of matched trigger strings under ``"matches"``.
     """
 
-    norm = normalize_for_intake(text or "")
+    norm = normalize_for_intake(text)
     doc_type_lc = (doc_type or "").lower()
     clause_set: Set[str] = {c.lower() for c in clause_types or []}
 
@@ -295,7 +296,9 @@ def filter_rules(
         if ok:
             regex_pats = trig.get("regex")
             if regex_pats:
-                regex_matches = [m.group(0) for p in regex_pats for m in p.finditer(norm)]
+                regex_matches = [
+                    m.group(0) for p in regex_pats for m in p.finditer(norm)
+                ]
                 if not regex_matches:
                     ok = False
                 else:


### PR DESCRIPTION
## Summary
- allow `filter_rules` to accept optional `text`, `doc_type`, and `clause_types`
- ensure normalization is called directly and document optional scope
- test rule filtering when `doc_type` is `None`

## Testing
- `pre-commit run --files contract_review_app/legal_rules/loader.py tests/rules/test_filter_rules.py`
- `pytest tests/rules/test_filter_rules.py`
- `python tools/doctor.py --out /tmp/doctor --json`


------
https://chatgpt.com/codex/tasks/task_e_68c19072a06c8325aa7caab5fddd5aae