### PR TITLE
fix: preserve document party data before enrichment

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -2024,9 +2024,10 @@ def api_analyze(
             )
             for p in summary.get("parties", [])
         ]
+        doc_parties = [Party(**p.model_dump()) for p in parties]
         parties = enrich_parties_with_companies_house(parties)
         summary["parties"] = [p.model_dump() for p in parties]
-        companies_meta = build_companies_meta(parties)
+        companies_meta = build_companies_meta(parties, doc_parties=doc_parties)
     except Exception:
         pass
 

--- a/contract_review_app/integrations/service.py
+++ b/contract_review_app/integrations/service.py
@@ -111,12 +111,13 @@ def _verdict_for_party(p: Party, data: Dict[str, Any] | None) -> Dict[str, Any]:
     return verdict
 
 
-def build_companies_meta(parties: List[Party]) -> List[Dict[str, Any]]:
+def build_companies_meta(parties: List[Party], doc_parties: List[Party] | None = None) -> List[Dict[str, Any]]:
     if os.getenv("FEATURE_COMPANIES_HOUSE", "0") != "1" or not ch_client.KEY:
         return []
     meta: List[Dict[str, Any]] = []
-    for p in parties:
-        doc = {"name": p.name, "number": p.company_number}
+    for idx, p in enumerate(parties):
+        src = doc_parties[idx] if doc_parties and idx < len(doc_parties) else p
+        doc = {"name": src.name, "number": src.company_number}
         data: Dict[str, Any] | None = None
         try:
             if p.company_number:

--- a/tests/integrations/test_enrich_parties.py
+++ b/tests/integrations/test_enrich_parties.py
@@ -70,3 +70,26 @@ def test_build_companies_meta():
     meta = build_companies_meta([p])
     assert meta[0]["matched"]["company_number"] == "123"
     assert meta[0]["verdict"]["level"] == "ok"
+
+
+@respx.mock
+def test_build_companies_meta_preserves_doc_data():
+    respx.get(f"{BASE}/search/companies").respond(
+        json={"items": [{"title": "ACME LTD", "company_number": "555"}]}, headers={"ETag": "s1"}
+    )
+    respx.get(f"{BASE}/company/555").respond(
+        json={
+            "company_name": "ACME LTD",
+            "company_number": "555",
+            "company_status": "active",
+        }
+    )
+    respx.get(f"{BASE}/company/555/officers?items_per_page=1").respond(json={"total_results": 3})
+    respx.get(
+        f"{BASE}/company/555/persons-with-significant-control?items_per_page=1"
+    ).respond(json={"total_results": 2})
+    doc_party = Party(name="Acme Ltd")
+    enriched = enrich_parties_with_companies_house([Party(**doc_party.model_dump())])
+    meta = build_companies_meta(enriched, doc_parties=[doc_party])
+    assert meta[0]["from_document"]["number"] is None
+    assert meta[0]["matched"]["company_number"] == "555"


### PR DESCRIPTION
## Summary
- capture document party values before Companies House enrichment
- reflect original party data in companies meta output
- test meta generation preserves raw document fields

## Testing
- `pytest tests/integrations/test_enrich_parties.py tests/panel/test_analyze_enrichment_pipeline.py -q`
- `npx jest contract_review_app/frontend/draft_panel/index.rtl.test.tsx` *(fails: Cannot find module '@babel/preset-env')*
- `pytest tests/integrations/test_enrich_parties.py tests/panel/test_analyze_enrichment_pipeline.py tests/api/test_companies_endpoints.py tests/api/test_ch_gate.py -q` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b2e0a6f083259ee19e73bf408e05