### PR TITLE
Auto-sync schema version from /health

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/selftest.js
+++ b/contract_review_app/contract_review_app/static/panel/app/selftest.js
@@ -522,18 +522,22 @@ window.addEventListener("DOMContentLoaded", async () => {
     const serverSchema =
       (resp.headers && resp.headers.get && resp.headers.get('x-schema-version')) ||
       (resp.json && resp.json.schema) || '';
-    if (serverSchema && storedSchema !== serverSchema) {
-      const el = document.getElementById('schemaInput');
-      if (el) el.value = serverSchema;
-      try {
-        localStorage.setItem(SCHEMA_STORAGE, serverSchema);
-        CAI.Store?.setSchemaVersion?.(serverSchema);
-      } catch {}
-      const warnEl = document.getElementById('schemaWarn');
-      if (warnEl && storedSchema) {
-        warnEl.textContent = `Schema mismatch: ${storedSchema} → ${serverSchema}`;
-        warnEl.style.display = 'inline';
+    if (serverSchema) {
+      if (storedSchema !== serverSchema) {
+        const el = document.getElementById('schemaInput');
+        if (el) el.value = serverSchema;
+        try {
+          localStorage.setItem(SCHEMA_STORAGE, serverSchema);
+          CAI.Store?.setSchemaVersion?.(serverSchema);
+        } catch {}
+        const warnEl = document.getElementById('schemaWarn');
+        if (warnEl) {
+          warnEl.textContent = `schema: ${serverSchema} (synced)`;
+          warnEl.className = 'small ok';
+          warnEl.style.display = 'inline';
+        }
       }
+      console.log(`schema: ${serverSchema} (synced)`);
     }
   } catch {
     const latEl = document.getElementById('llmLatency');

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1,6 +1,6 @@
 import { applyMetaToBadges, parseFindings, AnalyzeFinding } from "./api-client";
 import { getApiKeyFromStore, getSchemaFromStore } from "./store";
-import { postJSON, getHealth, getStoredKey, getStoredSchema, setStoredSchema, ensureHeadersSet } from "../../../contract_review_app/frontend/common/http";
+import { postJSON, getStoredKey, getStoredSchema, setStoredSchema, ensureHeadersSet } from "../../../contract_review_app/frontend/common/http";
 const g: any = globalThis as any;
 g.parseFindings = g.parseFindings || parseFindings;
 g.applyMetaToBadges = g.applyMetaToBadges || applyMetaToBadges;
@@ -437,14 +437,23 @@ async function onGetAIDraft(ev?: Event) {
 
 async function doHealth() {
   try {
-    const json: any = await getHealth(getBackend());
+    const prev = getStoredSchema();
+    const resp = await fetch(`${getBackend()}/health`, { method: 'GET' });
+    const json: any = await resp.json().catch(() => ({}));
+    const schema = resp.headers.get('x-schema-version') || json?.schema || null;
+    if (schema) {
+      setStoredSchema(schema);
+      if (schema !== prev) {
+        console.log(`schema: ${schema} (synced)`);
+      }
+    }
     setConnBadge(true);
     try {
       applyMetaToBadges({
         cid: null,
         xcache: null,
         latencyMs: null,
-        schema: json?.schema || null,
+        schema: schema || null,
         provider: json?.provider || null,
         model: json?.model || null,
         llm_mode: null,
@@ -452,7 +461,7 @@ async function doHealth() {
         status: json?.status || null,
       });
     } catch {}
-    notifyOk(`Health: ${json?.status || 'ok'}${json?.schema ? ` (schema ${json.schema})` : ''}`);
+    notifyOk(`Health: ${json?.status || 'ok'}${schema ? ` (schema ${schema})` : ''}`);
   } catch (e) {
     setConnBadge(false);
     notifyWarn('Health failed');

--- a/word_addin_dev/app/selftest.js
+++ b/word_addin_dev/app/selftest.js
@@ -522,18 +522,22 @@ window.addEventListener("DOMContentLoaded", async () => {
     const serverSchema =
       (resp.headers && resp.headers.get && resp.headers.get('x-schema-version')) ||
       (resp.json && resp.json.schema) || '';
-    if (serverSchema && storedSchema !== serverSchema) {
-      const el = document.getElementById('schemaInput');
-      if (el) el.value = serverSchema;
-      try {
-        localStorage.setItem(SCHEMA_STORAGE, serverSchema);
-        CAI.Store?.setSchemaVersion?.(serverSchema);
-      } catch {}
-      const warnEl = document.getElementById('schemaWarn');
-      if (warnEl && storedSchema) {
-        warnEl.textContent = `Schema mismatch: ${storedSchema} → ${serverSchema}`;
-        warnEl.style.display = 'inline';
+    if (serverSchema) {
+      if (storedSchema !== serverSchema) {
+        const el = document.getElementById('schemaInput');
+        if (el) el.value = serverSchema;
+        try {
+          localStorage.setItem(SCHEMA_STORAGE, serverSchema);
+          CAI.Store?.setSchemaVersion?.(serverSchema);
+        } catch {}
+        const warnEl = document.getElementById('schemaWarn');
+        if (warnEl) {
+          warnEl.textContent = `schema: ${serverSchema} (synced)`;
+          warnEl.className = 'small ok';
+          warnEl.style.display = 'inline';
+        }
       }
+      console.log(`schema: ${serverSchema} (synced)`);
     }
   } catch {
     const latEl = document.getElementById('llmLatency');


### PR DESCRIPTION
## Summary
- sync schema version from `/health` when self-test page loads and log when updated
- fetch `/health` on Word taskpane init, update schema storage and log new version

## Testing
- `python -m tools.build_panel`
- `npx esbuild word_addin_dev/app/assets/taskpane.ts --bundle --outfile=word_addin_dev/taskpane.bundle.js --format=iife --platform=browser`
- `pytest tests/panel -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c6a9d5548325b03d0455f7d3ac48