### PR TITLE
fix: preserve newlines in rule filtering

### DIFF
--- a/contract_review_app/legal_rules/loader.py
+++ b/contract_review_app/legal_rules/loader.py
@@ -13,6 +13,13 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from ..corpus.normalizer import normalize_text
 
+
+def _normalize_multiline(text: str) -> str:
+    """Normalize ``text`` while preserving line breaks."""
+
+    return "\n".join(normalize_text(line) for line in (text or "").splitlines())
+
+
 log = logging.getLogger(__name__)
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -252,7 +259,7 @@ def filter_rules(
     ``"rule"`` key and a list of matched trigger strings under ``"matches"``.
     """
 
-    norm = normalize_text(text or "")
+    norm = _normalize_multiline(text)
     doc_type_lc = (doc_type or "").lower()
     clause_set: Set[str] = {c.lower() for c in clause_types or []}
 
@@ -295,7 +302,9 @@ def filter_rules(
         if ok:
             regex_pats = trig.get("regex")
             if regex_pats:
-                regex_matches = [m.group(0) for p in regex_pats for m in p.finditer(norm)]
+                regex_matches = [
+                    m.group(0) for p in regex_pats for m in p.finditer(norm)
+                ]
                 if not regex_matches:
                     ok = False
                 else:


### PR DESCRIPTION
## Summary
- normalize input text line-by-line so rule triggers retain newline boundaries
- test that start-of-line anchored triggers match after normalization

## Testing
- `pre-commit run --files contract_review_app/legal_rules/loader.py tests/rules/test_filter_rules.py`
- `pytest tests/rules/test_filter_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68c19076493c8325a991034fa35f96ee