### PR TITLE
Enable vitest to load external bundle and simplify panel build tests

### DIFF
--- a/tools/build_panel.py
+++ b/tools/build_panel.py
@@ -51,8 +51,6 @@ def main(*, run_tests: bool = False) -> None:
                 "word_addin_dev",
                 "run",
                 "test",
-                "--",
-                "--runInBand",
             ],
             check=True,
             cwd=ROOT,

--- a/word_addin_dev/vitest.config.ts
+++ b/word_addin_dev/vitest.config.ts
@@ -5,4 +5,9 @@ export default defineConfig({
     include: ['app/**/__tests__/**/*.{test,spec}.ts?(x)', 'app/src/**/*.{test,spec}.ts?(x)'],
     setupFiles: ['./vitest.setup.ts'],
   },
+  server: {
+    fs: {
+      allow: ['..'],
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- allow Vitest to access files outside the word_addin_dev directory
- drop unsupported `--runInBand` flag from panel build script tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run build:panel`

------
https://chatgpt.com/codex/tasks/task_e_68c3e47e9c788325bbf895b31465a36e