### PR TITLE
fix: start API in CI without batch file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,30 @@ jobs:
       - name: Run tests
         run: pytest -q
   smoke-start:
-    if: ${{ false }}
     runs-on: windows-latest
     steps:
-      - run: echo "skip"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements-dev.txt
+      - name: Start API (uvicorn)
+        shell: bash
+        env:
+          FEATURE_COMPANIES_HOUSE: "0"
+          LLM_MODE: "mock"
+          X_SCHEMA_VERSION: "1.4"
+        run: |
+          nohup python -m uvicorn contract_review_app.api.app:app \
+            --host 127.0.0.1 --port 9443 --ssl-keyfile tests/certs/key.pem --ssl-certfile tests/certs/cert.pem > server.log 2>&1 &
+          for i in {1..30}; do
+            code=$(curl -sk -o /dev/null -w "%{http_code}" https://127.0.0.1:9443/health || true)
+            [ "$code" = "200" ] && break
+            sleep 1
+          done
+          curl -sk https://127.0.0.1:9443/health | sed -e 's/.*provider.*/[health scrubbed]/'
+      - name: Run smoke tests
+        run: pytest tests/test_routes_smoke.py::test_health_ok -q


### PR DESCRIPTION
## Summary
- start backend directly with uvicorn in smoke-start workflow
- wait for /health before running smoke tests

## Testing
- `pytest tests/test_routes_smoke.py::test_health_ok -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1c0943c088325818ad1e7e7f1b7cd