### PR TITLE
fix: disable extended logging in production by default

### DIFF
--- a/word_addin_dev/app/__tests__/annotate_plan.test.ts
+++ b/word_addin_dev/app/__tests__/annotate_plan.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { AnalyzeFinding } from '../assets/api-client';
-import { annotate, MAX_ANNOTATE_OPS } from '../assets/annotate';
+import { planAnnotations, MAX_ANNOTATE_OPS } from '../assets/annotate';
 import { findAnchors } from '../assets/anchors';
 
 
@@ -58,7 +58,7 @@ describe('annotate scheduler', () => {
       search: () => ({ items: [], load: () => {} })
     } as any;
     const finding: AnalyzeFinding = { start: 0, end: 3, snippet: 'abc', rule_id: 'r1' };
-    const ops = annotate([finding]);
+    const ops = planAnnotations([finding]);
     const anchors = await findAnchors(body, ops[0].raw);
     const skipped = anchors.length === 0 ? [ops[0]] : [];
     expect(skipped.length).toBe(1);
@@ -71,7 +71,7 @@ describe('annotate scheduler', () => {
       snippet: 'x',
       rule_id: `r${i}`
     }));
-    const ops = annotate(findings);
+    const ops = planAnnotations(findings);
     expect(ops.length).toBe(MAX_ANNOTATE_OPS);
   });
 });

--- a/word_addin_dev/app/__tests__/logging.test.ts
+++ b/word_addin_dev/app/__tests__/logging.test.ts
@@ -4,6 +4,7 @@ describe('extended error logging', () => {
   beforeEach(() => {
     vi.resetModules();
     delete (globalThis as any).__ENABLE_EXTENDED_LOGS__;
+    delete (globalThis as any).__ENV__;
     (globalThis as any).window = globalThis;
     (globalThis as any).localStorage = {
       getItem: () => null,
@@ -41,6 +42,16 @@ describe('extended error logging', () => {
     process.env.NODE_ENV = 'production';
     await import('../assets/taskpane');
     expect(config.extendedErrorLogging).toBeUndefined();
+  });
+
+  it('defaults to production when env is undefined', async () => {
+    const config: any = {};
+    (globalThis as any).OfficeExtension = { config };
+    const origProcess = (globalThis as any).process;
+    (globalThis as any).process = undefined;
+    await import('../assets/taskpane');
+    expect(config.extendedErrorLogging).toBeUndefined();
+    (globalThis as any).process = origProcess;
   });
 
   it('can be enabled in production via flag', async () => {

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -98,7 +98,7 @@ export function planAnnotations(findings: AnalyzeFinding[]): AnnotationPlan[] {
 
 
   const ops: AnnotationPlan[] = [];
-  let lastStart = Number.POSITIVE_INFINITY;
+  let lastEnd = -1;
 
   let skipped = 0;
   for (const f of sorted) {
@@ -124,7 +124,7 @@ export function planAnnotations(findings: AnalyzeFinding[]): AnnotationPlan[] {
       normalized_fallback: normalizeText((f as any).normalized_snippet || "")
     });
 
-    if (typeof f.start === "number") lastStart = f.start;
+    lastEnd = end;
     if (ops.length >= MAX_ANNOTATE_OPS) break;
   }
   const g: any = globalThis as any;

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -8,7 +8,8 @@ import { postJSON, getStoredKey, getStoredSchema, setStoredSchema, ensureHeaders
 const oe: any = (globalThis as any).OfficeExtension;
 const gg: any = (globalThis as any);
 if (oe && oe.config) {
-  const isProd = typeof process !== "undefined" && process.env?.NODE_ENV === "production";
+  const env = gg.__ENV__ ?? (typeof process !== "undefined" ? process.env?.NODE_ENV : "production");
+  const isProd = env === "production";
   if (!isProd || gg.__ENABLE_EXTENDED_LOGS__) {
     // @ts-ignore
     oe.config.extendedErrorLogging = true;


### PR DESCRIPTION
## Summary
- guard Office extendedErrorLogging using runtime `__ENV__` and default to production
- cover missing env path in tests and clean up annotate planner

## Testing
- `cd word_addin_dev && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c517eda883259b769bdb40bb8d8d