### PR TITLE
feat: deduplicate rules with priority and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
               print("ERROR: Python-based rules are not allowed:\n" + "\n".join(bad))
               sys.exit(1)
           PY
+      - name: Validate rule ids (no conflicting duplicates)
+        run: |
+          python tools/validate_rules.py
       - name: Run tests
         run: pytest -q
   smoke-start:

--- a/contract_review_app/tests/engine/test_rules_dedup.py
+++ b/contract_review_app/tests/engine/test_rules_dedup.py
@@ -1,0 +1,43 @@
+import pathlib
+
+import pytest
+
+from contract_review_app.legal_rules import loader
+from tools import validate_rules
+
+YAML_A = "rule_id: duplicate_x\nTitle: From policy_packs\n"
+YAML_B = "rule_id: duplicate_x\nTitle: From core\n"
+
+
+def write(p: pathlib.Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_loader_picks_higher_priority(tmp_path, monkeypatch):
+    root_pp = tmp_path / "contract_review_app/legal_rules/policy_packs"
+    root_core = tmp_path / "core/rules"
+
+    write(root_pp / "pack/a.yaml", YAML_A)
+    write(root_core / "some/b.yaml", YAML_B)
+
+    monkeypatch.setattr(loader, "RULE_ROOTS", [str(root_pp), str(root_core)])
+
+    rules = loader.load_rules()
+    ids = {r["rule_id"] for r in rules}
+    assert "duplicate_x" in ids
+    chosen = next(r for r in rules if r["rule_id"] == "duplicate_x")
+    assert chosen.get("Title") == "From policy_packs"
+
+
+def test_validate_rules_detects_conflicts(tmp_path, capsys):
+    root_pp = tmp_path / "contract_review_app/legal_rules/policy_packs"
+    root_core = tmp_path / "core/rules"
+    write(root_pp / "pack/a.yaml", "rule_id: conflict_1\nTitle: V1\n")
+    write(root_core / "pack/a.yaml", "rule_id: conflict_1\nTitle: V2\n")
+
+    with pytest.raises(SystemExit) as exc:
+        validate_rules.validate([root_pp, root_core])
+    assert exc.value.code == 2
+    out = capsys.readouterr().out.lower()
+    assert "conflicting" in out or "conflict" in out

--- a/tools/validate_rules.py
+++ b/tools/validate_rules.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+import yaml
+
+RULE_ROOTS = [
+    "contract_review_app/legal_rules/policy_packs",
+    "core/rules",
+]
+ALLOWED_RULE_EXTS = {".yml", ".yaml"}
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _resolve(p: str | Path) -> Path:
+    p = Path(p)
+    if not p.is_absolute():
+        p = ROOT_DIR / p
+    return p
+
+
+@dataclass
+class Entry:
+    path: Path
+    sha256: str
+    title: Optional[str]
+
+
+def _gather(roots: Sequence[str | Path]) -> tuple[Dict[str, List[Entry]], List[Path]]:
+    rule_map: Dict[str, List[Entry]] = {}
+    missing: List[Path] = []
+    for root in roots:
+        base = _resolve(root)
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if path.is_dir():
+                continue
+            if path.suffix.lower() not in ALLOWED_RULE_EXTS:
+                continue
+            try:
+                docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+            except Exception:
+                continue
+            for data in docs:
+                if not data:
+                    continue
+                if isinstance(data, dict) and data.get("rule"):
+                    rules = [data["rule"]]
+                elif isinstance(data, dict) and data.get("rules"):
+                    rules = list(data.get("rules") or [])
+                elif isinstance(data, list):
+                    rules = list(data)
+                else:
+                    rules = [data] if isinstance(data, dict) else []
+                for raw in rules:
+                    if not isinstance(raw, dict):
+                        continue
+                    rid = raw.get("rule_id") or raw.get("id")
+                    if not rid:
+                        if path not in missing:
+                            missing.append(path)
+                        continue
+                    title = raw.get("Title") or raw.get("title")
+                    sha = hashlib.sha256(
+                        yaml.safe_dump(raw, sort_keys=True).encode("utf-8")
+                    ).hexdigest()
+                    rule_map.setdefault(rid, []).append(Entry(path, sha, title))
+    return rule_map, missing
+
+
+def validate(paths: Sequence[str | Path] | None = None) -> None:
+    roots = paths or RULE_ROOTS
+    rule_map, missing = _gather(roots)
+    for p in missing:
+        print(f"Rule without rule_id: {p}")
+    conflicts: List[tuple[str, List[Entry]]] = []
+    duplicates: List[tuple[str, List[Entry]]] = []
+    for rid, entries in rule_map.items():
+        if len(entries) > 1:
+            hashes = {e.sha256 for e in entries}
+            if len(hashes) > 1:
+                conflicts.append((rid, entries))
+            else:
+                duplicates.append((rid, entries))
+    for rid, entries in duplicates:
+        paths = ", ".join(str(e.path) for e in entries)
+        print(f"Duplicate rule_id {rid} in: {paths}")
+    if conflicts:
+        for rid, entries in conflicts:
+            paths = ", ".join(str(e.path) for e in entries)
+            print(f"Conflicting rule_id {rid} in: {paths}")
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    try:
+        validate()
+    except SystemExit as exc:
+        sys.exit(exc.code)


### PR DESCRIPTION
## Summary
- load only highest-priority version of each rule_id and log shadowed duplicates
- add tools/validate_rules.py to detect conflicting rule files
- run rule validation in CI and add tests for deduplication

## Testing
- `pre-commit run --files .github/workflows/ci.yml contract_review_app/legal_rules/loader.py contract_review_app/tests/engine/test_rules_dedup.py tools/validate_rules.py`
- `PYTHONPATH=. pytest contract_review_app/tests/engine/test_rules_loader_exts.py contract_review_app/tests/engine/test_rules_dedup.py -q`
- `python tools/validate_rules.py && echo success`

------
https://chatgpt.com/codex/tasks/task_e_68c1d518331c83259e09fed04a00d01e