### PR TITLE
Report doc type origin and rule coverage statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ application start. If these checks fail, `/health` reports a non-OK status
 so deployments can detect missing dependencies. PyYAML must be present or
 `/api/analyze` will not load rule packs.
 
+Rules whose configured document types do not match the analyzed document are
+now reported with the status `doc_type_mismatch` in rule coverage data. The
+UI panel surfaces this status so missing coverage is visible during checks.
+
 ## Word Add-in
 
 After running an analysis the task pane displays the current CID. You can open

--- a/contract_review_app/analysis/extract_summary.py
+++ b/contract_review_app/analysis/extract_summary.py
@@ -205,12 +205,13 @@ def extract_document_snapshot(text: str) -> DocumentSnapshot:
     subject = _extract_subject(text)
     subject_raw = subject.get("raw") if subject else None
 
-    slug, confidence, evidence, score_map = guess_doc_type(text, subject_raw)
+    slug, confidence, evidence, score_map, source = guess_doc_type(text, subject_raw)
     doc_type = slug_to_display(slug)
     if confidence < 0.1:
         doc_type = "unknown"
     if doc_type == "License (IP)" and "ip" not in text.lower():
         doc_type = "License"
+    doc_type_source = source if doc_type != "unknown" else None
     hints.extend(evidence[:5])
     parties = _extract_parties(text, hints)
     dates = _extract_dates(text, hints)
@@ -233,6 +234,7 @@ def extract_document_snapshot(text: str) -> DocumentSnapshot:
     snapshot = DocumentSnapshot(
         type=doc_type,
         type_confidence=confidence,
+        type_source=doc_type_source,
         parties=parties,
         dates=dates,
         term=term,

--- a/contract_review_app/analysis/summary_schemas.py
+++ b/contract_review_app/analysis/summary_schemas.py
@@ -39,6 +39,7 @@ class ConditionsVsWarranties(AppBaseModel):
 class DocumentSnapshot(AppBaseModel):
     type: str = "unknown"
     type_confidence: float = 0.0
+    type_source: Optional[str] = None
     parties: List[Party] = Field(default_factory=list)
     dates: Dict[str, Optional[str]] = Field(default_factory=dict)
     term: TermInfo = Field(default_factory=TermInfo)

--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -620,6 +620,9 @@ def _ensure_legacy_doc_type(summary: dict) -> None:
         "confidence": score,
         "candidates": [{"type": t, "score": score}] if t else [],
     }
+    src = summary.get("type_source")
+    if src:
+        summary["doc_type"]["source"] = src
 
 
 # --------------------------------------------------------------------
@@ -1827,6 +1830,7 @@ def api_analyze(
     active_packs: List[str] = []
     rules_loaded = 0
     fired_rules_meta: List[Dict[str, Any]] = []
+    coverage_rules: List[Dict[str, Any]] = []
     t3 = t2
     t4 = t2
     try:
@@ -1837,15 +1841,24 @@ def api_analyze(
 
         _yaml_loader.load_rule_packs()
         filtered = _yaml_loader.filter_rules(
-            txt or "", doc_type=snap.type, clause_types=clause_types_set
+            txt or "",
+            doc_type=snap.type,
+            clause_types=clause_types_set,
+            jurisdiction=snap.jurisdiction,
         )
         t3 = time.perf_counter()
         yaml_findings = _yaml_engine.analyze(
-            txt or "", [r["rule"] for r in filtered]
+            txt or "", [r["rule"] for r in filtered if not r.get("status")]
         )
         t4 = time.perf_counter()
         active_packs = [p.get("path") for p in _yaml_loader.loaded_packs()]
         rules_loaded = _yaml_loader.rules_count()
+
+        coverage_rules = []
+        for item in filtered:
+            rid = item["rule"].get("id")
+            st = item.get("status", "matched")
+            coverage_rules.append({"rule_id": rid, "status": st})
 
         for item in filtered:
             rule = item["rule"]
@@ -1884,6 +1897,7 @@ def api_analyze(
         active_packs = []
         rules_loaded = 0
         fired_rules_meta = []
+        coverage_rules = []
 
     if yaml_findings:
         filtered_yaml = [
@@ -1975,6 +1989,10 @@ def api_analyze(
         "schema_version": SCHEMA_VERSION,
         "meta": meta,
         "summary": summary,
+    }
+    envelope["rules_coverage"] = {
+        "doc_type": {"value": snap.type, "source": snap.type_source},
+        "rules": coverage_rules,
     }
     IDEMPOTENCY_CACHE.set(cid, envelope)
     rec = {"resp": envelope, "cid": cid}

--- a/contract_review_app/contract_review_app/static/panel/taskpane.html
+++ b/contract_review_app/contract_review_app/static/panel/taskpane.html
@@ -149,6 +149,7 @@
   </div>
 
   <div class="row muted">Endpoints: <code>/health</code> · <code>/api/analyze</code> · <code>/api/gpt-draft</code> · <code>/api/qa-recheck</code></div>
+  <div class="row muted">Rules without matching document type are marked as <code>doc_type_mismatch</code>.</div>
   <div class="row card">
     <div class="row"><input id="backendUrl" placeholder="https://localhost:9443" /></div>
     <div class="row flex">

--- a/contract_review_app/engine/pipeline.py
+++ b/contract_review_app/engine/pipeline.py
@@ -371,7 +371,7 @@ def analyze_document(
     """
     t = text or ""
     text_for_match, _pd = normalized_view(t)
-    type_slug, type_conf, _, score_map = guess_doc_type(t)
+    type_slug, type_conf, _, score_map, _src = guess_doc_type(t)
     dtype = slug_to_display(type_slug)
     debug_top = [
         {"type": slug_to_display(s), "score": round(v, 3)}

--- a/contract_review_app/engine/pipeline_compat.py
+++ b/contract_review_app/engine/pipeline_compat.py
@@ -228,7 +228,7 @@ def to_panel_shape(ssot: dict | Any) -> Tuple[dict, dict, list[dict]]:
 
     doc_summary = _get(doc, "summary", {}) or {}
     if "type" not in doc_summary:
-        slug, conf, _, score_map = guess_doc_type(str(_get(doc, "text", "")))
+        slug, conf, _, score_map, _src = guess_doc_type(str(_get(doc, "text", "")))
         dtype = slug_to_display(slug)
         debug_top = [
             {"type": slug_to_display(s), "score": round(v, 3)}

--- a/contract_review_app/tests/test_document_type_classifier.py
+++ b/contract_review_app/tests/test_document_type_classifier.py
@@ -23,3 +23,10 @@ def test_document_type_classifier(expected: str, text: str):
     snap = extract_document_snapshot(text)
     assert snap.type == expected
     assert snap.type_confidence >= 0.6
+
+
+def test_document_type_abbrev_fallback():
+    text = "NDA\nText without keywords"
+    snap = extract_document_snapshot(text)
+    assert snap.type == "NDA"
+    assert snap.type_source == "title"

--- a/tests/rules/test_filter_rules.py
+++ b/tests/rules/test_filter_rules.py
@@ -42,11 +42,10 @@ def test_filter_rules(monkeypatch):
         "Payment is due. A NonCompete clause applies."
     )
     res = loader.filter_rules(text, doc_type="MSA", clause_types=["Termination", "Payment"])
+    statuses = {r["rule"]["id"]: r.get("status") for r in res}
+    assert statuses["R1"] == "doc_type_mismatch"
 
-    ids = {r["rule"]["id"] for r in res}
-    assert ids == {"R2", "R3", "R4"}
-
-    matches = {r["rule"]["id"]: r["matches"] for r in res}
+    matches = {r["rule"]["id"]: r.get("matches", []) for r in res if r.get("matches")}
     assert any(m.lower().startswith("term") for m in matches["R2"])
     assert any("noncompete" in m.lower() for m in matches["R3"])
     assert any("pay" in m.lower() for m in matches["R4"])

--- a/tests/test_doc_type_backcompat.py
+++ b/tests/test_doc_type_backcompat.py
@@ -4,8 +4,9 @@ from fastapi.testclient import TestClient
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
 
-client = TestClient(app)
+client = TestClient(app, headers={"x-schema-version": SCHEMA_VERSION})
 SAMPLE = "CONFIDENTIALITY AGREEMENT\nThis Agreement is made..."
 
 def test_analyze_has_both_flat_and_legacy_type():

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -149,6 +149,7 @@
   </div>
 
   <div class="row muted">Endpoints: <code>/health</code> · <code>/api/analyze</code> · <code>/api/gpt-draft</code> · <code>/api/qa-recheck</code></div>
+  <div class="row muted">Rules without matching document type are marked as <code>doc_type_mismatch</code>.</div>
   <div class="row card">
     <div class="row"><input id="backendUrl" placeholder="https://localhost:9443" /></div>
     <div class="row flex">


### PR DESCRIPTION
## Summary
- track rule filtering reasons like document type or jurisdiction mismatch
- expose document type with its source and include rule coverage in API responses
- add abbreviation-based document type fallback classifier with tests

## Testing
- `pytest tests/rules/test_filter_rules.py contract_review_app/tests/test_document_type_classifier.py tests/test_doc_type_uk_samples.py contract_review_app/tests/api/test_api_analyze_type.py tests/test_doc_type_api.py tests/test_doc_type_backcompat.py --disable-warnings`
- `node tests/panel/test_selftest_call.js`

------
https://chatgpt.com/codex/tasks/task_e_68c1919ada088325bb89dfee88b887ed