### PR TITLE
fix(add-in): restore ESLint core rules

### DIFF
--- a/word_addin_dev/.eslintrc.cjs
+++ b/word_addin_dev/.eslintrc.cjs
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
-  extends: ['plugin:@typescript-eslint/recommended'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   ignorePatterns: ['dist', 'taskpane.bundle.js', 'app/assets'],
   overrides: [
     {


### PR DESCRIPTION
## Summary
- extend Word add-in ESLint config with `eslint:recommended` to retain core rules

## Testing
- `npm test` (word_addin_dev)
- `npm run lint` (word_addin_dev)
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `python tools/doctor.py --out /tmp/doctor.json --json` *(fails: ModuleNotFoundError: No module named 'starlette')*


------
https://chatgpt.com/codex/tasks/task_e_68c32b785a4c8325a7ca450a705575dd