### PR TITLE
Handle findings missing clause type in Word add-in

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -130,7 +130,7 @@ function filterByThreshold(list: AnalyzeFinding[], thr: "low" | "medium" | "high
 }
 
 function buildLegalComment(f: AnalyzeFinding): string {
-  if (!f || !f.rule_id || !f.clause_type || !f.snippet) {
+  if (!f || !f.rule_id || !f.snippet) {
     console.warn("buildLegalComment: missing required fields", f);
     return "";
   }
@@ -198,7 +198,7 @@ export async function annotateFindingsIntoWord(findings: AnalyzeFinding[]): Prom
   let lastStart = Number.POSITIVE_INFINITY;
   let skipped = 0;
   for (const f of sorted) {
-    if (!f || !f.rule_id || !f.clause_type || !f.snippet) {
+    if (!f || !f.rule_id || !f.snippet) {
       console.warn("annotateFindingsIntoWord: skipping invalid finding", f);
       skipped++;
       continue;


### PR DESCRIPTION
## Summary
- Allow Word comments to be generated even when `clause_type` is absent
- Skip findings only when they lack `rule_id` or `snippet`

## Testing
- `npm --prefix word_addin_dev run build`
- `PYTHONPATH=. python tools/build_panel.py`
- `node -e "...annotateFindingsIntoWord..."`
- `pre-commit run --files word_addin_dev/app/assets/taskpane.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c2920e3974832599b8bab40d336756