### PR TITLE
feat: add finding dedupe and safe annotation

### DIFF
--- a/contract_review_app/legal_rules/loader.py
+++ b/contract_review_app/legal_rules/loader.py
@@ -255,6 +255,18 @@ def load_rule_packs() -> None:
             except ValueError:  # pragma: no cover
                 rel = path
             _PACKS.append({"path": str(rel), "rule_count": rule_count})
+    # Remove deprecated and duplicate rules by id
+    uniq: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+    for r in _RULES:
+        rid = r.get("id")
+        if r.get("deprecated"):
+            continue
+        if rid in seen:
+            continue
+        seen.add(rid)
+        uniq.append(r)
+    _RULES[:] = uniq
 
 
 # load on import

--- a/contract_review_app/legal_rules/policy_packs/core_en_v1.yaml
+++ b/contract_review_app/legal_rules/policy_packs/core_en_v1.yaml
@@ -14,6 +14,7 @@ rules:
   - id: confidentiality_basic
     clause_type: confidentiality
     severity: medium
+    deprecated: true
     patterns:
       - "(?i)confidential information"
       - "(?i)keep.*confidential"

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "vite": "^7.1.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2"
   }
 }

--- a/panel/__tests__/annotate.spec.js
+++ b/panel/__tests__/annotate.spec.js
@@ -1,34 +1,35 @@
-import { annotateFindingsIntoWord } from '../../word_addin_dev/app/assets/taskpane';
+require('ts-node/register');
+const { annotateFindingsIntoWord } = require('../../word_addin_dev/app/assets/taskpane');
 
 describe('annotateFindingsIntoWord', () => {
   it('skips overlapping ranges and warns', async () => {
-    const inserted: string[] = [];
-    (global as any).__lastAnalyzed = 'abcdefghij';
+    const inserted = [];
+    global.__lastAnalyzed = 'abcdefghij';
 
-    (global as any).Word = {
-      run: async (fn: any) => {
+    global.Word = {
+      run: async fn => {
         const ctx = {
           document: {
             body: {
               search: () => ({
-                items: [{ insertComment: (msg: string) => { inserted.push(msg); } }],
+                items: [{ insertComment: msg => { inserted.push(msg); } }],
                 load: () => {}
               })
             }
           },
           sync: async () => {}
-        } as any;
+        };
         return fn(ctx);
       }
     };
 
-    const warns: string[] = [];
-    (global as any).notifyWarn = (msg: string) => { warns.push(msg); };
+    const warns = [];
+    global.notifyWarn = msg => { warns.push(msg); };
 
     await annotateFindingsIntoWord([
       { start: 0, end: 5, snippet: 'abcde', rule_id: 'r1', severity: 'high' },
       { start: 3, end: 8, snippet: 'defgh', rule_id: 'r2', severity: 'medium' }
-    ] as any);
+    ]);
 
     expect(inserted.length).toBe(1);
     expect(warns[0]).toMatch(/Skipped 1 overlaps/);

--- a/panel/__tests__/dedupe.spec.js
+++ b/panel/__tests__/dedupe.spec.js
@@ -1,0 +1,16 @@
+require('ts-node/register');
+const { dedupeFindings } = require('../../word_addin_dev/app/assets/taskpane');
+
+describe('dedupeFindings', () => {
+  it('removes duplicates and invalid ranges', () => {
+    const input = [
+      { rule_id: 'r', start: 0, end: 5, snippet: 'abcde', severity: 'low' },
+      { rule_id: 'r', start: 0, end: 5, snippet: 'abcde', severity: 'high' },
+      { rule_id: 'r2', start: 10, end: 9, snippet: 'bad' },
+      { rule_id: 'r3', start: 0, end: 20000, snippet: 'xxxxx' }
+    ];
+    const out = dedupeFindings(input);
+    expect(out.length).toBe(1);
+    expect(out[0].severity).toBe('high');
+  });
+});

--- a/panel/__tests__/flags.spec.js
+++ b/panel/__tests__/flags.spec.js
@@ -1,0 +1,23 @@
+require('ts-node/register');
+const { isAddCommentsOnAnalyzeEnabled, setAddCommentsOnAnalyze } = require('../../word_addin_dev/app/assets/taskpane');
+
+describe('Add comments flag', () => {
+  beforeEach(() => {
+    const g = global;
+    g.localStorage = {
+      store: {},
+      getItem(k) { return this.store[k] ?? null; },
+      setItem(k, v) { this.store[k] = v; },
+      removeItem(k) { delete this.store[k]; }
+    };
+  });
+
+  it('defaults to true when missing', () => {
+    expect(isAddCommentsOnAnalyzeEnabled()).toBe(true);
+  });
+
+  it('persists value', () => {
+    setAddCommentsOnAnalyze(false);
+    expect(isAddCommentsOnAnalyzeEnabled()).toBe(false);
+  });
+});

--- a/tests/api/test_analyze_minimal.py
+++ b/tests/api/test_analyze_minimal.py
@@ -11,7 +11,7 @@ client = TestClient(app)
 def test_analyze_minimal():
     resp = client.post(
         "/api/analyze",
-        json={"text": "Hello"},
+        json={"text": "Each party shall keep the other's information confidential."},
         headers={"x-api-key": "local-test-key-123", "x-schema-version": SCHEMA_VERSION},
     )
     assert resp.status_code == 200
@@ -19,7 +19,10 @@ def test_analyze_minimal():
     assert resp.headers.get("x-cid")
     data = resp.json()
     assert isinstance(data.get("analysis"), dict) and data["analysis"]
-    assert isinstance(data["analysis"].get("findings"), list)
+    findings = data["analysis"].get("findings") or []
+    assert isinstance(findings, list)
+    spans = {(f.get("start"), f.get("end"), f.get("snippet")) for f in findings}
+    assert len(spans) == len(findings)
 
 
 @settings(deadline=None, max_examples=25)

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -245,6 +245,12 @@
         <span>Add comments on Analyze</span>
       </label>
     </div>
+    <div class="row">
+      <label class="toggle">
+        <input id="cai-dry-run-annotate" type="checkbox">
+        <span>Dry-run annotate (no comments)</span>
+      </label>
+    </div>
     <div id="qaResiduals" class="row" style="display:none">
       <strong>Residual risks</strong>
       <ul class="list" id="qaResidualList"></ul>


### PR DESCRIPTION
## Summary
- add dedupeFindings and log diagnostics before annotating
- handle Office 0xA7210002 with anchor/selection fallbacks
- default "Add comments on Analyze" on and add dry-run toggle
- skip deprecated confidentiality_basic rule and dedupe rule IDs
- add tests for dedupe and comment flag

## Testing
- `pytest tests/api/test_analyze_minimal.py`
- `npx -y jest panel/__tests__/annotate.spec.js panel/__tests__/dedupe.spec.js panel/__tests__/flags.spec.js` *(fails: Jest encountered an unexpected token in taskpane.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cde19c008325a6d93432df2b5444