### PR TITLE
Improve request timeout handling and static HEAD responses

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -80,6 +80,9 @@ _PROCESS_CID = str(uuid.uuid4())
 
 class NormalizeAndTraceMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
+        if request.method == "HEAD" and request.url.path.startswith("/panel/"):
+            return await call_next(request)
+
         response = await call_next(request)
 
         body, headers, media_type = await capture_response(response)

--- a/contract_review_app/contract_review_app/static/panel/app/assets/health.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/health.ts
@@ -6,7 +6,7 @@ export async function checkHealth(opts: { backend?: string; timeoutMs?: number }
     const url = backend ? `${backend}/health` : '/health';
     const ctrl = new AbortController();
     const timeout = opts.timeoutMs ?? 9000;
-    const t = setTimeout(() => ctrl.abort(), timeout);
+    const t = setTimeout(() => ctrl.abort('timeout'), timeout);
     cached = fetch(url, { signal: ctrl.signal }).then(async resp => {
       clearTimeout(t);
       const json = await resp.json().catch(() => ({}));

--- a/tests/tools/test_panel_serving.py
+++ b/tests/tools/test_panel_serving.py
@@ -1,0 +1,42 @@
+import asyncio
+import logging
+from httpx import AsyncClient, ASGITransport
+from contract_review_app.api.app import app
+
+
+async def _head_get(ac: AsyncClient, path: str):
+    head = await ac.head(path)
+    get = await ac.get(path)
+    assert head.status_code == 200
+    assert get.status_code == 200
+    assert int(head.headers["content-length"]) == len(get.content) > 0
+
+
+def test_head_and_get_html_js():
+    async def _run():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            await _head_get(ac, "/panel/taskpane.html")
+            await _head_get(ac, "/panel/taskpane.bundle.js")
+    asyncio.run(_run())
+
+
+def test_parallel_gets():
+    async def _run():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r1, r2 = await asyncio.gather(
+                ac.get("/panel/taskpane.html"),
+                ac.get("/panel/taskpane.html"),
+            )
+            assert r1.status_code == r2.status_code == 200
+            assert len(r1.content) == len(r2.content) > 0
+    asyncio.run(_run())
+
+
+def test_no_errors_after_head_get(caplog):
+    async def _run():
+        caplog.set_level(logging.ERROR)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            await ac.head("/panel/taskpane.html")
+            await ac.get("/panel/taskpane.html")
+        assert not any(rec.levelno >= logging.ERROR for rec in caplog.records)
+    asyncio.run(_run())

--- a/word_addin_dev/app/__tests__/postJson.timeout.spec.ts
+++ b/word_addin_dev/app/__tests__/postJson.timeout.spec.ts
@@ -1,23 +1,54 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 describe('postJson timeout', () => {
-  it('aborts on timeout', async () => {
-    (globalThis as any).window = globalThis;
+  it('uses dynamic timeout for small text', async () => {
+    (globalThis as any).window = { dispatchEvent: () => {}, addEventListener: () => {} } as any;
+    const calls: number[] = [];
+    (globalThis as any).setTimeout = (fn: any, ms: number) => { calls.push(ms); return 0 as any; };
+    (globalThis as any).clearTimeout = () => {};
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
-    (globalThis as any).fetch = (_:any, opts:any) => new Promise((_res, rej) => {
-      opts.signal.addEventListener('abort', () => rej(new DOMException('aborted','AbortError')));
-    });
+    (globalThis as any).fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
     const { postJson } = await import('../assets/api-client.ts');
-    await expect(postJson('/x', {}, 5)).rejects.toThrow();
+    await postJson('/api/analyze', { text: 'hi' });
+    expect(calls[0]).toBeGreaterThanOrEqual(9000);
+    expect(calls[0]).toBeLessThanOrEqual(30000);
   });
 
-  it('health check times out', async () => {
-    (globalThis as any).window = globalThis;
+  it('large text uses 60s and resolves before abort', async () => {
+    vi.useFakeTimers();
+    (globalThis as any).window = { dispatchEvent: () => {}, addEventListener: () => {} } as any;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
-    (globalThis as any).fetch = (_:any, opts:any) => new Promise((_res, rej) => {
-      opts.signal.addEventListener('abort', () => rej(new DOMException('aborted','AbortError')));
-    });
-    const { checkHealth } = await import('../assets/health.ts');
-    await expect(checkHealth({ timeoutMs: 5 })).rejects.toThrow();
+    (globalThis as any).fetch = vi.fn(() =>
+      new Promise(res => setTimeout(() => res({ ok:true, json: async()=>({}), headers:new Headers(), status:200 }), 12000))
+    );
+    const { postJson } = await import('../assets/api-client.ts');
+    const p = postJson('/api/analyze', { text: 'a'.repeat(120000) });
+    await vi.advanceTimersByTimeAsync(12000);
+    await expect(p).resolves.toBeTruthy();
+    vi.useRealTimers();
+  });
+
+  it('retries once on timeout', async () => {
+    vi.useFakeTimers();
+    (globalThis as any).window = { dispatchEvent: () => {}, addEventListener: () => {} } as any;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    const timers: number[] = [];
+    const origSet = setTimeout;
+    (globalThis as any).setTimeout = ((fn: any, ms: number) => { timers.push(ms); return origSet(fn, ms); }) as any;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce((_u, opts:any) => new Promise((_res, rej) => {
+        opts.signal.addEventListener('abort', () => rej(new DOMException('x','AbortError')));
+      }))
+      .mockResolvedValueOnce({ ok:true, json: async()=>({}), headers:new Headers(), status:200 });
+    ;(globalThis as any).fetch = fetchMock;
+    const { postJson } = await import('../assets/api-client.ts');
+    const p = postJson('/api/analyze', { text: 'hi' });
+    await vi.advanceTimersByTimeAsync(30000);
+    await expect(p).resolves.toBeTruthy();
+    expect(fetchMock.mock.calls.length).toBe(2);
+    expect(timers[0]).toBe(30000);
+    expect(timers[1]).toBe(60000);
+    vi.useRealTimers();
   });
 });

--- a/word_addin_dev/app/__tests__/usewholedoc.analyze.large.spec.ts
+++ b/word_addin_dev/app/__tests__/usewholedoc.analyze.large.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('analyze large logging', () => {
+  it('logs size and duration', async () => {
+    vi.useFakeTimers();
+    (globalThis as any).window = { dispatchEvent: () => {}, addEventListener: () => {} } as any;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    const longText = 'A'.repeat(120000);
+    const fetchMock = vi.fn(() =>
+      new Promise(res => setTimeout(() => res({ ok:true, json: async()=>({}), headers:new Headers(), status:200 }), 12000))
+    );
+    (globalThis as any).fetch = fetchMock;
+    const logSpy = vi.spyOn(console, 'log');
+    const { postJson } = await import('../assets/api-client.ts');
+    const p = postJson('/api/analyze', { text: longText });
+    await vi.advanceTimersByTimeAsync(12000);
+    await p;
+    const size = new TextEncoder().encode(longText).length;
+    const rec = logSpy.mock.calls.find(c => c[0] === 'analyze');
+    expect(rec?.[1].size_bytes).toBe(size);
+    expect(rec?.[1].t_ms).toBeGreaterThanOrEqual(11000);
+    vi.useRealTimers();
+  });
+});

--- a/word_addin_dev/app/assets/health.ts
+++ b/word_addin_dev/app/assets/health.ts
@@ -6,7 +6,7 @@ export async function checkHealth(opts: { backend?: string; timeoutMs?: number }
     const url = backend ? `${backend}/health` : '/health';
     const ctrl = new AbortController();
     const timeout = opts.timeoutMs ?? 9000;
-    const t = setTimeout(() => ctrl.abort(), timeout);
+    const t = setTimeout(() => ctrl.abort('timeout'), timeout);
     cached = fetch(url, { signal: ctrl.signal }).then(async resp => {
       clearTimeout(t);
       const json = await resp.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- Add dynamic, overridable timeouts with retry and logging for /api/analyze
- Respect pagehide/unload only for aborting requests, optional visibility flag
- Preserve Content-Length on panel HEAD requests and enhance error reporting

## Testing
- `npx vitest run word_addin_dev/app/__tests__/postJson.timeout.spec.ts word_addin_dev/app/__tests__/unload.spec.ts word_addin_dev/app/__tests__/usewholedoc.analyze.large.spec.ts`
- `pytest tests/tools/test_panel_serving.py`


------
https://chatgpt.com/codex/tasks/task_e_68c433ef7b38832595196d21e94a96e1