### PR TITLE
fix: enable annotate button after binding handler

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -715,17 +715,21 @@ function wireUI() {
     isAddCommentsOnAnalyzeEnabled();
   }
   const annotateBtn = document.getElementById("btnAnnotate") as HTMLButtonElement | null;
-  annotateBtn?.addEventListener("click", async () => {
-    if (annotateBtn.disabled) return;
-    annotateBtn.disabled = true;
-    try {
-      const data = (window as any).__last?.analyze?.json || {};
-      const findings = (globalThis as any).parseFindings(data);
-      await (globalThis as any).annotateFindingsIntoWord(findings);
-    } finally {
-      annotateBtn.disabled = false;
-    }
-  });
+  if (annotateBtn) {
+    annotateBtn.addEventListener("click", async () => {
+      if (annotateBtn.disabled) return;
+      annotateBtn.disabled = true;
+      try {
+        const data = (window as any).__last?.analyze?.json || {};
+        const findings = (globalThis as any).parseFindings(data);
+        await (globalThis as any).annotateFindingsIntoWord(findings);
+      } finally {
+        annotateBtn.disabled = false;
+      }
+    });
+    annotateBtn.classList.remove("js-disable-while-busy");
+    annotateBtn.removeAttribute("disabled");
+  }
 
   onDraftReady('');
   wireResultsToggle();


### PR DESCRIPTION
## Summary
- ensure Annotate button removes disabled state when wiring custom click handler

## Testing
- `npm test --silent`
- `pytest contract_review_app/tests/api/test_api_health_schema.py contract_review_app/tests/api/test_api_headers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2b6d560888325b6b7b3be2208b549