### PR TITLE
feat: expose rule coverage audit mode

### DIFF
--- a/contract_review_app/legal_rules/loader.py
+++ b/contract_review_app/legal_rules/loader.py
@@ -290,6 +290,20 @@ def filter_rules(
         if req_clauses and clause_set.isdisjoint(req_clauses):
             rule_flags |= NO_CLAUSE
 
+        if rule_flags & (DOC_TYPE_MISMATCH | NO_CLAUSE):
+            coverage.append(
+                {
+                    "doc_type": doc_type_lc,
+                    "pack_id": rule.get("pack"),
+                    "rule_id": rule.get("id"),
+                    "severity": rule.get("severity"),
+                    "evidence": matches,
+                    "spans": spans,
+                    "flags": rule_flags,
+                }
+            )
+            continue
+
         trig = rule.get("triggers") or {}
         ok = True
 


### PR DESCRIPTION
## Summary
- track rule gate statuses with bit flags in loader
- surface rule coverage for all rules via `/api/analyze?debug=coverage`
- add tests for rule coverage audit mode
- skip trigger evaluation after doc type or clause gate failures

## Testing
- `LLM_PROVIDER=mock pytest tests/rules/test_filter_rules.py tests/api/test_rule_audit_mode.py`
- `LLM_PROVIDER=mock python tools/doctor.py --out /tmp/doctor_out.json --json` *(fails: AZURE_OPENAI_API_KEY is missing or looks like a placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68c19597ce04832594b0e8eb6e2bc98f