### PR TITLE
Add busy indicator book with event bus and tests

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -11,7 +11,7 @@ export type Meta = {
 };
 
 import { getApiKeyFromStore, getSchemaFromStore } from "./store.ts";
-import { registerFetch, deregisterFetch, registerTimer, deregisterTimer } from './pending.ts';
+import { registerFetch, deregisterFetch, registerTimer, deregisterTimer, withBusy } from './pending.ts';
 import { checkHealth } from './health.ts';
 
 export type AnalyzeFinding = {
@@ -91,72 +91,76 @@ function base(): string {
 }
 
 export async function postJSON(path: string, body: any, timeoutMs = 9000) {
-  const url = base() + path;
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  const schema = getSchemaFromStore() || '1.4';
-  headers['x-schema-version'] = schema;
-  const key = getApiKeyFromStore();
-  if (key) headers['x-api-key'] = key;
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
-  registerFetch(ctrl);
-  registerTimer(t);
-  try {
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body || {}),
-      credentials: 'include',
-      signal: ctrl.signal,
-    });
-    const json = await resp.json().catch(() => ({}));
-    return { resp, json };
-  } finally {
-    clearTimeout(t);
-    deregisterTimer(t);
-    deregisterFetch(ctrl);
-  }
+  return withBusy(async () => {
+    const url = base() + path;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const schema = getSchemaFromStore() || '1.4';
+    headers['x-schema-version'] = schema;
+    const key = getApiKeyFromStore();
+    if (key) headers['x-api-key'] = key;
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    registerFetch(ctrl);
+    registerTimer(t);
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body || {}),
+        credentials: 'include',
+        signal: ctrl.signal,
+      });
+      const json = await resp.json().catch(() => ({}));
+      return { resp, json };
+    } finally {
+      clearTimeout(t);
+      deregisterTimer(t);
+      deregisterFetch(ctrl);
+    }
+  });
 }
 export { postJSON as postJson };
 ;(window as any).postJson = postJSON;
 
 async function req(path: string, { method='GET', body=null, key=path, timeoutMs=9000 }: { method?: string; body?: any; key?: string; timeoutMs?: number } = {}) {
-  const headers: Record<string, string> = { 'Content-Type':'application/json' };
-  const apiKey = getApiKeyFromStore();
-  if (apiKey) headers['x-api-key'] = apiKey;
-  headers['x-schema-version'] = getSchemaFromStore() || '1.4';
+  return withBusy(async () => {
+    const headers: Record<string, string> = { 'Content-Type':'application/json' };
+    const apiKey = getApiKeyFromStore();
+    if (apiKey) headers['x-api-key'] = apiKey;
+    headers['x-schema-version'] = getSchemaFromStore() || '1.4';
 
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
-  registerFetch(ctrl);
-  registerTimer(t);
-  let r: Response;
-  try {
-    r = await fetch(base()+path, {
-      method,
-      headers,
-      body: body ? JSON.stringify(body) : undefined,
-      credentials: 'include',
-      signal: ctrl.signal,
-    });
-  } finally {
-    clearTimeout(t);
-    deregisterTimer(t);
-    deregisterFetch(ctrl);
-  }
-  const json = await r.json().catch(() => ({}));
-  const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
-  try { applyMetaToBadges(meta); } catch {}
-  try {
-    const w = window as any;
-    if (!w.__last) w.__last = {};
-    w.__last[key] = { status: r.status, req: { path, method, body }, json };
-  } catch {}
-  return { ok: r.ok, json, resp: r, meta };
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    registerFetch(ctrl);
+    registerTimer(t);
+    let r: Response;
+    try {
+      r = await fetch(base()+path, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+        credentials: 'include',
+        signal: ctrl.signal,
+      });
+    } finally {
+      clearTimeout(t);
+      deregisterTimer(t);
+      deregisterFetch(ctrl);
+    }
+    const json = await r.json().catch(() => ({}));
+    const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
+    try { applyMetaToBadges(meta); } catch {}
+    try {
+      const w = window as any;
+      if (!w.__last) w.__last = {};
+      w.__last[key] = { status: r.status, req: { path, method, body }, json };
+    } catch {}
+    return { ok: r.ok, json, resp: r, meta };
+  });
 }
 
 export async function apiHealth(backend?: string) {
-  return checkHealth({ backend });
+  return withBusy(() => checkHealth({ backend }));
 }
 
 export async function apiAnalyze(text: string) {

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.css
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.css
@@ -1,0 +1,31 @@
+.cai-book {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  pointer-events: none;
+  display: none;
+}
+.cai-book:not(.hidden) { display: block; }
+.cai-book__icon {
+  width: 44px;
+  height: 36px;
+  background:
+    linear-gradient(#8b5a2b, #5a3a1e) left/8px 100% no-repeat,
+    linear-gradient(#8b5a2b, #5a3a1e) 8px 0/8px 100% no-repeat,
+    linear-gradient(#f5f0e8, #e8dfd1) right/28px 100% no-repeat;
+  border: 2px solid #5a3a1e;
+  border-radius: 2px;
+  box-sizing: border-box;
+  animation: caiPageFlip 1s infinite linear;
+  transform-style: preserve-3d;
+}
+@keyframes caiPageFlip {
+  0% { transform: rotateY(0); }
+  50% { transform: rotateY(180deg); }
+  100% { transform: rotateY(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cai-book__icon { animation: none; opacity: .75; }
+}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}

--- a/contract_review_app/contract_review_app/static/panel/taskpane.html
+++ b/contract_review_app/contract_review_app/static/panel/taskpane.html
@@ -9,6 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Contract AI - Draft Assistant</title>
   <link rel="stylesheet" href="./app/assets/notifier.css" />
+  <link rel="stylesheet" href="./app/assets/taskpane.css" />
   <!-- hdrWarn block removed -->
   <style>
     :root{
@@ -264,6 +265,10 @@
 
   <!-- loading indicator -->
   <div id="busyBar" style="display:none"></div>
+  <div id="loading-book" role="status" aria-live="polite" aria-atomic="true" class="cai-book hidden" data-test-id="loading-book">
+    <div class="cai-book__icon" aria-hidden="true"></div>
+    <span class="sr-only">Processing…</span>
+  </div>
 
   <div class="row card">
     <div class="muted" style="margin-bottom:6px">Original clause:</div>

--- a/word_addin_dev/app/__tests__/loading.indicator.spec.ts
+++ b/word_addin_dev/app/__tests__/loading.indicator.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+function setupDom() {
+  const dom = new JSDOM('<div id="loading-book" class="cai-book hidden"></div>', { url: 'https://localhost' });
+  (globalThis as any).window = dom.window as any;
+  (globalThis as any).document = dom.window.document as any;
+  (globalThis as any).CustomEvent = dom.window.CustomEvent;
+  dom.window.addEventListener('cai:busy', (e: any) => {
+    const el = dom.window.document.getElementById('loading-book');
+    const busy = !!(e?.detail?.busy);
+    if (busy) el?.classList.remove('hidden');
+    else el?.classList.add('hidden');
+  });
+  return dom;
+}
+
+describe('loading indicator', () => {
+  it('shows during operation and hides after completion', async () => {
+    vi.resetModules();
+    const dom = setupDom();
+    const { withBusy } = await import('../assets/pending.ts');
+    const p = withBusy(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await Promise.resolve();
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(false);
+    await p;
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+  });
+
+  it('aggregates concurrent operations', async () => {
+    vi.resetModules();
+    const dom = setupDom();
+    const { withBusy } = await import('../assets/pending.ts');
+    const wait = (ms:number) => new Promise(r => setTimeout(r, ms));
+    const p1 = withBusy(() => wait(20));
+    const p2 = withBusy(() => wait(40));
+    await Promise.resolve();
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(false);
+    await p1;
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(false);
+    await p2;
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+  });
+
+  it('hides after rejected operation', async () => {
+    vi.resetModules();
+    const dom = setupDom();
+    const { withBusy } = await import('../assets/pending.ts');
+    await withBusy(async () => { throw new Error('x'); }).catch(() => {});
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+  });
+
+  it('isolates per window', async () => {
+    const wait = (ms:number) => new Promise(r => setTimeout(r, ms));
+
+    vi.resetModules();
+    const dom1 = setupDom();
+    const { withBusy: withBusy1 } = await import('../assets/pending.ts');
+    await withBusy1(() => wait(20));
+    expect(dom1.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+
+    vi.resetModules();
+    const dom2 = setupDom();
+    const { withBusy: withBusy2 } = await import('../assets/pending.ts');
+    expect(dom1.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+    await withBusy2(() => wait(20));
+    expect(dom2.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -11,7 +11,7 @@ export type Meta = {
 };
 
 import { getApiKeyFromStore, getSchemaFromStore } from "./store.ts";
-import { registerFetch, deregisterFetch, registerTimer, deregisterTimer } from './pending.ts';
+import { registerFetch, deregisterFetch, registerTimer, deregisterTimer, withBusy } from './pending.ts';
 import { checkHealth } from './health.ts';
 
 export type AnalyzeFinding = {
@@ -91,72 +91,76 @@ function base(): string {
 }
 
 export async function postJSON(path: string, body: any, timeoutMs = 9000) {
-  const url = base() + path;
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  const schema = getSchemaFromStore() || '1.4';
-  headers['x-schema-version'] = schema;
-  const key = getApiKeyFromStore();
-  if (key) headers['x-api-key'] = key;
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
-  registerFetch(ctrl);
-  registerTimer(t);
-  try {
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body || {}),
-      credentials: 'include',
-      signal: ctrl.signal,
-    });
-    const json = await resp.json().catch(() => ({}));
-    return { resp, json };
-  } finally {
-    clearTimeout(t);
-    deregisterTimer(t);
-    deregisterFetch(ctrl);
-  }
+  return withBusy(async () => {
+    const url = base() + path;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const schema = getSchemaFromStore() || '1.4';
+    headers['x-schema-version'] = schema;
+    const key = getApiKeyFromStore();
+    if (key) headers['x-api-key'] = key;
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    registerFetch(ctrl);
+    registerTimer(t);
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body || {}),
+        credentials: 'include',
+        signal: ctrl.signal,
+      });
+      const json = await resp.json().catch(() => ({}));
+      return { resp, json };
+    } finally {
+      clearTimeout(t);
+      deregisterTimer(t);
+      deregisterFetch(ctrl);
+    }
+  });
 }
 export { postJSON as postJson };
 ;(window as any).postJson = postJSON;
 
 async function req(path: string, { method='GET', body=null, key=path, timeoutMs=9000 }: { method?: string; body?: any; key?: string; timeoutMs?: number } = {}) {
-  const headers: Record<string, string> = { 'Content-Type':'application/json' };
-  const apiKey = getApiKeyFromStore();
-  if (apiKey) headers['x-api-key'] = apiKey;
-  headers['x-schema-version'] = getSchemaFromStore() || '1.4';
+  return withBusy(async () => {
+    const headers: Record<string, string> = { 'Content-Type':'application/json' };
+    const apiKey = getApiKeyFromStore();
+    if (apiKey) headers['x-api-key'] = apiKey;
+    headers['x-schema-version'] = getSchemaFromStore() || '1.4';
 
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
-  registerFetch(ctrl);
-  registerTimer(t);
-  let r: Response;
-  try {
-    r = await fetch(base()+path, {
-      method,
-      headers,
-      body: body ? JSON.stringify(body) : undefined,
-      credentials: 'include',
-      signal: ctrl.signal,
-    });
-  } finally {
-    clearTimeout(t);
-    deregisterTimer(t);
-    deregisterFetch(ctrl);
-  }
-  const json = await r.json().catch(() => ({}));
-  const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
-  try { applyMetaToBadges(meta); } catch {}
-  try {
-    const w = window as any;
-    if (!w.__last) w.__last = {};
-    w.__last[key] = { status: r.status, req: { path, method, body }, json };
-  } catch {}
-  return { ok: r.ok, json, resp: r, meta };
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    registerFetch(ctrl);
+    registerTimer(t);
+    let r: Response;
+    try {
+      r = await fetch(base()+path, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+        credentials: 'include',
+        signal: ctrl.signal,
+      });
+    } finally {
+      clearTimeout(t);
+      deregisterTimer(t);
+      deregisterFetch(ctrl);
+    }
+    const json = await r.json().catch(() => ({}));
+    const meta = metaFromResponse({ headers: r.headers, json, status: r.status });
+    try { applyMetaToBadges(meta); } catch {}
+    try {
+      const w = window as any;
+      if (!w.__last) w.__last = {};
+      w.__last[key] = { status: r.status, req: { path, method, body }, json };
+    } catch {}
+    return { ok: r.ok, json, resp: r, meta };
+  });
 }
 
 export async function apiHealth(backend?: string) {
-  return checkHealth({ backend });
+  return withBusy(() => checkHealth({ backend }));
 }
 
 export async function apiAnalyze(text: string) {

--- a/word_addin_dev/app/assets/taskpane.css
+++ b/word_addin_dev/app/assets/taskpane.css
@@ -1,0 +1,31 @@
+.cai-book {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  pointer-events: none;
+  display: none;
+}
+.cai-book:not(.hidden) { display: block; }
+.cai-book__icon {
+  width: 44px;
+  height: 36px;
+  background:
+    linear-gradient(#8b5a2b, #5a3a1e) left/8px 100% no-repeat,
+    linear-gradient(#8b5a2b, #5a3a1e) 8px 0/8px 100% no-repeat,
+    linear-gradient(#f5f0e8, #e8dfd1) right/28px 100% no-repeat;
+  border: 2px solid #5a3a1e;
+  border-radius: 2px;
+  box-sizing: border-box;
+  animation: caiPageFlip 1s infinite linear;
+  transform-style: preserve-3d;
+}
+@keyframes caiPageFlip {
+  0% { transform: rotateY(0); }
+  50% { transform: rotateY(180deg); }
+  100% { transform: rotateY(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cai-book__icon { animation: none; opacity: .75; }
+}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}

--- a/word_addin_dev/app/panel_dom.schema.json
+++ b/word_addin_dev/app/panel_dom.schema.json
@@ -2,7 +2,7 @@
   "_comment": "Любая панельная HTML-страница обязана содержать эти id",
   "required_ids": [
     "btnUseWholeDoc", "btnAnalyze",
-    "originalText", "results", "busyBar",
+    "originalText", "results", "busyBar", "loading-book",
     "officeBadge", "connBadge"
   ]
 }

--- a/word_addin_dev/app/src/panel/taskpane.html
+++ b/word_addin_dev/app/src/panel/taskpane.html
@@ -49,6 +49,10 @@ pre{background:#f0f0f0;padding:8px;border-radius:4px;white-space:pre-wrap;}
 </template>
 <textarea id="originalText" class="hidden"></textarea>
 <div id="busyBar" class="hidden"></div>
+<div id="loading-book" role="status" aria-live="polite" aria-atomic="true" class="cai-book hidden" data-test-id="loading-book">
+  <div class="cai-book__icon" aria-hidden="true"></div>
+  <span class="sr-only">Processing…</span>
+</div>
 
 <section id="resultsBlock" class="hidden">
   <div>

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -9,6 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Contract AI - Draft Assistant</title>
   <link rel="stylesheet" href="./app/assets/notifier.css" />
+  <link rel="stylesheet" href="./app/assets/taskpane.css" />
   <!-- hdrWarn block removed -->
   <style>
     :root{
@@ -264,6 +265,10 @@
 
   <!-- loading indicator -->
   <div id="busyBar" style="display:none"></div>
+  <div id="loading-book" role="status" aria-live="polite" aria-atomic="true" class="cai-book hidden" data-test-id="loading-book">
+    <div class="cai-book__icon" aria-hidden="true"></div>
+    <span class="sr-only">Processing…</span>
+  </div>
 
   <div class="row card">
     <div class="muted" style="margin-bottom:6px">Original clause:</div>


### PR DESCRIPTION
## Summary
- add CSS-based loading book indicator and integrate into taskpane
- introduce busy event bus and wrap long operations with withBusy
- cover busy indicator behavior with new vitest specs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4208b68d4832583065a529bdf88bc