### PR TITLE
Guard DOM element lookup before styling in panel self-test

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/panel_selftest.html
+++ b/contract_review_app/contract_review_app/static/panel/panel_selftest.html
@@ -120,8 +120,10 @@
     await import("./app/assets/store.js?v=DEV");
     const existingKey = localStorage.getItem('api_key') || (window.CAI?.Store?.get?.().apiKey);
     if (existingKey) {
-      document.querySelector('label[for="apiKeyInput"]').style.display = 'none';
-      document.getElementById('apiKeyInput').style.display = 'none';
+      const lbl = document.querySelector('label[for="apiKeyInput"]');
+      if (lbl) lbl.style.display = 'none';
+      const inputEl = document.getElementById('apiKeyInput');
+      if (inputEl) inputEl.style.display = 'none';
     }
     await import("./app/assets/api-client.js?v=DEV");
     await import("./app/selftest.js?v=DEV");

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -120,8 +120,10 @@
     await import("./app/assets/store.js?v=DEV");
     const existingKey = localStorage.getItem('api_key') || (window.CAI?.Store?.get?.().apiKey);
     if (existingKey) {
-      document.querySelector('label[for="apiKeyInput"]').style.display = 'none';
-      document.getElementById('apiKeyInput').style.display = 'none';
+      const lbl = document.querySelector('label[for="apiKeyInput"]');
+      if (lbl) lbl.style.display = 'none';
+      const inputEl = document.getElementById('apiKeyInput');
+      if (inputEl) inputEl.style.display = 'none';
     }
     await import("./app/assets/api-client.js?v=DEV");
     await import("./app/selftest.js?v=DEV");


### PR DESCRIPTION
## Summary
- ensure API key label and input elements exist before applying `style.display` in panel self-test pages

## Testing
- `pre-commit run --files contract_review_app/contract_review_app/static/panel/panel_selftest.html word_addin_dev/panel_selftest.html`


------
https://chatgpt.com/codex/tasks/task_e_68c2dd6223048325a24a0b1457cebc96