### PR TITLE
fix: respect occurrence index in context-aware search

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -415,7 +415,7 @@ export async function applyOpsTracked(
         const sFull = body.search(searchText, searchOpts);
         sFull.load('items');
         await ctx.sync();
-        const fullRange = pick(sFull, 0);
+        const fullRange = pick(sFull, occIdx);
         if (fullRange) {
           const inner = fullRange.search(snippet, searchOpts);
           inner.load('items');


### PR DESCRIPTION
## Summary
- ensure context-aware clause replacement respects occurrence index

## Testing
- `pre-commit run --files word_addin_dev/app/assets/taskpane.ts word_addin_dev/taskpane.html`
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: test_companies_health_enabled asserts 403 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c527ed7883259732eb9019941d44