### PR TITLE
feat: expand anchor handling and comment insertion

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -268,7 +268,7 @@ from contract_review_app.core.schemas import (
     SuggestEdit,
     SuggestResponse,
 )
-from contract_review_app.intake.normalization import normalize_text
+from contract_review_app.intake.normalization import normalize_text, normalize_for_intake
 
 # --- LLM provider & limits (final resolution) ---
 from contract_review_app.llm.provider import get_provider
@@ -544,6 +544,10 @@ def _analyze_document(text: str, risk: str = "medium") -> Dict[str, Any] | JSONR
         )
 
     findings = engine.analyze(text or "", loader._RULES)
+    for f in findings:
+      snip = f.get("snippet")
+      if isinstance(snip, str):
+        f["normalized_snippet"] = normalize_for_intake(snip)
 
     order = {"low": 0, "medium": 1, "high": 2, "critical": 3}
     thr = order.get((risk or "medium").lower(), 1)

--- a/contract_review_app/tests/api/test_analyze_normalized_snippet.py
+++ b/contract_review_app/tests/api/test_analyze_normalized_snippet.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+from contract_review_app.intake.normalization import normalize_for_intake
+
+client = TestClient(app)
+
+
+def test_analyze_returns_normalized_snippet():
+    text = "Process\u00A0Agent\r\nfoo"
+    resp = client.post("/api/analyze", json={"text": text})
+    assert resp.status_code == 200
+    data = resp.json()
+    findings = data.get("findings") or data.get("results", {}).get("analysis", {}).get("findings", [])
+    assert findings
+    f = findings[0]
+    assert f["normalized_snippet"] == normalize_for_intake(f["snippet"])

--- a/panel/__tests__/anchors.spec.js
+++ b/panel/__tests__/anchors.spec.js
@@ -1,0 +1,39 @@
+require('ts-node/register');
+const { findAnchors } = require('../../word_addin_dev/app/assets/anchors.js');
+
+describe('findAnchors', () => {
+  it('anchors.exact-match', async () => {
+    const range = { start: 1, end: 4 };
+    const ctx = { sync: jest.fn(async () => {}), trackedObjects: { add: jest.fn() } };
+    const body = {
+      context: ctx,
+      search: txt => ({ items: txt === 'foo' ? [range] : [], load: () => {} })
+    };
+    const res = await findAnchors(body, 'foo');
+    expect(res).toHaveLength(1);
+    expect(res[0]).toBe(range);
+    expect(ctx.trackedObjects.add).toHaveBeenCalledWith(range);
+  });
+
+  it('anchors.normalized-fallback', async () => {
+    const range = { start: 0, end: 3 };
+    const ctx = { sync: jest.fn(async () => {}), trackedObjects: { add: jest.fn() } };
+    const body = {
+      context: ctx,
+      search: txt => ({ items: txt === 'foo bar' ? [range] : [], load: () => {} })
+    };
+    const res = await findAnchors(body, 'foo\u00A0bar');
+    expect(res).toHaveLength(1);
+  });
+
+  it('anchors.overlap-pruning', async () => {
+    const r1 = { start: 0, end: 5 };
+    const r2 = { start: 2, end: 6 };
+    const r3 = { start: 4, end: 8 };
+    const ctx = { sync: jest.fn(async () => {}), trackedObjects: { add: jest.fn() } };
+    const body = { context: ctx, search: () => ({ items: [r1, r2, r3], load: () => {} }) };
+    const res = await findAnchors(body, 'x');
+    expect(res).toHaveLength(1);
+    expect(res[0]).toBe(r1);
+  });
+});

--- a/panel/__tests__/annotate.insert.spec.js
+++ b/panel/__tests__/annotate.insert.spec.js
@@ -1,0 +1,49 @@
+require('ts-node/register');
+const { insertComments } = require('../../word_addin_dev/app/assets/annotate.js');
+const { findAnchors } = require('../../word_addin_dev/app/assets/anchors.js');
+
+describe('insertComments', () => {
+  it('annotate.success', async () => {
+    const comments = [];
+    const ranges = [
+      { start: 0, end: 1, insertComment: msg => comments.push(msg) },
+      { start: 2, end: 3, insertComment: msg => comments.push(msg) },
+      { start: 4, end: 5, insertComment: msg => comments.push(msg) },
+    ];
+    const ctx = { sync: jest.fn(async () => {}), trackedObjects: { add: jest.fn() }, document: { body: {} } };
+    const body = { context: ctx, search: () => ({ items: ranges, load: () => {} }) };
+    const anchors = await findAnchors(body, 'x');
+    const inserted = await insertComments(ctx, anchors.map(r => ({ range: r, message: 'm' })));
+    expect(inserted).toBe(3);
+    expect(ctx.sync).toHaveBeenCalledTimes(2);
+  });
+
+  it('annotate.retry-on-0xA7210002', async () => {
+    const inserted = [];
+    const range = {
+      attempts: 0,
+      insertComment(msg) {
+        if (this.attempts++ === 0) throw new Error('0xA7210002');
+        inserted.push(msg);
+      },
+      expandTo() { return this; }
+    };
+    const ctx = { sync: jest.fn(async () => {}), document: { body: {} } };
+    const count = await insertComments(ctx, [{ range, message: 'm' }]);
+    expect(count).toBe(1);
+    expect(inserted).toHaveLength(1);
+  });
+
+  it('annotate.skip-after-retry', async () => {
+    const range = {
+      attempts: 0,
+      insertComment() {
+        this.attempts++; throw new Error('0xA7210002');
+      },
+      expandTo() { return this; }
+    };
+    const ctx = { sync: jest.fn(async () => {}), document: { body: {} } };
+    const count = await insertComments(ctx, [{ range, message: 'm' }]);
+    expect(count).toBe(0);
+  });
+});

--- a/panel/__tests__/counter.spec.js
+++ b/panel/__tests__/counter.spec.js
@@ -1,0 +1,48 @@
+require('ts-node/register');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('counter.correct', () => {
+  let sandbox;
+  let logs;
+  beforeEach(() => {
+    logs = [];
+    global.window = { __lastAnalyzed: 'abcdef' };
+    global.document = { getElementById: () => ({ style: {}, addEventListener: () => {} }), querySelector: () => null, addEventListener: () => {}, body: { dispatchEvent() {} } };
+    global.notifyOk = jest.fn();
+    global.notifyWarn = jest.fn();
+    global.Word = {
+      run: async fn => {
+        const ctx = {
+          document: {
+            body: {
+              search: () => ({ items: [{ insertComment: () => {} }], load: () => {} }),
+            },
+            getSelection: () => ({ insertComment: () => {} }),
+          },
+          sync: async () => {},
+        };
+        return fn(ctx);
+      }
+    };
+    const code = fs.readFileSync(path.resolve(__dirname, '../../word_addin_dev/app/assets/taskpane.js'), 'utf-8').replace(/bootstrap\(\);\s*$/, '');
+    const base = path.resolve(__dirname, '../../word_addin_dev/app/assets');
+    const consoleMock = { log: (m) => logs.push(m), warn: () => {}, error: () => {} };
+    sandbox = { window: global.window, document: global.document, notifyOk: (m) => logs.push(`[OK] ${m}`), notifyWarn: () => {}, Word: global.Word, console: consoleMock, exports: {}, require: (p) => require(path.join(base, p + '.js')) };
+    vm.createContext(sandbox);
+    vm.runInContext(code, sandbox);
+  });
+
+  it('reports correct number after dedupe and overlap', async () => {
+    const findings = [
+      { rule_id: 'r1', start: 0, end: 5, snippet: 'abcde', severity: 'high', clause_type: 'x' },
+      { rule_id: 'r1', start: 0, end: 5, snippet: 'abcde', severity: 'low', clause_type: 'x' },
+      { rule_id: 'r2', start: 6, end: 8, snippet: 'fg', severity: 'medium', clause_type: 'y' },
+    ];
+    await sandbox.exports.annotateFindingsIntoWord(findings.filter(f => f.severity === 'high'));
+    expect(logs.some(m => /Will insert: 1/.test(m))).toBe(true);
+    await sandbox.exports.annotateFindingsIntoWord(findings);
+    expect(logs.some(m => /Will insert: 2/.test(m))).toBe(true);
+  });
+});

--- a/panel/__tests__/dedupe.spec.js
+++ b/panel/__tests__/dedupe.spec.js
@@ -1,23 +1,18 @@
 require('ts-node/register');
-// Node doesn't resolve `.ts` extensions by default, so explicitly include it
-const { dedupeFindings } = require('../../word_addin_dev/app/assets/dedupe.ts');
+const { dedupeFindings } = require('../../word_addin_dev/app/assets/dedupe.js');
 
-describe('dedupeFindings', () => {
-  it('returns single entry for exact duplicates', () => {
-    const sample = { rule_id: 'r', start: 0, end: 5, snippet: 'abcde' };
-    const input = Array.from({ length: 5 }, () => ({ ...sample }));
-    const out = dedupeFindings(input);
-    expect(out.length).toBe(1);
-  });
-
-  it('keeps findings with different ranges', () => {
-    const base = { rule_id: 'r', snippet: 'abcde' };
-    const input = [
-      { ...base, start: 0, end: 5 },
-      { ...base, start: 1, end: 6 },
-      { ...base, start: 2, end: 7 }
+describe('dedupe.removes-duplicates', () => {
+  it('removes duplicates and preserves order', () => {
+    const list = [
+      { rule_id: 'r1', start: 0, end: 5, snippet: 'abcde', severity: 'low' },
+      { rule_id: 'r1', start: 0, end: 5, snippet: 'abcde', severity: 'high' },
+      { rule_id: 'r2', start: 6, end: 8, snippet: 'fg', severity: 'medium' },
+      { rule_id: 'r1', start: 0, end: 5, snippet: 'abcde', severity: 'medium' },
     ];
-    const out = dedupeFindings(input);
-    expect(out.length).toBe(3);
+    const res = dedupeFindings(list);
+    expect(res.length).toBe(2);
+    expect(res[0].rule_id).toBe('r1');
+    expect(res[0].severity).toBe('high');
+    expect(res[1].rule_id).toBe('r2');
   });
 });

--- a/panel/__tests__/flags.spec.js
+++ b/panel/__tests__/flags.spec.js
@@ -1,23 +1,25 @@
 require('ts-node/register');
-const { isAddCommentsOnAnalyzeEnabled, setAddCommentsOnAnalyze } = require('../../word_addin_dev/app/assets/taskpane');
 
 describe('Add comments flag', () => {
+  let mod;
   beforeEach(() => {
-    const g = global;
-    g.localStorage = {
+    global.window = {};
+    global.document = { getElementById: () => ({ style: {}, addEventListener: () => {} }), querySelector: () => null, addEventListener: () => {}, body: { dispatchEvent() {} } };
+    global.localStorage = {
       store: {},
       getItem(k) { return this.store[k] ?? null; },
       setItem(k, v) { this.store[k] = v; },
       removeItem(k) { delete this.store[k]; }
     };
+    mod = require('../../word_addin_dev/app/assets/taskpane.js');
   });
 
   it('defaults to true when missing', () => {
-    expect(isAddCommentsOnAnalyzeEnabled()).toBe(true);
+    expect(mod.isAddCommentsOnAnalyzeEnabled()).toBe(true);
   });
 
   it('persists value', () => {
-    setAddCommentsOnAnalyze(false);
-    expect(isAddCommentsOnAnalyzeEnabled()).toBe(false);
+    mod.setAddCommentsOnAnalyze(false);
+    expect(mod.isAddCommentsOnAnalyzeEnabled()).toBe(false);
   });
 });

--- a/word_addin_dev/app/assets/anchors.ts
+++ b/word_addin_dev/app/assets/anchors.ts
@@ -1,0 +1,82 @@
+import { normalizeText } from "./dedupe";
+
+interface RangeLike {
+  start?: number;
+  end?: number;
+  [key: string]: any;
+}
+
+interface BodyLike {
+  context: any;
+  search: (txt: string, opts: any) => { items: RangeLike[]; load?: (arg: string) => void };
+}
+
+/**
+ * Find non-overlapping anchors in the document body for a raw snippet.
+ *
+ * Searches for the raw snippet first. If no matches are found, falls back to
+ * searching the normalized snippet (same rules as backend normalization).
+ * Returned ranges are sorted by (start,end) and overlapping ranges are pruned,
+ * keeping the longest (or first if equal). All returned ranges are added to
+ * ``context.trackedObjects``.
+ */
+export async function findAnchors(body: BodyLike, snippetRaw: string): Promise<RangeLike[]> {
+  const ctx = body.context;
+  const opt = { matchCase: false, matchWholeWord: false };
+
+  const attempt = (txt: string) => {
+    const res = body.search(txt, opt) as any;
+    if (res && typeof res.load === "function") res.load("items");
+    return res;
+  };
+
+  const rawRes = attempt(snippetRaw || "");
+  await ctx.sync();
+  let items: RangeLike[] = rawRes?.items || [];
+
+  if (!items.length) {
+    const norm = normalizeText(snippetRaw || "");
+    const normRes = attempt(norm);
+    await ctx.sync();
+    items = normRes?.items || [];
+  }
+
+  // Sort by start,end
+  items.sort((a, b) => {
+    const sa = a.start ?? 0;
+    const sb = b.start ?? 0;
+    if (sa !== sb) return sa - sb;
+    const ea = a.end ?? sa;
+    const eb = b.end ?? sb;
+    return ea - eb;
+  });
+
+  // Merge overlaps keeping longest/first
+  const result: RangeLike[] = [];
+  for (const r of items) {
+    const start = r.start ?? 0;
+    const end = r.end ?? start;
+    const last = result[result.length - 1];
+    if (last && start < (last.end ?? start)) {
+      const lastLen = (last.end ?? 0) - (last.start ?? 0);
+      const curLen = end - start;
+      if (curLen > lastLen) {
+        result[result.length - 1] = r;
+      }
+      continue;
+    }
+    result.push(r);
+  }
+
+  for (const r of result) {
+    try {
+      ctx.trackedObjects?.add?.(r);
+    } catch {
+      // ignore tracking errors
+    }
+  }
+
+  return result;
+}
+
+export type { RangeLike };

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -1,0 +1,47 @@
+/** Utilities for inserting comments into Word with batching and retries. */
+export interface CommentItem {
+  range: any;
+  message: string;
+}
+
+/**
+ * Insert comments for provided ranges. Operations are batched: ``context.sync``
+ * is called after every 20 successful insertions and once at the end. If
+ * ``range.insertComment`` throws an error containing ``0xA7210002`` it retries
+ * once after rehydrating the range via ``expandTo(context.document.body)``. On
+ * second failure the error is logged and the comment is skipped.
+ *
+ * Returns the number of comments successfully queued for insertion.
+ */
+export async function insertComments(ctx: any, items: CommentItem[]): Promise<number> {
+  let inserted = 0;
+  let pending = 0;
+  for (const it of items) {
+    let r = it.range;
+    const msg = it.message;
+    try {
+      r.insertComment(msg);
+      inserted++;
+    } catch (e: any) {
+      if (String(e).includes("0xA7210002")) {
+        try {
+          r = r.expandTo ? r.expandTo(ctx.document.body) : r;
+          r.insertComment(msg);
+          inserted++;
+        } catch (e2) {
+          console.warn("annotate retry failed", e2);
+        }
+      } else {
+        console.warn("annotate error", e);
+      }
+    }
+    pending++;
+    if (pending % 20 === 0) {
+      await ctx.sync();
+    }
+  }
+  if (pending % 20 !== 0) {
+    await ctx.sync();
+  }
+  return inserted;
+}

--- a/word_addin_dev/app/assets/dedupe.ts
+++ b/word_addin_dev/app/assets/dedupe.ts
@@ -5,6 +5,7 @@ export function normalizeText(s: string | undefined | null): string {
   return s
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n")
+    .replace(/\u00A0/g, " ")
     .replace(/[ \t]+/g, " ")
     .trim();
 }

--- a/word_addin_dev/app/assets/store.ts
+++ b/word_addin_dev/app/assets/store.ts
@@ -1,5 +1,6 @@
 const DEFAULT_API_KEY = "";
 export const DEFAULT_SCHEMA = "1.4";
+const ADD_COMMENTS_KEY = "cai-comment-on-analyze";
 
 function ensureDefaults(): void {
   try {
@@ -8,6 +9,9 @@ function ensureDefaults(): void {
     }
     if (localStorage.getItem("schema_version") === null) {
       localStorage.setItem("schema_version", DEFAULT_SCHEMA);
+    }
+    if (localStorage.getItem(ADD_COMMENTS_KEY) === null) {
+      localStorage.setItem(ADD_COMMENTS_KEY, "1");
     }
   } catch {
     // ignore
@@ -43,6 +47,27 @@ export function getSchemaFromStore(): string {
 export function setSchemaVersion(v: string): void {
   try {
     localStorage.setItem("schema_version", v);
+  } catch {
+    // ignore
+  }
+}
+
+export function getAddCommentsFlag(): boolean {
+  try {
+    const v = localStorage.getItem(ADD_COMMENTS_KEY);
+    if (v === null) {
+      localStorage.setItem(ADD_COMMENTS_KEY, "1");
+      return true;
+    }
+    return v !== "0";
+  } catch {
+    return true;
+  }
+}
+
+export function setAddCommentsFlag(v: boolean): void {
+  try {
+    localStorage.setItem(ADD_COMMENTS_KEY, v ? "1" : "0");
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary
- add anchor search with normalization fallback and overlap pruning
- batch insert Word comments with retry logic on 0xA7210002
- surface “Will insert: N” and persist Add comments flag in storage
- expose normalized_snippet in analyze results

## Testing
- `NODE_OPTIONS='-r ts-node/register' npx jest --transform '{}' panel/__tests__/anchors.spec.js panel/__tests__/annotate.insert.spec.js panel/__tests__/dedupe.spec.js panel/__tests__/flags.spec.js panel/__tests__/counter.spec.js` *(fails: expect(received).toBe(expected))*
- `pytest contract_review_app/tests/api/test_analyze_normalized_snippet.py` *(fails: assert 400 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c289f282a88325b049fa053a27b24b