### PR TITLE
Initialize Violins audio after DOM load

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1028,7 +1028,9 @@ async function bootstrap(info?: Office.OfficeInfo) {
 
 if (!(globalThis as any).__CAI_TESTING__) {
   document.addEventListener("DOMContentLoaded", () => {
-    Violins.initAudio();
+    if (typeof Violins !== "undefined" && typeof Violins.initAudio === "function") {
+      Violins.initAudio();
+    }
     Office.onReady(info => bootstrap(info));
   });
 }


### PR DESCRIPTION
## Summary
- Initialize Violins audio engine after DOM loads in taskpane entrypoint
- Declare global Violins type for TypeScript compilation
- Guard against missing Violins global before calling `initAudio`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `PYTHONPATH=. pytest contract_review_app/tests -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c2dfeeadd4832589e3bc4bd08c1158