### PR TITLE
fix: make one-click startup branch optional

### DIFF
--- a/tools/start_oneclick.ps1
+++ b/tools/start_oneclick.ps1
@@ -1,5 +1,5 @@
 param(
-  [string]$Branch = "codex/implement-anchor-search-with-tests"
+  [string]$Branch
 )
 
 $ErrorActionPreference = "Stop"
@@ -8,6 +8,9 @@ Set-Location (Join-Path $root "..")  # в корень репо
 
 # 1) Git sync
 git fetch origin
+if ([string]::IsNullOrWhiteSpace($Branch)) {
+  $Branch = (git rev-parse --abbrev-ref HEAD).Trim()
+}
 git switch $Branch
 git pull
 


### PR DESCRIPTION
## Summary
- default to current branch when start_oneclick.ps1 is called without a branch
- keep one-click startup working after feature branches are merged

## Testing
- `pre-commit run --files tools/start_oneclick.ps1` (passed)
- `pytest tests/panel/test_anchor_fallbacks.py tests/panel/test_cache_buster.py contract_review_app/tests/api/test_analyze_normalized_snippet.py` (passed)


------
https://chatgpt.com/codex/tasks/task_e_68c2a6d99de4832586f1f12e782fec0b