### PR TITLE
Avoid Word.run when no operations remain

### DIFF
--- a/tests/panel/test_apply_ops_empty.py
+++ b/tests/panel/test_apply_ops_empty.py
@@ -1,0 +1,30 @@
+import json
+import subprocess
+import textwrap
+
+JS = textwrap.dedent('''
+const vm = require('vm');
+const fs = require('fs');
+let code = fs.readFileSync('word_addin_dev/taskpane.bundle.js', 'utf-8');
+code = code.replace(/bootstrap\(\);/, '');
+let runCount = 0;
+const sandbox = {
+  window: { __lastAnalyzed: '' },
+  Word: {
+    run: async (fn) => { runCount++; await fn({}); }
+  }
+};
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+(async () => {
+  await sandbox.applyOpsTracked([{start:5,end:3,replacement:'X'}]);
+  console.log(JSON.stringify({runCount}));
+})();
+''')
+
+def test_no_word_run_for_empty_ops(tmp_path):
+    script = tmp_path / 'run.js'
+    script.write_text(JS)
+    result = subprocess.run(['node', str(script)], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['runCount'] == 0

--- a/tests/panel/test_apply_ops_tracked.py
+++ b/tests/panel/test_apply_ops_tracked.py
@@ -6,7 +6,7 @@ JS = textwrap.dedent('''
 const vm = require('vm');
 const fs = require('fs');
 let code = fs.readFileSync('word_addin_dev/taskpane.bundle.js', 'utf-8');
-code = code.replace(/bootstrap\(\);\s*$/, '');
+code = code.replace(/bootstrap\(\);/, '');
 const inserts = [];
 const sandbox = {
   window: { __lastAnalyzed: 'abc abc' },


### PR DESCRIPTION
## Summary
- Deduplicate and validate edit operations before applying them and skip Word.run if nothing remains
- Expose `applyOpsTracked` globally for tests and add coverage for empty-operation case

## Testing
- `npm test --prefix word_addin_dev`
- `python -m pytest tests/panel/test_apply_ops_tracked.py tests/panel/test_apply_ops_empty.py -q`
- `python -m pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c2c25abb188325b73c43aa6a325208