### PR TITLE
fix: safe Office bootstrap and insert

### DIFF
--- a/word_addin_dev/app/__tests__/annotate_plan.test.ts
+++ b/word_addin_dev/app/__tests__/annotate_plan.test.ts
@@ -33,6 +33,12 @@ describe('annotate scheduler', () => {
     expect(ops.length).toBe(0);
   });
 
+  it('returns empty array for non-array input', () => {
+    // @ts-expect-error deliberately passing invalid type
+    const ops = planAnnotations('nope');
+    expect(ops.length).toBe(0);
+  });
+
   it('merges overlapping anchors', async () => {
     const body = {
       context: { sync: async () => {}, trackedObjects: { add: () => {} } },

--- a/word_addin_dev/app/__tests__/bootstrap.test.ts
+++ b/word_addin_dev/app/__tests__/bootstrap.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('startPanel bootstrap', () => {
+  it('waits for Office.onReady before wiring', async () => {
+    (globalThis as any).__CAI_TESTING__ = true;
+    const qSpy = vi.fn(() => null);
+    (globalThis as any).document = {
+      querySelector: qSpy,
+      getElementById: () => null,
+      addEventListener: () => {},
+      readyState: 'complete'
+    } as any;
+    (globalThis as any).localStorage = { getItem: () => '', setItem: () => {} };
+    (globalThis as any).fetch = vi.fn(async () => ({ json: async () => ({}) }));
+    const mod = await import('../src/panel/index');
+    let readyResolve: () => void;
+    const onReady = vi.fn(() => new Promise<void>(res => { readyResolve = res; }));
+    (globalThis as any).Office = { onReady };
+    const p = mod.startPanel();
+    expect(onReady).toHaveBeenCalled();
+    expect(qSpy).not.toHaveBeenCalled();
+    readyResolve();
+    await p;
+    expect(qSpy).toHaveBeenCalled();
+  });
+});

--- a/word_addin_dev/app/__tests__/insertIntoWord.test.ts
+++ b/word_addin_dev/app/__tests__/insertIntoWord.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+
+describe('onInsertIntoWord', () => {
+  it('does not throw when DOM elements are missing', async () => {
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).document = {
+      querySelector: () => null,
+      getElementById: () => null,
+    } as any;
+    const mod = await import('../src/panel/index');
+    await expect(mod.onInsertIntoWord()).resolves.toBeUndefined();
+  });
+});

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -91,7 +91,8 @@ export const MAX_ANNOTATE_OPS = 200;
  */
 export function planAnnotations(findings: AnalyzeFinding[]): AnnotationPlan[] {
   const base = normalizeText((globalThis as any).__lastAnalyzed || "");
-  const deduped = dedupeFindings(findings || []);
+  const list = Array.isArray(findings) ? findings : [];
+  const deduped = dedupeFindings(list);
   const sorted = deduped
     .slice()
     .sort((a, b) => (a.start ?? Number.POSITIVE_INFINITY) - (b.start ?? Number.POSITIVE_INFINITY));

--- a/word_addin_dev/app/src/panel/analyze.flow.spec.ts
+++ b/word_addin_dev/app/src/panel/analyze.flow.spec.ts
@@ -47,9 +47,11 @@ describe('dev bootstrap', () => {
       return { status: 200, json: async () => ({}) } as any
     }
     ;(globalThis as any).Word = { run: async (fn: any) => fn({ document: { body: { load: () => {}, text: '' }, getSelection: () => ({ load: () => {}, text: '' }) }, sync: async () => {} }) }
-    ;(globalThis as any).Office = { onReady: () => Promise.resolve() }
+    ;(globalThis as any).Office = { onReady: () => Promise.resolve() };
 
-    await import('./index')
+    (globalThis as any).__CAI_TESTING__ = true;
+    const mod = await import('./index')
+    await mod.startPanel()
 
     expect(store['api_key']).toBe('local-test-key-123')
     expect(store['schema_version']).toBe('1.5')

--- a/word_addin_dev/app/src/panel/taskpane.html
+++ b/word_addin_dev/app/src/panel/taskpane.html
@@ -65,7 +65,8 @@ pre{background:#f0f0f0;padding:8px;border-radius:4px;white-space:pre-wrap;}
 </section>
 
 <section id="draftPane" class="hidden">
-  <textarea id="draftText"></textarea>
+  <button id="btnInsertIntoWord" class="btn" hidden>Insert result into Word</button>
+  <textarea id="txtDraft"></textarea>
   <div>
     <button id="btnPreviewDiff" disabled>Preview diff</button>
     <button id="btnApplyTracked" disabled>Apply (tracked + comment)</button>


### PR DESCRIPTION
## Summary
- defer panel wiring until both DOM and Office are ready
- insert drafts into Word safely via null-checked DOM helpers
- guard annotate planner from non-array findings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8b877108325a191628f364ab58e