### PR TITLE
ci: run add-in tests without Jest flag

### DIFF
--- a/.github/workflows/addin-ci.yml
+++ b/.github/workflows/addin-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm --prefix word_addin_dev ci
       - run: npm --prefix word_addin_dev run lint
         continue-on-error: true
-      - run: npm --prefix word_addin_dev test
+      - run: npm --prefix word_addin_dev run test
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- ensure add-in CI runs Vitest without Jest-specific flags

## Testing
- `npx --yes jest`
- `npm --prefix word_addin_dev run test` *(fails: Failed to load url @testing-library/jest-dom/vitest)*
- `pytest -q tests/panel tests/tools` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c32b85a72083258f5e04c47906251b