### PR TITLE
feat: enable Office.js rich error logging

### DIFF
--- a/word_addin_dev/app/assets/insert.ts
+++ b/word_addin_dev/app/assets/insert.ts
@@ -19,6 +19,8 @@ export async function insertDraftText(text: string): Promise<void> {
     target.insertText(text, w.Word.InsertLocation.replace);
     await context.sync();
   }).catch((e: any) => {
+    const g: any = globalThis as any;
+    g.logRichError?.(e, "insertDraft");
     console.warn('insertDraftText error', e?.code, e?.message, e?.debugInfo);
     throw e;
   });


### PR DESCRIPTION
## Summary
- enable Office.js extended error logging and expose `logRichError`
- record rich debug info in Word.run catch blocks
- forward Word insertion errors through shared logger

## Testing
- ⚠️ `npm run build:panel` (ModuleNotFoundError: No module named 'bump_build')
- ⚠️ `PYTHONPATH=. python tools/build_panel.py` (no output)

------
https://chatgpt.com/codex/tasks/task_e_68c2b9f869ac832586000fd80bff8506