### PR TITLE
Improve panel HEAD handling and analysis timeouts

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -692,7 +692,11 @@ async def panel_head(path: str = ""):
     full = (base / path).resolve()
     if full.is_dir():
         full = full / "index.html"
-    if not str(full).startswith(str(base)) or not full.is_file():
+    try:
+        full.relative_to(base)
+    except ValueError:
+        raise HTTPException(status_code=404)
+    if not full.is_file():
         raise HTTPException(status_code=404)
     return FileResponse(full)
 

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -137,8 +137,22 @@ export async function postJSON(path: string, body: any, timeoutOverride?: number
         const rb = params.get('rb');
         if (rb) backoffMs = parseInt(rb, 10);
       } catch {}
+      timeoutMs = timeoutMs ?? ANALYZE_BASE_MS;
+    } else {
+      if (timeoutMs == null) {
+        try {
+          const route = path.split('/').pop() || '';
+          const ov = localStorage.getItem(`cai_timeout_ms:${route}`);
+          if (ov) timeoutMs = parseInt(ov, 10);
+        } catch {}
+      }
+      if (timeoutMs == null) {
+        timeoutMs = 30000;
+        if (sizeBytes > 300000) timeoutMs = 90000;
+        else if (sizeBytes > 100000) timeoutMs = 60000;
+      }
+      timeoutMs = Math.min(timeoutMs, 120000);
     }
-    timeoutMs = timeoutMs ?? ANALYZE_BASE_MS;
 
     async function attempt(n: number): Promise<any> {
       const ctrl = new AbortController();

--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -4,7 +4,6 @@ import { ensureHeadersSet as ensureHeadersAuto } from '../../../../contract_revi
 const $ = <T extends HTMLElement = HTMLElement>(sel: string) =>
   document.querySelector(sel) as T | null;
 const show = (el: HTMLElement | null) => { if (el) el.hidden = false; };
-const hide = (el: HTMLElement | null) => { if (el) el.hidden = true; };
 
 export function wireDom() {
   $<HTMLButtonElement>('#btnInsertIntoWord')?.addEventListener('click', onInsertIntoWord);
@@ -44,4 +43,3 @@ if (!(globalThis as { __CAI_TESTING__?: boolean }).__CAI_TESTING__) {
     void startPanel();
   }
 }
-


### PR DESCRIPTION
## Summary
- prevent panel HEAD route from escaping base directory
- restore longer default timeouts for non-analyze POSTs
- remove unused panel helper triggering lint

## Testing
- `pre-commit run --files contract_review_app/api/app.py contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts word_addin_dev/app/src/panel/index.ts`
- `npm --prefix word_addin_dev test`
- `pytest -q tests/tools` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c47e575e94832589a628a38024e963