### PR TITLE
Add mixed contract fixture with coverage test

### DIFF
--- a/fixtures/contracts/mixed_sample.txt
+++ b/fixtures/contracts/mixed_sample.txt
@@ -1,0 +1,15 @@
+CONFIDENTIALITY: The parties agree to keep information strictly confidential and use it only for performing this agreement.
+
+LIABILITY: The total liability shall not exceed the fees paid, except in cases of fraud or wilful misconduct.
+
+ANTI-BRIBERY: Each party shall comply with the UK Bribery Act 2010, maintain adequate procedures, and prohibit facilitation payments.
+
+DATA PROTECTION: Each party shall comply with the UK GDPR and Data Protection Act 2018 when processing personal data.
+
+TERMINATION: Either party may terminate this Agreement upon 30 days' written notice.
+
+INTELLECTUAL PROPERTY: All intellectual property created by Supplier in performing the Services shall vest in Customer.
+
+GOVERNING LAW AND DISPUTE RESOLUTION: This Agreement is governed by the laws of England and Wales and any dispute shall be resolved by arbitration in London.
+
+PAYMENT: Supplier shall issue invoices monthly in pounds sterling, payable within 30 days, plus any applicable VAT.

--- a/tests/panel/test_rules_mixed_e2e.py
+++ b/tests/panel/test_rules_mixed_e2e.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
+from contract_review_app.engine.report_html import render_html_report
+
+
+def test_rules_mixed_e2e(tmp_path, monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key-123456789012345678901234")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+
+    client = TestClient(app, headers={"x-schema-version": SCHEMA_VERSION})
+
+    text = Path("fixtures/contracts/mixed_sample.txt").read_text(encoding="utf-8")
+    resp = client.post("/api/analyze?debug=coverage", json={"text": text})
+    assert resp.status_code == 200
+
+    data = resp.json()
+    fired = sorted({r["rule_id"] for r in data["meta"]["fired_rules"]})
+    assert len(fired) >= 8
+
+    snap_path = Path(__file__).with_name("test_rules_mixed_e2e_snapshot.json")
+    expected = json.loads(snap_path.read_text(encoding="utf-8"))
+    assert fired == expected
+
+    trace = data
+    trace["cid"] = resp.headers.get("x-cid", "")
+    report_html = render_html_report(trace)
+    (tmp_path / "mixed_sample_report.html").write_text(report_html, encoding="utf-8")

--- a/tests/panel/test_rules_mixed_e2e_snapshot.json
+++ b/tests/panel/test_rules_mixed_e2e_snapshot.json
@@ -1,0 +1,17 @@
+[
+  "P2.INVOICE_CONTENT_VAT",
+  "P9.EINVOICE_PLATFORM_VAT_CONTROL",
+  "confidentiality",
+  "confidentiality_basic",
+  "gl_england_wales",
+  "governing_law",
+  "governing_law_basic",
+  "ip_rights",
+  "ipr.further_assurances.poa",
+  "ipr.indemnity.remedies",
+  "liability_cap_basic",
+  "pricing_payment",
+  "termination_notice_basic",
+  "title.commingling.bulk_processing",
+  "title.waivers.third_party_liens"
+]


### PR DESCRIPTION
## Summary
- add mixed-sample contract covering confidentiality, liability, anti-bribery, GDPR, termination, IP, governing law and payment topics
- add end-to-end test checking at least eight rules fire and producing an HTML report

## Testing
- `pre-commit run --files fixtures/contracts/mixed_sample.txt tests/panel/test_rules_mixed_e2e.py tests/panel/test_rules_mixed_e2e_snapshot.json`
- `pytest tests/panel/test_rules_mixed_e2e.py`


------
https://chatgpt.com/codex/tasks/task_e_68c191b72fe083258809559267d1f525