### PR TITLE
Handle overlapping Word annotations and retry insert

### DIFF
--- a/panel/__tests__/annotate.spec.ts
+++ b/panel/__tests__/annotate.spec.ts
@@ -1,0 +1,36 @@
+import { annotateFindingsIntoWord } from '../../word_addin_dev/app/assets/taskpane';
+
+describe('annotateFindingsIntoWord', () => {
+  it('skips overlapping ranges and warns', async () => {
+    const inserted: string[] = [];
+    (global as any).__lastAnalyzed = 'abcdefghij';
+
+    (global as any).Word = {
+      run: async (fn: any) => {
+        const ctx = {
+          document: {
+            body: {
+              search: () => ({
+                items: [{ insertComment: (msg: string) => { inserted.push(msg); } }],
+                load: () => {}
+              })
+            }
+          },
+          sync: async () => {}
+        } as any;
+        return fn(ctx);
+      }
+    };
+
+    const warns: string[] = [];
+    (global as any).notifyWarn = (msg: string) => { warns.push(msg); };
+
+    await annotateFindingsIntoWord([
+      { start: 0, end: 5, snippet: 'abcde', rule_id: 'r1', severity: 'high' },
+      { start: 3, end: 8, snippet: 'defgh', rule_id: 'r2', severity: 'medium' }
+    ] as any);
+
+    expect(inserted.length).toBe(1);
+    expect(warns[0]).toMatch(/Skipped 1 overlaps/);
+  });
+});


### PR DESCRIPTION
## Summary
- sort Word annotation ranges by end and skip overlaps
- retry comment insertion once on 0xA7210002 and warn about skipped overlaps
- add Jest test covering overlap skipping logic

## Testing
- `npm test --workspace panel` *(fails: No workspaces found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c42154748325a06ec1c4d9b7d173