### PR TITLE
feat: show rule citations in legal comments

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -141,7 +141,8 @@ function buildLegalComment(f: AnalyzeFinding): string {
   const law = Array.isArray(f.law_refs) && f.law_refs.length ? f.law_refs.join('; ') : "—";
   const conflict = Array.isArray(f.conflict_with) && f.conflict_with.length ? f.conflict_with.join('; ') : "—";
   const fix = f.suggestion?.text || '—';
-  return `[${sev}] ${rid}${ct}\nReason: ${advice}\nLaw: ${law}\nConflict: ${conflict}\nSuggested fix: ${fix}`;
+  const citations = Array.isArray(f.citations) && f.citations.length ? `\nCitations: ${f.citations.join('; ')}` : '';
+  return `[${sev}] ${rid}${ct}\nReason: ${advice}\nLaw: ${law}\nConflict: ${conflict}${citations}\nSuggested fix: ${fix}`;
 }
 
 function nthOccurrenceIndex(hay: string, needle: string, startPos?: number): number {


### PR DESCRIPTION
## Summary
- include rule citations in Word add-in legal comments

## Testing
- `PYTHONPATH=. npm run build:panel`


------
https://chatgpt.com/codex/tasks/task_e_68c292219090832586a35283e7880f5d