### PR TITLE
Add live backend test watcher and setup tests

### DIFF
--- a/ContractAI-Watch-Tests.local.ps1
+++ b/ContractAI-Watch-Tests.local.ps1
@@ -1,0 +1,12 @@
+# Запускает отдельным окном улучшенный watch всех бэкенд-тестов (ptw)
+$ErrorActionPreference = "Stop"
+$repo = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repo
+
+$tools = Join-Path $repo "tools\watch_backend_tests.ps1"
+if (-not (Test-Path $tools)) { throw "Missing $tools" }
+
+# Полный режим (ptw). Существующая кнопка не трогаем.
+Start-Process powershell -ArgumentList "-NoExit","-Command","`"$tools -All`""
+
+Write-Host "Launched improved backend test watcher (ptw). Close window to stop."

--- a/README.md
+++ b/README.md
@@ -107,3 +107,11 @@ rg -n --pcre2 "[\p{Cyrillic}]" contract_review_app core word_addin_dev | tee i18
 ```
 
 The generated `i18n_inventory.txt` should be empty in a clean repository.
+
+## Live test watch (improved)
+
+Установка: pip install -r requirements-dev.txt
+
+Запуск: .\ContractAI-Watch-Tests.local.ps1 (откроется окно ptw; редактируешь код — тесты идут автоматически)
+
+Быстрый режим (по желанию): .\tools\watch_backend_tests.ps1 -Fast (pytest -f loop-on-fail)

--- a/contract_review_app/tests/api/test_companies_health.py
+++ b/contract_review_app/tests/api/test_companies_health.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 
 from fastapi.testclient import TestClient
 
@@ -12,7 +13,12 @@ def _client(monkeypatch, feature: str | None, key: str | None):
         monkeypatch.setenv("CH_API_KEY", key)
     import contract_review_app.config as config
     importlib.reload(config)
+    import contract_review_app.api.integrations as integrations
     import contract_review_app.api.app as app_module
+    import contract_review_app.integrations.companies_house.client as ch_client
+    importlib.reload(ch_client)
+    ch_client.KEY = os.getenv("CH_API_KEY") or os.getenv("COMPANIES_HOUSE_API_KEY", "")
+    importlib.reload(integrations)
     importlib.reload(app_module)
     return TestClient(app_module.app)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-testpaths = contract_review_app/tests
+testpaths = contract_review_app/tests tests/dev
 addopts = -q -ra
 norecursedirs = _legacy_disabled
 pythonpath = .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ pytest-xdist==3.6.1
 build>=1.2.1
 fpdf2>=2.7
 openapi-spec-validator>=0.7
+pytest-watch>=4.2.0

--- a/tests/dev/test_watch_setup.py
+++ b/tests/dev/test_watch_setup.py
@@ -1,0 +1,26 @@
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]  # .../repo/contract_review_app/tests/dev/ -> repo
+
+def test_watch_scripts_exist():
+    tools = REPO_ROOT / "tools" / "watch_backend_tests.ps1"
+    launcher = REPO_ROOT / "ContractAI-Watch-Tests.local.ps1"
+    assert tools.exists(), f"{tools} must exist"
+    assert launcher.exists(), f"{launcher} must exist"
+
+def test_pytest_watch_installed():
+    try:
+        importlib.import_module("pytest_watch")
+    except Exception as e:
+        raise AssertionError(f"pytest-watch must be importable: {e}")
+
+def test_pytest_ini_present_and_points_to_tests():
+    ini = REPO_ROOT / "pytest.ini"
+    assert ini.exists(), "pytest.ini must exist"
+    content = ini.read_text(encoding="utf-8", errors="ignore")
+    assert "testpaths" in content, "pytest.ini should define testpaths"
+    # базовая проверка — твои тесты лежат в contract_review_app/tests
+    assert "contract_review_app/tests" in content.replace("\\", "/"), "pytest.ini must include contract_review_app/tests"

--- a/tools/watch_backend_tests.ps1
+++ b/tools/watch_backend_tests.ps1
@@ -1,0 +1,70 @@
+Param(
+  [switch]$Fast,   # быстрый режим: loop-on-fail (pytest -f -q)
+  [switch]$All     # полный режим: ptw (pytest-watch) - все тесты при каждом изменении
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-RepoRoot {
+  $here = Split-Path -Parent $MyInvocation.MyCommand.Path
+  while ($true) {
+    if (Test-Path (Join-Path $here "pytest.ini")) { return $here }
+    $parent = Split-Path -Parent $here
+    if ($parent -eq $here) { throw "pytest.ini not found above $($MyInvocation.MyCommand.Path)" }
+    $here = $parent
+  }
+}
+
+$RepoRoot = Resolve-RepoRoot
+Set-Location $RepoRoot
+
+# Активируем venv, если python не виден
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+  $venv = Join-Path $RepoRoot ".\.venv\Scripts\Activate.ps1"
+  if (Test-Path $venv) {
+    & $venv
+  } else {
+    Write-Warning "Virtual env not found, relying on global python."
+  }
+}
+
+# Базовые env (безопасные дефолты, не затираем если уже выставлены)
+if (-not $env:API_KEY) { $env:API_KEY = "local-test-key-123" }
+if (-not $env:CONTRACTAI_PROVIDER) { $env:CONTRACTAI_PROVIDER = "mock" }  # prod: 'azure'
+
+Write-Host "[watch] Repo: $RepoRoot"
+Write-Host "[watch] API_KEY=$($env:API_KEY)"
+Write-Host "[watch] CONTRACTAI_PROVIDER=$($env:CONTRACTAI_PROVIDER)"
+
+# Проверим наличие pytest
+python - << 'PYEOF'
+import sys
+try:
+    import pytest  # noqa
+except Exception as e:
+    print("! pytest is not installed:", e, file=sys.stderr)
+    sys.exit(1)
+PYEOF
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+if ($All) {
+  # Требует pytest-watch
+  python - << 'PYEOF'
+import sys
+try:
+    import pytest_watch  # noqa
+except Exception as e:
+    print("! pytest-watch is not installed:", e, file=sys.stderr)
+    sys.exit(1)
+PYEOF
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  Write-Host "[watch] Starting FULL watch via ptw (pytest-watch)..."
+  ptw --runner "pytest -q" --ignore _legacy_disabled --onfail "powershell -command [console]::beep(1000,200)"
+  exit $LASTEXITCODE
+}
+
+# По умолчанию: быстрый loop-on-fail
+Write-Host "[watch] Starting FAST loop-on-fail: pytest -f -q"
+python -m pytest -f -q
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- add watch scripts for backend tests and launcher
- document improved test watcher
- verify watch setup via new tests and fix company health tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`
- `pytest tests/dev/test_watch_setup.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c2d433729c8325a79b98279ab0f086