### PR TITLE
fix: guard Office.js extended logging

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -4,9 +4,12 @@ export { normalizeText, dedupeFindings } from "./dedupe";
 import { getApiKeyFromStore, getSchemaFromStore, getAddCommentsFlag, setAddCommentsFlag } from "./store";
 import { postJSON, getStoredKey, getStoredSchema, setStoredSchema, ensureHeadersSet } from "../../../contract_review_app/frontend/common/http";
 
-// enable rich debug
-// @ts-ignore
-OfficeExtension.config.extendedErrorLogging = true;
+// enable rich debug when OfficeExtension is available
+const oe: any = (globalThis as any).OfficeExtension;
+if (oe && oe.config) {
+  // @ts-ignore
+  oe.config.extendedErrorLogging = true;
+}
 
 export function logRichError(e: any, tag = "Word") {
   try {


### PR DESCRIPTION
## Summary
- guard OfficeExtension access when enabling rich error logging

## Testing
- ✅ `pre-commit run --files word_addin_dev/app/assets/taskpane.ts`
- ❌ `npm run build:panel` (ModuleNotFoundError: No module named 'bump_build')
- ⚠️ `PYTHONPATH=. python tools/build_panel.py` (no output)


------
https://chatgpt.com/codex/tasks/task_e_68c2bd9ca3d48325ba07db0d0b2ed04b