### PR TITLE
test: use ts-node for dedupe spec

### DIFF
--- a/panel/__tests__/dedupe.spec.js
+++ b/panel/__tests__/dedupe.spec.js
@@ -1,4 +1,5 @@
-const { dedupeFindings } = require('../../build/dedupe.js');
+require('ts-node/register');
+const { dedupeFindings } = require('../../word_addin_dev/app/assets/dedupe');
 
 describe('dedupeFindings', () => {
   it('returns single entry for exact duplicates', () => {


### PR DESCRIPTION
## Summary
- run dedupe spec directly against TypeScript helper via ts-node

## Testing
- `npx tsc word_addin_dev/app/assets/dedupe.ts --module commonjs --target es2019 --skipLibCheck --outDir build --noEmitOnError false`
- `node_modules/.bin/jest panel/__tests__/dedupe.spec.js --transform='{"^.+\\.tsx?$":"ts-jest"}'`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb5599408325ad23e6f90c4e43f8