### PR TITLE
Fix panel build imports and unify panel startup checks

### DIFF
--- a/tests/tools/test_build_panel.py
+++ b/tests/tools/test_build_panel.py
@@ -26,3 +26,38 @@ def test_build_panel_copies_and_substitutes(tmp_path, monkeypatch):
         out = (dest / name).read_text()
         assert '123' in out and '__BUILD_TS__' not in out
     assert (dest / 'app' / 'assets' / 'dummy.txt').exists()
+
+
+def test_build_panel_cli(tmp_path):
+    root = tmp_path / 'repo'
+    tools_dir = root / 'tools'
+    src = root / 'word_addin_dev'
+    dest = root / 'contract_review_app' / 'contract_review_app' / 'static' / 'panel'
+    assets = src / 'app' / 'assets'
+    assets.mkdir(parents=True, exist_ok=True)
+    for name in ['taskpane.html', 'taskpane.bundle.js', 'panel_selftest.html']:
+        (src / name).write_text(f'{name} __BUILD_TS__')
+    (assets / 'dummy.txt').write_text('x')
+
+    # copy build_panel script
+    tools_dir.mkdir(parents=True)
+    script_path = tools_dir / 'build_panel.py'
+    from pathlib import Path
+    script_path.write_text(Path(bp.__file__).read_text())
+    # write simple bump_build
+    (root / 'bump_build.py').write_text(
+        'from pathlib import Path\n'
+        'def bump_build(root: Path | None = None):\n'
+        '    root = Path(root or ".")\n'
+        '    for name in ["taskpane.html","taskpane.bundle.js","panel_selftest.html"]:\n'
+        '        p = root/"word_addin_dev"/name\n'
+        '        p.write_text(p.read_text().replace("__BUILD_TS__", "123"))\n'
+    )
+
+    import subprocess, sys
+    subprocess.check_call([sys.executable, 'tools/build_panel.py'], cwd=root)
+
+    for name in ['taskpane.html', 'taskpane.bundle.js', 'panel_selftest.html']:
+        out = (dest / name).read_text()
+        assert '123' in out and '__BUILD_TS__' not in out
+    assert (dest / 'app' / 'assets' / 'dummy.txt').exists()

--- a/tools/build_panel.py
+++ b/tools/build_panel.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 
 from pathlib import Path
 import shutil
+import sys
+
+# Ensure project root on sys.path so direct invocation works
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(ROOT.as_posix())
 
 from bump_build import bump_build
-
-ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "word_addin_dev"
 DEST = ROOT / "contract_review_app" / "contract_review_app" / "static" / "panel"
 

--- a/word_addin_dev/app/__tests__/dev.gating.spec.ts
+++ b/word_addin_dev/app/__tests__/dev.gating.spec.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const html = readFileSync(new URL('../../taskpane.html', import.meta.url), 'utf-8');
+if (!html.includes('id="btnTest"')) throw new Error('btnTest missing from canonical HTML');
 
 const mkDoc = () => {
   const el: any = { disabled: false, style: { display: '' }, addEventListener: () => {}, classList: { remove: () => {} }, removeAttribute: () => {} };

--- a/word_addin_dev/app/__tests__/dom.ids.spec.ts
+++ b/word_addin_dev/app/__tests__/dom.ids.spec.ts
@@ -1,23 +1,14 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const html = readFileSync(new URL('../../taskpane.html', import.meta.url), 'utf-8');
 
 describe('dom ids', () => {
-  beforeEach(() => { vi.resetModules(); });
-
-  it('reads risk threshold from selectRiskThreshold', async () => {
-    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
-    (globalThis as any).__CAI_TESTING__ = true;
-    (globalThis as any).document = {
-      getElementById: (id: string) => id === 'selectRiskThreshold' ? { value: 'high' } : null,
-    } as any;
-    const mod = await import('../assets/taskpane.ts');
-    expect(mod.getRiskThreshold()).toBe('high');
-  });
-
-  it('missing selectRiskThreshold defaults to medium', async () => {
-    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
-    (globalThis as any).__CAI_TESTING__ = true;
-    (globalThis as any).document = { getElementById: () => null } as any;
-    const mod = await import('../assets/taskpane.ts');
-    expect(mod.getRiskThreshold()).toBe('medium');
+  it('contains required ids', () => {
+    const required = ['btnAnalyze', 'selectRiskThreshold'];
+    for (const id of required) {
+      expect(html).toContain(`id="${id}"`);
+    }
+    expect(html).not.toContain('id="riskThreshold"');
   });
 });

--- a/word_addin_dev/app/__tests__/health.negatives.spec.ts
+++ b/word_addin_dev/app/__tests__/health.negatives.spec.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
-describe('apiHealth negatives', () => {
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('checkHealth negatives', () => {
+  beforeEach(() => { vi.resetModules(); });
+
   it('handles non-ok response', async () => {
     (globalThis as any).window = globalThis;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
@@ -9,8 +12,8 @@ describe('apiHealth negatives', () => {
       headers: new Headers(),
       status: 500,
     });
-    const mod = await import('../assets/api-client.ts');
-    const res = await mod.apiHealth();
+    const { checkHealth } = await import('../assets/health.ts');
+    const res = await checkHealth();
     expect(res.ok).toBe(false);
     expect(res.json).toEqual({ foo: 1 });
   });
@@ -19,7 +22,7 @@ describe('apiHealth negatives', () => {
     (globalThis as any).window = globalThis;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
     (globalThis as any).fetch = vi.fn().mockRejectedValue(new Error('boom'));
-    const mod = await import('../assets/api-client.ts');
-    await expect(mod.apiHealth()).rejects.toThrow('boom');
+    const { checkHealth } = await import('../assets/health.ts');
+    await expect(checkHealth()).rejects.toThrow('boom');
   });
 });

--- a/word_addin_dev/app/__tests__/health.positive.spec.ts
+++ b/word_addin_dev/app/__tests__/health.positive.spec.ts
@@ -1,12 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('health positive', () => {
+  beforeEach(() => { vi.resetModules(); });
+
   it('returns ok', async () => {
     (globalThis as any).window = globalThis;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
-    (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}) , headers: new Headers(), status:200 });
-    const { apiHealth } = await import('../assets/api-client.ts');
-    const res = await apiHealth();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    (globalThis as any).fetch = fetchMock;
+    const { checkHealth } = await import('../assets/health.ts');
+    const res = await checkHealth({ backend: 'http://x' });
     expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const res2 = await checkHealth({ backend: 'http://x' });
+    expect(res2.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/word_addin_dev/app/__tests__/postJson.timeout.spec.ts
+++ b/word_addin_dev/app/__tests__/postJson.timeout.spec.ts
@@ -10,4 +10,14 @@ describe('postJson timeout', () => {
     const { postJson } = await import('../assets/api-client.ts');
     await expect(postJson('/x', {}, 5)).rejects.toThrow();
   });
+
+  it('health check times out', async () => {
+    (globalThis as any).window = globalThis;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    (globalThis as any).fetch = (_:any, opts:any) => new Promise((_res, rej) => {
+      opts.signal.addEventListener('abort', () => rej(new DOMException('aborted','AbortError')));
+    });
+    const { checkHealth } = await import('../assets/health.ts');
+    await expect(checkHealth({ timeoutMs: 5 })).rejects.toThrow();
+  });
 });

--- a/word_addin_dev/app/__tests__/riskThreshold.read.spec.ts
+++ b/word_addin_dev/app/__tests__/riskThreshold.read.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('risk threshold read', () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it('reads selectRiskThreshold', async () => {
+    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).document = {
+      getElementById: (id: string) => id === 'selectRiskThreshold' ? { value: 'high' } : null,
+    } as any;
+    const mod = await import('../assets/taskpane.ts');
+    expect(mod.getRiskThreshold()).toBe('high');
+  });
+
+  it('defaults to medium when missing', async () => {
+    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).document = { getElementById: () => null } as any;
+    const mod = await import('../assets/taskpane.ts');
+    expect(mod.getRiskThreshold()).toBe('medium');
+  });
+});

--- a/word_addin_dev/app/__tests__/startup.selftest.spec.ts
+++ b/word_addin_dev/app/__tests__/startup.selftest.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const baseEnv = () => {
   (globalThis as any).window = globalThis;
-  (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
+  (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true }, host: 'Word' } } as any;
   (globalThis as any).Word = { Revision:{}, Comment:{}, SearchOptions:{}, ContentControl:{} } as any;
   (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
   (globalThis as any).__CAI_TESTING__ = true;
@@ -10,30 +10,37 @@ const baseEnv = () => {
 
 describe('startup selftest', () => {
   beforeEach(() => { vi.resetModules(); });
+
   it('fails when id missing', async () => {
     baseEnv();
-    (globalThis as any).document = { getElementById: (id:string) => id==='btnAnalyze'? { setAttribute: () => {}, textContent: '' }: null, querySelector: () => null } as any;
-    (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}) , headers: new Headers(), status:200 });
-    const { runStartupSelftest } = await import('../assets/taskpane.ts');
-    const res = await runStartupSelftest();
+    (globalThis as any).document = { getElementById: (id:string) => id==='btnAnalyze'? { setAttribute: () => {}, textContent: ''}: null, querySelector: () => null } as any;
+    (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { runStartupSelftest } = await import('../assets/startup.selftest.ts');
+    const res = await runStartupSelftest('https://x');
     expect(res.ok).toBe(false);
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/^Startup FAIL:/));
   });
 
   it('fails when health fails', async () => {
     baseEnv();
     (globalThis as any).document = { getElementById: () => ({ setAttribute: () => {}, textContent: '' }) , querySelector: () => null } as any;
-    (globalThis as any).fetch = async () => { throw new Error('fail'); };
-    const { runStartupSelftest } = await import('../assets/taskpane.ts');
-    const res = await runStartupSelftest();
+    (globalThis as any).fetch = vi.fn().mockRejectedValue(new Error('fail'));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { runStartupSelftest } = await import('../assets/startup.selftest.ts');
+    const res = await runStartupSelftest('https://x');
     expect(res.ok).toBe(false);
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/^Startup FAIL:/));
   });
 
   it('passes on happy path', async () => {
     baseEnv();
     (globalThis as any).document = { getElementById: () => ({ setAttribute: () => {}, textContent: '' }) , querySelector: () => null } as any;
     (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}) , headers: new Headers(), status:200 });
-    const { runStartupSelftest } = await import('../assets/taskpane.ts');
-    const res = await runStartupSelftest();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { runStartupSelftest } = await import('../assets/startup.selftest.ts');
+    const res = await runStartupSelftest('https://x');
     expect(res.ok).toBe(true);
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/^Startup OK \| build=.*\| host=Word \| req=1\.4 \| features=\{.*\} \| backend=https:\/\/x$/));
   });
 });

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -12,6 +12,7 @@ export type Meta = {
 
 import { getApiKeyFromStore, getSchemaFromStore } from "./store.ts";
 import { registerFetch, deregisterFetch, registerTimer, deregisterTimer } from './pending.ts';
+import { checkHealth } from './health.ts';
 
 export type AnalyzeFinding = {
   rule_id: string;
@@ -154,8 +155,8 @@ async function req(path: string, { method='GET', body=null, key=path, timeoutMs=
   return { ok: r.ok, json, resp: r, meta };
 }
 
-export async function apiHealth() {
-  return req('/health', { key: 'health' });
+export async function apiHealth(backend?: string) {
+  return checkHealth({ backend });
 }
 
 export async function apiAnalyze(text: string) {

--- a/word_addin_dev/app/assets/bootstrap.ts
+++ b/word_addin_dev/app/assets/bootstrap.ts
@@ -1,10 +1,12 @@
+import { checkHealth } from './health.ts';
+
 export async function bootstrapHeaders() {
   // DEV ONLY: auto-populate schema and API key
   if (!localStorage.getItem('schema_version')) {
     try {
-      const h = await fetch('/health').then(r => r.json());
-      if (h && h.schema) {
-        localStorage.setItem('schema_version', String(h.schema));
+      const { json } = await checkHealth();
+      if (json && json.schema) {
+        localStorage.setItem('schema_version', String(json.schema));
       }
     } catch {}
   }

--- a/word_addin_dev/app/assets/health.ts
+++ b/word_addin_dev/app/assets/health.ts
@@ -1,0 +1,17 @@
+let cached: Promise<any> | null = null;
+
+export async function checkHealth(opts: { backend?: string; timeoutMs?: number } = {}) {
+  if (!cached) {
+    const backend = (opts.backend || '').replace(/\/+$/, '');
+    const url = backend ? `${backend}/health` : '/health';
+    const ctrl = new AbortController();
+    const timeout = opts.timeoutMs ?? 9000;
+    const t = setTimeout(() => ctrl.abort(), timeout);
+    cached = fetch(url, { signal: ctrl.signal }).then(async resp => {
+      clearTimeout(t);
+      const json = await resp.json().catch(() => ({}));
+      return { ok: resp.ok, json, resp };
+    });
+  }
+  return cached;
+}

--- a/word_addin_dev/app/assets/startup.selftest.ts
+++ b/word_addin_dev/app/assets/startup.selftest.ts
@@ -1,0 +1,38 @@
+import { logSupportMatrix } from './supports.ts';
+import { checkHealth } from './health.ts';
+
+export async function runStartupSelftest(backend: string) {
+  const missing: string[] = [];
+  ['btnAnalyze', 'selectRiskThreshold'].forEach(id => {
+    if (!document.getElementById(id)) missing.push(`missingID:${id}`);
+  });
+  if (!Office?.context?.requirements?.isSetSupported?.('WordApi', '1.4')) missing.push('req1.4:0');
+  const featsRaw = logSupportMatrix();
+  const features = {
+    revisions: featsRaw.revisions ? 1 : 0,
+    comments: featsRaw.comments ? 1 : 0,
+    search: featsRaw.search ? 1 : 0,
+    contentControls: featsRaw.contentControls ? 1 : 0,
+  } as Record<string, number>;
+  let healthOk = false;
+  try {
+    const res = await checkHealth({ backend });
+    healthOk = res.ok;
+    if (!healthOk) missing.push('health');
+  } catch {
+    missing.push('health:timeout');
+  }
+    const build = '__BUILD_TS__';
+  const host = (Office as any)?.context?.host || 'Word';
+  const ok = missing.length === 0;
+  const msg = ok
+    ? `Startup OK | build=${build} | host=${host} | req=1.4 | features=${JSON.stringify(features)} | backend=${backend}`
+    : `Startup FAIL: ${missing.join('; ')}`;
+  console.log(msg);
+  const badge = document.getElementById('startupBadge');
+  if (badge) {
+    badge.textContent = ok ? 'OK' : 'FAIL';
+    badge.setAttribute('data-status', ok ? 'ok' : 'fail');
+  }
+  return { ok, missing, features };
+}


### PR DESCRIPTION
## Summary
- fix tools/build_panel import path so script runs from repo root
- canonicalize panel HTML IDs and add risk-threshold tests
- introduce cached health check and shared startup self-test used across panel code

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run build:panel`
- `pytest tests/panel tests/tools` *(fails: assert 401 == 200, backend not running)*

------
https://chatgpt.com/codex/tasks/task_e_68c333caff1083258bea493682c79dc3