### PR TITLE
feat: expose rule coverage audit mode

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1836,7 +1836,7 @@ def api_analyze(
         )
 
         _yaml_loader.load_rule_packs()
-        filtered = _yaml_loader.filter_rules(
+        filtered, coverage = _yaml_loader.filter_rules(
             txt or "", doc_type=snap.type, clause_types=clause_types_set
         )
         t3 = time.perf_counter()
@@ -1884,6 +1884,7 @@ def api_analyze(
         active_packs = []
         rules_loaded = 0
         fired_rules_meta = []
+        coverage = []
 
     if yaml_findings:
         filtered_yaml = [
@@ -1964,6 +1965,7 @@ def api_analyze(
         "timings_ms": timings,
     }
 
+
     log.info("analysis meta", extra={"meta": meta})
 
     envelope = {
@@ -1976,6 +1978,8 @@ def api_analyze(
         "meta": meta,
         "summary": summary,
     }
+    if debug == "coverage":
+        envelope["rules_coverage"] = coverage
     IDEMPOTENCY_CACHE.set(cid, envelope)
     rec = {"resp": envelope, "cid": cid}
     an_cache.set(doc_hash, rec)

--- a/tests/api/test_rule_audit_mode.py
+++ b/tests/api/test_rule_audit_mode.py
@@ -1,0 +1,23 @@
+from contract_review_app.legal_rules import loader
+
+
+def test_rule_audit_mode(api):
+    r = api.post("/api/analyze?debug=coverage", json={"text": "Hello"})
+    assert r.status_code == 200
+    data = r.json()
+    coverage = data.get("rules_coverage")
+    assert isinstance(coverage, list)
+    assert len(coverage) == loader.rules_count()
+
+    sample = coverage[0]
+    assert {
+        "doc_type",
+        "pack_id",
+        "rule_id",
+        "severity",
+        "evidence",
+        "spans",
+        "flags",
+    } <= set(sample)
+
+    assert any(c["flags"] & loader.DOC_TYPE_MISMATCH for c in coverage)


### PR DESCRIPTION
## Summary
- track rule gate statuses with bit flags in loader
- surface rule coverage for all rules via `/api/analyze?debug=coverage`
- add tests for rule coverage audit mode

## Testing
- `pytest tests/rules/test_filter_rules.py tests/api/test_rule_audit_mode.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1916e72848325959fdba87113c285