### PR TITLE
Refactor annotate scheduler to two-phase ops

### DIFF
--- a/word_addin_dev/app/__tests__/annotate_plan.test.ts
+++ b/word_addin_dev/app/__tests__/annotate_plan.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { AnalyzeFinding } from '../assets/api-client';
+import { annotate } from '../assets/annotate';
+
+describe('annotate scheduler', () => {
+  beforeEach(() => {
+    // base text used to compute occurrence indexes
+    (globalThis as any).__lastAnalyzed = 'abc def abc xyz';
+  });
+
+  it('computes ops and skips overlaps', () => {
+    const findings: AnalyzeFinding[] = [
+      { start: 0, end: 3, snippet: 'abc', rule_id: 'r1' },
+      { start: 8, end: 11, snippet: 'abc', rule_id: 'r2' },
+      // overlap with first finding, should be skipped
+      { start: 2, end: 9, snippet: 'c def a', rule_id: 'r3' },
+    ];
+
+    const ops = annotate(findings);
+    expect(ops.length).toBe(2);
+    const map = Object.fromEntries(ops.map(o => [o.rule_id, o.occIdx]));
+    expect(map['r1']).toBe(0);
+    expect(map['r2']).toBe(1);
+  });
+
+  it('returns empty array for invalid findings', () => {
+    const findings: AnalyzeFinding[] = [
+      { start: undefined, end: undefined, snippet: '', rule_id: 'r1' },
+    ];
+    const ops = annotate(findings);
+    expect(ops.length).toBe(0);
+  });
+});
+

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -1,3 +1,6 @@
+import { AnalyzeFinding } from "./api-client";
+import { dedupeFindings, normalizeText } from "./dedupe";
+
 /** Utilities for inserting comments into Word with batching and retries. */
 export interface CommentItem {
   range: any;
@@ -45,3 +48,154 @@ export async function insertComments(ctx: any, items: CommentItem[]): Promise<nu
   }
   return inserted;
 }
+
+function nthOccurrenceIndex(hay: string, needle: string, startPos?: number): number {
+  if (!hay || !needle) return 0;
+  let idx = -1, n = 0;
+  while ((idx = hay.indexOf(needle, idx + 1)) !== -1 && idx < (startPos ?? hay.length)) n++;
+  return n;
+}
+
+function isDryRunAnnotateEnabled(): boolean {
+  try {
+    return !!(document.getElementById("cai-dry-run-annotate") as HTMLInputElement | null)?.checked;
+  } catch {
+    return false;
+  }
+}
+
+function buildLegalComment(f: AnalyzeFinding): string {
+  if (!f.rule_id || !f.snippet) {
+    console.warn("buildLegalComment: missing required fields", f);
+    return "";
+  }
+  const parts = [f.rule_id];
+  if (f.advice) parts.push(f.advice);
+  if (f.law_refs?.length) parts.push(f.law_refs.join("; "));
+  return parts.join("\n");
+}
+
+export interface AnnotateOp {
+  raw: string;
+  norm: string;
+  occIdx: number;
+  msg: string;
+  rule_id: string;
+  normalized_fallback: string;
+}
+
+/**
+ * Prepare annotate operations from analysis findings without touching Word objects.
+ */
+export function annotate(findings: AnalyzeFinding[]): AnnotateOp[] {
+  const base = normalizeText((globalThis as any).__lastAnalyzed || "");
+  const deduped = dedupeFindings(findings || []);
+  const sorted = deduped.slice().sort((a, b) => (b.end ?? 0) - (a.end ?? 0));
+
+  const ops: AnnotateOp[] = [];
+  let lastStart = Number.POSITIVE_INFINITY;
+  let skipped = 0;
+  for (const f of sorted) {
+    if (!f || !f.rule_id || !f.snippet) { skipped++; continue; }
+    const snippet = f.snippet;
+    const end = typeof f.end === "number" ? f.end : (typeof f.start === "number" ? f.start + snippet.length : undefined);
+    if (typeof end === "number" && end > lastStart) { skipped++; continue; }
+    const norm = normalizeText(snippet);
+    const occIdx = nthOccurrenceIndex(base, norm, f.start);
+    ops.push({
+      raw: snippet,
+      norm,
+      occIdx,
+      msg: buildLegalComment(f),
+      rule_id: f.rule_id,
+      normalized_fallback: normalizeText((f as any).normalized_snippet || "")
+    });
+    if (typeof f.start === "number") lastStart = f.start;
+  }
+  const g: any = globalThis as any;
+  if (skipped) g.notifyWarn?.(`Skipped ${skipped} overlaps/invalid`);
+  g.notifyOk?.(`Will insert: ${ops.length}`);
+  return ops;
+}
+
+/**
+ * Convert findings directly into Word comments using a two-phase plan.
+ */
+export async function findingsToWord(findings: AnalyzeFinding[]): Promise<number> {
+  const ops = annotate(findings);
+  if (!ops.length) return 0;
+  const g: any = globalThis as any;
+  return await g.Word?.run?.(async (ctx: any) => {
+    const body = ctx.document.body;
+    const searchOpts = { matchCase: false, matchWholeWord: false } as Word.SearchOptions;
+    const used: { start: number; end: number }[] = [];
+    let inserted = 0;
+
+    const pick = (coll: any, occ: number) => {
+      const arr = coll?.items || [];
+      if (!arr.length) return null;
+      return arr[Math.min(Math.max(occ, 0), arr.length - 1)] || null;
+    };
+
+    for (const op of ops) {
+      let target: any = null;
+
+      const sRaw = body.search(op.raw, searchOpts);
+      sRaw.load("items");
+      await ctx.sync();
+      target = pick(sRaw, op.occIdx);
+
+      if (!target) {
+        const fb = op.normalized_fallback && op.normalized_fallback !== op.norm ? op.normalized_fallback : op.norm;
+        if (fb && fb.trim()) {
+          const sNorm = body.search(fb, searchOpts);
+          sNorm.load("items");
+          await ctx.sync();
+          target = pick(sNorm, op.occIdx);
+        }
+      }
+
+      if (!target) {
+        const token = (() => {
+          const tks = op.raw.replace(/[^\p{L}\p{N} ]/gu, " ").split(" ").filter(x => x.length >= 12);
+          if (tks.length) return tks.sort((a, b) => b.length - a.length)[0].slice(0, 64);
+          return null;
+        })();
+        if (token) {
+          const sTok = body.search(token, searchOpts);
+          sTok.load("items");
+          await ctx.sync();
+          target = pick(sTok, 0);
+        }
+      }
+
+      if (target) {
+        target.load(["start", "end"]);
+        await ctx.sync();
+        const start = target.start ?? 0;
+        const end = target.end ?? start;
+        if (used.some(r => Math.max(r.start, start) < Math.min(r.end, end))) {
+          continue; // conflict
+        }
+        if (isDryRunAnnotateEnabled()) {
+          try { target.select(); } catch {}
+        } else if (op.msg) {
+          target.insertComment(op.msg);
+        }
+        used.push({ start, end });
+        inserted++;
+      } else {
+        console.warn("[annotate] no match for snippet", { rid: op.rule_id, snippet: op.raw.slice(0, 120) });
+      }
+    }
+
+    await ctx.sync();
+    return inserted;
+  }).catch((e: any) => {
+    const gg: any = globalThis as any;
+    gg.logRichError?.(e, "annotate");
+    console.warn("annotate run fail", e?.code, e?.message, e?.debugInfo);
+    return 0;
+  });
+}
+


### PR DESCRIPTION
## Summary
- split annotate into planning and application phases
- re-find ranges for each op and skip conflicts
- add unit tests for annotation scheduler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2bd1ebad883259738cf0a8803104b