### PR TITLE
feat(word-addin): add startup selftest and unload handling

### DIFF
--- a/word_addin_dev/app/__tests__/bootstrap.once.spec.ts
+++ b/word_addin_dev/app/__tests__/bootstrap.once.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('bootstrap once', () => {
+  beforeEach(() => { vi.resetModules(); });
+  it('invokes wireUI only once', async () => {
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
+    (globalThis as any).Word = { Revision:{}, Comment:{}, SearchOptions:{}, ContentControl:{} } as any;
+    (globalThis as any).document = { querySelector: () => null, getElementById: () => null, addEventListener: () => {} } as any;
+    const mod = await import('../assets/taskpane.ts');
+    mod.invokeBootstrap();
+    mod.invokeBootstrap();
+    expect(mod.getBootstrapCount()).toBe(1);
+  });
+});

--- a/word_addin_dev/app/__tests__/dev.gating.spec.ts
+++ b/word_addin_dev/app/__tests__/dev.gating.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mkDoc = () => {
+  const el: any = { disabled: false, style: { display: '' }, addEventListener: () => {}, classList: { remove: () => {} }, removeAttribute: () => {} };
+  return {
+    getElementById: (id: string) => id === 'btnTest' ? el : null,
+    querySelector: (sel: string) => sel === '#btnTest' ? el : null,
+  } as any;
+};
+
+describe('dev gating', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
+    (globalThis as any).Word = { Revision:{}, Comment:{}, SearchOptions:{}, ContentControl:{} } as any;
+  });
+
+  it('hides test button in prod', async () => {
+    (globalThis as any).ENV_MODE = 'prod';
+    (globalThis as any).document = mkDoc();
+    const { wireUI } = await import('../assets/taskpane.ts');
+    wireUI();
+    const btn = document.getElementById('btnTest') as any;
+    expect(btn.style.display).toBe('none');
+  });
+
+  it('shows test button in dev', async () => {
+    (globalThis as any).ENV_MODE = 'dev';
+    (globalThis as any).document = mkDoc();
+    const { wireUI } = await import('../assets/taskpane.ts');
+    wireUI();
+    const btn = document.getElementById('btnTest') as any;
+    expect(btn.style.display).toBe('');
+  });
+});

--- a/word_addin_dev/app/__tests__/dom.ids.spec.ts
+++ b/word_addin_dev/app/__tests__/dom.ids.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('dom ids', () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it('reads risk threshold from selectRiskThreshold', async () => {
+    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).document = {
+      getElementById: (id: string) => id === 'selectRiskThreshold' ? { value: 'high' } : null,
+    } as any;
+    const mod = await import('../assets/taskpane.ts');
+    expect(mod.getRiskThreshold()).toBe('high');
+  });
+
+  it('missing selectRiskThreshold defaults to medium', async () => {
+    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).document = { getElementById: () => null } as any;
+    const mod = await import('../assets/taskpane.ts');
+    expect(mod.getRiskThreshold()).toBe('medium');
+  });
+});

--- a/word_addin_dev/app/__tests__/health.positive.spec.ts
+++ b/word_addin_dev/app/__tests__/health.positive.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+
+describe('health positive', () => {
+  it('returns ok', async () => {
+    (globalThis as any).window = globalThis;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}) , headers: new Headers(), status:200 });
+    const { apiHealth } = await import('../assets/api-client.ts');
+    const res = await apiHealth();
+    expect(res.ok).toBe(true);
+  });
+});

--- a/word_addin_dev/app/__tests__/postJson.timeout.spec.ts
+++ b/word_addin_dev/app/__tests__/postJson.timeout.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+
+describe('postJson timeout', () => {
+  it('aborts on timeout', async () => {
+    (globalThis as any).window = globalThis;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    (globalThis as any).fetch = (_:any, opts:any) => new Promise((_res, rej) => {
+      opts.signal.addEventListener('abort', () => rej(new DOMException('aborted','AbortError')));
+    });
+    const { postJson } = await import('../assets/api-client.ts');
+    await expect(postJson('/x', {}, 5)).rejects.toThrow();
+  });
+});

--- a/word_addin_dev/app/__tests__/requirement.sets.spec.ts
+++ b/word_addin_dev/app/__tests__/requirement.sets.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mkDoc = (ids: string[]) => {
+  const elements: Record<string, any> = {};
+  ids.forEach(id => elements[id] = { disabled: false, style: { display: '' }, addEventListener: () => {}, classList: { remove: () => {} }, removeAttribute: () => {} });
+  return {
+    getElementById: (id: string) => elements[id] || null,
+    querySelector: (sel: string) => elements[sel.replace('#','')] || null,
+  } as any;
+};
+
+describe('requirement sets support', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
+  });
+
+  it('disables revisions buttons when revisions unsupported', async () => {
+    (globalThis as any).document = mkDoc(['btnApplyTracked','btnAcceptAll','btnRejectAll']);
+    (globalThis as any).Word = { Comment: {}, SearchOptions: {}, ContentControl: {} } as any;
+    const { wireUI } = await import('../assets/taskpane.ts');
+    wireUI();
+    const btn = document.getElementById('btnApplyTracked') as any;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('disables comment features when comments unsupported', async () => {
+    (globalThis as any).document = mkDoc(['btnAcceptAll']);
+    (globalThis as any).Word = { Revision: {}, SearchOptions: {}, ContentControl: {} } as any;
+    const { wireUI } = await import('../assets/taskpane.ts');
+    wireUI();
+    const btn = document.getElementById('btnAcceptAll') as any;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('disables search navigation when search unsupported', async () => {
+    (globalThis as any).document = mkDoc(['btnPrevIssue','btnNextIssue','btnQARecheck']);
+    (globalThis as any).Word = { Revision: {}, Comment: {}, ContentControl: {} } as any;
+    const { wireUI } = await import('../assets/taskpane.ts');
+    wireUI();
+    expect((document.getElementById('btnPrevIssue') as any).disabled).toBe(true);
+    expect((document.getElementById('btnQARecheck') as any).disabled).toBe(true);
+  });
+
+  it('disables annotate when content controls unsupported', async () => {
+    (globalThis as any).document = mkDoc(['btnAnnotate']);
+    (globalThis as any).Word = { Revision: {}, Comment: {}, SearchOptions: {} } as any;
+    const { wireUI } = await import('../assets/taskpane.ts');
+    wireUI();
+    expect((document.getElementById('btnAnnotate') as any).disabled).toBe(true);
+  });
+});

--- a/word_addin_dev/app/__tests__/startup.selftest.spec.ts
+++ b/word_addin_dev/app/__tests__/startup.selftest.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const baseEnv = () => {
+  (globalThis as any).window = globalThis;
+  (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
+  (globalThis as any).Word = { Revision:{}, Comment:{}, SearchOptions:{}, ContentControl:{} } as any;
+  (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+  (globalThis as any).__CAI_TESTING__ = true;
+};
+
+describe('startup selftest', () => {
+  beforeEach(() => { vi.resetModules(); });
+  it('fails when id missing', async () => {
+    baseEnv();
+    (globalThis as any).document = { getElementById: (id:string) => id==='btnAnalyze'? { setAttribute: () => {}, textContent: '' }: null, querySelector: () => null } as any;
+    (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}) , headers: new Headers(), status:200 });
+    const { runStartupSelftest } = await import('../assets/taskpane.ts');
+    const res = await runStartupSelftest();
+    expect(res.ok).toBe(false);
+  });
+
+  it('fails when health fails', async () => {
+    baseEnv();
+    (globalThis as any).document = { getElementById: () => ({ setAttribute: () => {}, textContent: '' }) , querySelector: () => null } as any;
+    (globalThis as any).fetch = async () => { throw new Error('fail'); };
+    const { runStartupSelftest } = await import('../assets/taskpane.ts');
+    const res = await runStartupSelftest();
+    expect(res.ok).toBe(false);
+  });
+
+  it('passes on happy path', async () => {
+    baseEnv();
+    (globalThis as any).document = { getElementById: () => ({ setAttribute: () => {}, textContent: '' }) , querySelector: () => null } as any;
+    (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}) , headers: new Headers(), status:200 });
+    const { runStartupSelftest } = await import('../assets/taskpane.ts');
+    const res = await runStartupSelftest();
+    expect(res.ok).toBe(true);
+  });
+});

--- a/word_addin_dev/app/__tests__/unload.spec.ts
+++ b/word_addin_dev/app/__tests__/unload.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+
+const mkEnv = () => {
+  const handlers: Record<string, ((ev: any) => void)[]> = {};
+  const win: any = {
+    addEventListener: (n: string, f: any) => { (handlers[n]||(handlers[n]=[])).push(f); },
+    dispatchEvent: (ev: Event) => { (handlers[ev.type]||[]).forEach(fn => fn(ev)); },
+  };
+  const prog = { className: 'progress', style: { display: 'block' } };
+  const doc: any = {
+    getElementById: (id: string) => id === 'progress' ? prog : null,
+    querySelector: () => null,
+    querySelectorAll: (sel: string) => sel === '.progress' ? [prog] : [],
+    addEventListener: () => {},
+  };
+  (globalThis as any).window = win;
+  (globalThis as any).document = doc;
+  (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+  (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
+  (globalThis as any).Word = { Revision: {}, Comment: {}, SearchOptions: {}, ContentControl: {} } as any;
+  (globalThis as any).__CAI_TESTING__ = true;
+  return { handlers, win, doc };
+};
+
+describe('unload cleanup', () => {
+  it('aborts pending fetch and hides progress', async () => {
+    const { handlers, win, doc } = mkEnv();
+    (globalThis as any).fetch = (_:any, opts:any = {}) => new Promise((_res, rej) => {
+      const sig = opts.signal;
+      if (sig) sig.addEventListener('abort', () => rej(new DOMException('aborted','AbortError')));
+    });
+    const { invokeBootstrap } = await import('../assets/taskpane.ts');
+    invokeBootstrap();
+    const { postJson } = await import('../assets/api-client.ts');
+    const p = postJson('/x', {});
+    win.dispatchEvent(new Event('pagehide'));
+    await expect(p).rejects.toThrow();
+    expect((doc.getElementById('progress') as any).style.display).toBe('none');
+    expect(handlers['pagehide'].length).toBe(1);
+    invokeBootstrap();
+    expect(handlers['pagehide'].length).toBe(1);
+  });
+});

--- a/word_addin_dev/app/assets/pending.ts
+++ b/word_addin_dev/app/assets/pending.ts
@@ -1,0 +1,29 @@
+export const pendingFetches = new Set<AbortController>();
+export const pendingTimers = new Set<any>();
+
+export function registerFetch(ctrl: AbortController) { pendingFetches.add(ctrl); }
+export function deregisterFetch(ctrl: AbortController) { pendingFetches.delete(ctrl); }
+export function registerTimer(id: any) { pendingTimers.add(id); }
+export function deregisterTimer(id: any) { pendingTimers.delete(id); }
+
+export function clearPending() {
+  pendingFetches.forEach(c => { try { c.abort(); } catch {} });
+  pendingFetches.clear();
+  pendingTimers.forEach(t => { try { clearTimeout(t); clearInterval(t); } catch {} });
+  pendingTimers.clear();
+  try {
+    document.querySelectorAll('.progress').forEach(el => { (el as HTMLElement).style.display = 'none'; });
+  } catch {}
+}
+
+export function registerUnloadHandlers() {
+  if ((globalThis as any).__pendingUnloadReg) return;
+  (globalThis as any).__pendingUnloadReg = true;
+  const handler = () => { clearPending(); (globalThis as any).__wasUnloaded = true; };
+  window.addEventListener('pagehide', handler);
+  window.addEventListener('unload', handler);
+  document.addEventListener('visibilitychange', () => { if (document.visibilityState === 'hidden') handler(); });
+}
+
+export function wasUnloaded(): boolean { return !!(globalThis as any).__wasUnloaded; }
+export function resetUnloadFlag() { (globalThis as any).__wasUnloaded = false; }

--- a/word_addin_dev/app/assets/supports.ts
+++ b/word_addin_dev/app/assets/supports.ts
@@ -1,0 +1,29 @@
+export type FeatureSupport = {
+  revisions: boolean;
+  comments: boolean;
+  search: boolean;
+  contentControls: boolean;
+};
+
+export function detectSupports(): FeatureSupport {
+  const req = !!(globalThis as any).Office?.context?.requirements?.isSetSupported?.('WordApi','1.4');
+  const w: any = (globalThis as any).Word || {};
+  const rev = req && !!w?.Revision;
+  const com = req && !!w?.Comment;
+  const srch = req && !!w?.SearchOptions;
+  const cc = req && !!w?.ContentControl;
+  return { revisions: rev, comments: com, search: srch, contentControls: cc };
+}
+
+export const supports = {
+  revisions: () => detectSupports().revisions,
+  comments: () => detectSupports().comments,
+  search: () => detectSupports().search,
+  contentControls: () => detectSupports().contentControls,
+};
+
+export function logSupportMatrix() {
+  const s = detectSupports();
+  try { console.log('support matrix', s); } catch {}
+  return s;
+}


### PR DESCRIPTION
## Summary
- add feature detection utility and disable unsupported controls
- implement unload cleanup registry and startup self-test
- gate dev controls by ENV_MODE and add network timeouts

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run build:panel` *(fails: ModuleNotFoundError: No module named 'bump_build')*

------
https://chatgpt.com/codex/tasks/task_e_68c32d598b848325ab58b6cc81995a20