### PR TITLE
E2E smoke: health → analyze(CID) → report/summary → gpt-draft; duplicates=0

### DIFF
--- a/tests/api/test_e2e_smoke.py
+++ b/tests/api/test_e2e_smoke.py
@@ -1,0 +1,38 @@
+import pytest
+from contract_review_app.api.models import SCHEMA_VERSION
+
+
+def test_e2e_smoke(api):
+    # Health check
+    r = api.get('/health')
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get('schema') == SCHEMA_VERSION
+    assert r.headers.get('x-schema-version') == SCHEMA_VERSION
+
+    # Analyze document
+    r = api.post('/api/analyze', json={'text': 'Hello world', 'language': 'en-GB'})
+    assert r.status_code == 200
+    cid = r.headers.get('x-cid')
+    assert cid
+    analysis = r.json()['analysis']
+    findings = analysis.get('findings', [])
+    keys = {(f.get('rule_id'), f.get('start'), f.get('end')) for f in findings}
+    assert len(keys) == len(findings)
+    assert analysis.get('duplicates_removed', 0) >= 0
+
+    # Trace and report
+    r_trace = api.get(f'/api/trace/{cid}')
+    assert r_trace.status_code == 200
+    r_report = api.get(f'/api/report/{cid}.html')
+    assert r_report.status_code in {200, 404}
+
+    # Summary
+    r_summary = api.post('/api/summary', json={'cid': cid})
+    assert r_summary.status_code == 200
+
+    # GPT draft
+    payload = {'cid': cid, 'clause': 'Ping', 'mode': 'friendly'}
+    r_draft = api.post('/api/gpt-draft', json=payload)
+    assert r_draft.status_code == 200
+    assert r_draft.json().get('proposed_text', '').strip()


### PR DESCRIPTION
## Summary
- extend panel flow test with deduplication assertions
- add API smoke test covering health → analyze → trace/report → summary → gpt-draft

## Testing
- `pytest -q tests/panel/test_panel_flows.py`
- `pytest -q tests/api/test_e2e_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1c8ec56a48325a4f0126a8e960110