### PR TITLE
Initialize Violins audio after DOM load

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -10,6 +10,8 @@ import {
   setApiKey,
 } from "./store";
 
+declare const Violins: { initAudio: () => void };
+
 // enable rich debug when OfficeExtension is available
 const oe: any = (globalThis as any).OfficeExtension;
 const gg: any = (globalThis as any);
@@ -1026,6 +1028,7 @@ async function bootstrap(info?: Office.OfficeInfo) {
 
 if (!(globalThis as any).__CAI_TESTING__) {
   document.addEventListener("DOMContentLoaded", () => {
+    Violins.initAudio();
     Office.onReady(info => bootstrap(info));
   });
 }


### PR DESCRIPTION
## Summary
- Initialize Violins audio engine after DOM loads in taskpane entrypoint
- Declare global Violins type for TypeScript compilation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `PYTHONPATH=. pytest contract_review_app/tests -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c2dd6386308325aff1fab8370dea0e