### PR TITLE
test: use ts-node for dedupe spec

### DIFF
--- a/panel/__tests__/dedupe.spec.js
+++ b/panel/__tests__/dedupe.spec.js
@@ -1,5 +1,6 @@
 require('ts-node/register');
-const { dedupeFindings } = require('../../word_addin_dev/app/assets/dedupe');
+// Node doesn't resolve `.ts` extensions by default, so explicitly include it
+const { dedupeFindings } = require('../../word_addin_dev/app/assets/dedupe.ts');
 
 describe('dedupeFindings', () => {
   it('returns single entry for exact duplicates', () => {


### PR DESCRIPTION
## Summary
- run dedupe spec directly against TypeScript helper via ts-node
- require TypeScript helper with explicit `.ts` extension so Node can resolve it

## Testing
- `npx tsc word_addin_dev/app/assets/dedupe.ts --module commonjs --target es2019 --skipLibCheck --outDir build --noEmitOnError false`
- `npx jest panel/__tests__/dedupe.spec.js --transform='{ "^.+\\.tsx?$": "ts-jest" }'`


------
https://chatgpt.com/codex/tasks/task_e_68c1ee5eb9608325a62f3c17dc5f8d5e