### PR TITLE
Enforce panel DOM contract and self-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build:panel": "python tools/build_panel.py"
+    "build:panel": "python tools/build_panel.py --run-tests"
   },
   "devDependencies": {
     "ts-node": "^10.9.2"

--- a/tools/build_panel.py
+++ b/tools/build_panel.py
@@ -9,6 +9,7 @@ panel artefacts from ``word_addin_dev`` into
 from __future__ import annotations
 
 from pathlib import Path
+import argparse
 import shutil
 import sys
 import subprocess
@@ -29,31 +30,33 @@ FILES = [
 ]
 
 
-def main() -> None:
-    # run vitest suite to ensure DOM contract before copying assets
-    subprocess.run(
-        [
-            "npm",
-            "--prefix",
-            "word_addin_dev",
-            "ci",
-        ],
-        check=True,
-        cwd=ROOT,
-    )
-    subprocess.run(
-        [
-            "npm",
-            "--prefix",
-            "word_addin_dev",
-            "run",
-            "test",
-            "--",
-            "--runInBand",
-        ],
-        check=True,
-        cwd=ROOT,
-    )
+def main(*, run_tests: bool = False) -> None:
+    """Build panel assets and optionally run vitest."""
+    if run_tests:
+        # run vitest suite to ensure DOM contract before copying assets
+        subprocess.run(
+            [
+                "npm",
+                "--prefix",
+                "word_addin_dev",
+                "ci",
+            ],
+            check=True,
+            cwd=ROOT,
+        )
+        subprocess.run(
+            [
+                "npm",
+                "--prefix",
+                "word_addin_dev",
+                "run",
+                "test",
+                "--",
+                "--runInBand",
+            ],
+            check=True,
+            cwd=ROOT,
+        )
 
     bump_build(ROOT)
 
@@ -66,4 +69,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run-tests",
+        action="store_true",
+        help="run npm install and vitest before copying assets",
+    )
+    main(run_tests=parser.parse_args().run_tests)


### PR DESCRIPTION
## Summary
- gate NPM install/test in build_panel behind --run-tests flag
- invoke build script with flag to keep DOM contract validation during builds

## Testing
- `pre-commit run --files tools/build_panel.py package.json`
- `pytest tests/tools/test_build_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3ab91a1108325af90729ae620a6fa