### PR TITLE
Add live backend test watcher and setup tests

### DIFF
--- a/ContractAI-Watch-Tests.local.ps1
+++ b/ContractAI-Watch-Tests.local.ps1
@@ -7,6 +7,7 @@ $tools = Join-Path $repo "tools\watch_backend_tests.ps1"
 if (-not (Test-Path $tools)) { throw "Missing $tools" }
 
 # Полный режим (ptw). Существующая кнопка не трогаем.
-Start-Process powershell -ArgumentList "-NoExit","-Command","`"$tools -All`""
+# Use -File so the script runs even when the repo path contains spaces.
+Start-Process powershell -ArgumentList "-NoExit", "-File", "`"$tools`"", "-All"
 
 Write-Host "Launched improved backend test watcher (ptw). Close window to stop."


### PR DESCRIPTION
## Summary
- avoid quoting bug so watch backend tests script runs even when repo path has spaces

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`
- `pytest tests/dev/test_watch_setup.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8cf21cc83258bc5510e4991667e