### PR TITLE
Deduplicate findings and avoid overlapping ranges in engine.analyze

### DIFF
--- a/contract_review_app/legal_rules/engine.py
+++ b/contract_review_app/legal_rules/engine.py
@@ -5,6 +5,25 @@ from dataclasses import dataclass
 import re
 from typing import List, Dict, Any
 
+# deterministic ordering for severities
+_SEV_ORD = {
+    "critical": 3,
+    "major": 2,
+    "high": 2,
+    "medium": 1,
+    "minor": 1,
+    "low": 0,
+    "info": 0,
+}
+
+
+def _sev_ord(v: Any) -> int:
+    return _SEV_ORD.get(str(v or "").lower(), 0)
+
+
+def _norm_snippet(s: str) -> str:
+    return re.sub(r"\s+", " ", (s or "").strip()).lower()
+
 
 # ---------------------------------------------------------------------------
 # Block splitting
@@ -89,5 +108,61 @@ def analyze(text: str, rules: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                         "occurrences": hits,
                     }
                 )
-    return findings
+    # Stable sort: start, end, severity desc, rule_id
+    findings.sort(
+        key=lambda f: (
+            int(f.get("start", 0)),
+            int(f.get("end", 0)),
+            -_sev_ord(f.get("severity")),
+            str(f.get("rule_id") or ""),
+        )
+    )
+
+    # Deduplicate by (rule_id, norm(snippet), start, end)
+    deduped: List[Dict[str, Any]] = []
+    seen = set()
+    for f in findings:
+        k = (
+            f.get("rule_id"),
+            _norm_snippet(f.get("snippet", "")),
+            int(f.get("start", 0)),
+            int(f.get("end", 0)),
+        )
+        if k in seen:
+            continue
+        seen.add(k)
+        deduped.append(f)
+
+    # Remove overlapping ranges with worse priority
+    result: List[Dict[str, Any]] = []
+    for f in deduped:
+        keep = True
+        while result and int(f["start"]) < int(result[-1]["end"]):
+            prev = result[-1]
+            s_curr = _sev_ord(f.get("severity"))
+            s_prev = _sev_ord(prev.get("severity"))
+            if s_curr > s_prev:
+                result.pop()
+                continue
+            if s_curr < s_prev:
+                keep = False
+                break
+            span_curr = int(f["end"]) - int(f["start"])
+            span_prev = int(prev["end"]) - int(prev["start"])
+            if span_curr < span_prev:
+                result.pop()
+                continue
+            if span_curr > span_prev:
+                keep = False
+                break
+            # same severity and span
+            if (f.get("rule_id") or "") == (prev.get("rule_id") or ""):
+                keep = False
+                break
+            # different rule_id -> keep existing prev
+            keep = False
+            break
+        if keep:
+            result.append(f)
+    return result
 

--- a/tests/api/test_analyze_minimal.py
+++ b/tests/api/test_analyze_minimal.py
@@ -19,6 +19,7 @@ def test_analyze_minimal():
     assert resp.headers.get("x-cid")
     data = resp.json()
     assert isinstance(data.get("analysis"), dict) and data["analysis"]
+    assert isinstance(data["analysis"].get("findings"), list)
 
 
 @settings(deadline=None, max_examples=25)

--- a/tests/api/test_dedup.py
+++ b/tests/api/test_dedup.py
@@ -1,0 +1,11 @@
+import re
+from contract_review_app.legal_rules import engine
+
+
+def test_engine_dedup_removes_duplicates():
+    rule = {"id": "R1", "patterns": [re.compile("foo")], "severity": "major"}
+    findings = engine.analyze("foo", [rule, rule])
+    assert len(findings) == 1
+    f = findings[0]
+    assert f["rule_id"] == "R1"
+    assert f["start"] == 0 and f["end"] > 0


### PR DESCRIPTION
## Summary
- add severity ordering and normalized snippet helpers
- stable-sort findings, deduplicate identical entries, and drop overlaps
- extend API tests and cover finding deduplication

## Testing
- `pytest -q tests/api/test_analyze_minimal.py::test_analyze_minimal`
- `pytest -q tests/api/test_dedup.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1bd822ef88325a31c4545a12673c9