### PR TITLE
feat(ui): progressive fetch + caching + error toasts

### DIFF
--- a/tests/api/test_ch_normalization.py
+++ b/tests/api/test_ch_normalization.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from contract_review_app.api.integrations import _normalize_profile
+
+FIXT = Path("tests/fixtures/ch_blackrock_profile.json")
+
+
+def test_normalize_blackrock():
+    data = json.loads(FIXT.read_text())
+    norm = _normalize_profile(data, officers=3, psc=1)
+    assert norm["status"] == "active"
+    assert norm["company_number"] == "02022650"
+    assert norm["registered_office"]["postcode"] == "EC2N 2DL"
+    assert norm["officers_count"] == 3
+    assert norm["psc_count"] == 1

--- a/tests/fixtures/ch_blackrock_profile.json
+++ b/tests/fixtures/ch_blackrock_profile.json
@@ -1,0 +1,24 @@
+{
+  "company_number": "02022650",
+  "company_name": "BLACK ROCK (UK) LIMITED",
+  "company_status": "active",
+  "type": "ltd",
+  "jurisdiction": "england-wales",
+  "date_of_creation": "1986-05-20",
+  "registered_office_address": {
+    "address_line_1": "12 THROGMORTON AVENUE",
+    "address_line_2": "CITY OF LONDON",
+    "postal_code": "EC2N 2DL",
+    "locality": "LONDON",
+    "country": "UNITED KINGDOM"
+  },
+  "sic_codes": ["70229"],
+  "accounts": {
+    "last_accounts": {"made_up_to": "2023-12-31"},
+    "next_accounts": {"due_on": "2024-12-31"}
+  },
+  "confirmation_statement": {
+    "last_made_up_to": "2024-06-20",
+    "next_due": "2025-07-04"
+  }
+}

--- a/tests/integrations/test_ch_integration.py
+++ b/tests/integrations/test_ch_integration.py
@@ -1,0 +1,31 @@
+import json
+import os
+
+import respx
+from contract_review_app.core.schemas import Party
+from contract_review_app.integrations.service import build_companies_meta
+from contract_review_app.integrations.companies_house import client as ch_client
+
+FIXT = json.loads(open("tests/fixtures/ch_blackrock_profile.json", "r", encoding="utf-8").read())
+BASE = ch_client.BASE
+
+
+def setup_function():
+    os.environ["FEATURE_COMPANIES_HOUSE"] = "1"
+    os.environ["CH_API_KEY"] = "x"
+    ch_client.KEY = "x"
+    ch_client._CACHE.clear()  # type: ignore
+    ch_client._LAST.clear()  # type: ignore
+
+
+@respx.mock
+def test_build_companies_meta_blackrock():
+    respx.get(f"{BASE}/company/02022650").respond(json=FIXT)
+    respx.get(f"{BASE}/company/02022650/officers?items_per_page=1").respond(json={"total_results": 1})
+    respx.get(
+        f"{BASE}/company/02022650/persons-with-significant-control?items_per_page=1"
+    ).respond(json={"total_results": 0})
+    p = Party(name="BLACK ROCK (UK) LIMITED", company_number="02022650")
+    meta = build_companies_meta([p])
+    assert meta[0]["matched"]["company_number"] == "02022650"
+    assert meta[0]["verdict"]["level"] == "ok"


### PR DESCRIPTION
## Summary
- fetch Companies House profiles asynchronously with sessionStorage caching and spinner placeholders
- show toast on CH rate limits without collapsing panel
- add Companies House client, normalization, and integration tests

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'toBeInTheDocument' does not exist, Property 'render' does not exist)*
- `pytest tests/integrations/test_ch_client.py tests/api/test_ch_normalization.py tests/integrations/test_ch_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b191e9e08325bee47416f9906e75