### PR TITLE
Use unified timeout localStorage key

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -142,7 +142,7 @@ export async function postJSON(path: string, body: any, timeoutOverride?: number
       if (timeoutMs == null) {
         try {
           const route = path.split('/').pop() || '';
-          const ov = localStorage.getItem(`cai_timeout_ms:${route}`);
+          const ov = localStorage.getItem(`cai.timeout.${route}.ms`);
           if (ov) timeoutMs = parseInt(ov, 10);
         } catch {}
       }

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -25,7 +25,7 @@ console.log('ContractAI build', BUILD_ID);
 let __cfg_timeout: string | null = null;
 let __cfg_abort_vis = '0';
 try {
-  __cfg_timeout = localStorage.getItem('cai_timeout_ms:analyze');
+  __cfg_timeout = localStorage.getItem('cai.timeout.analyze.ms');
   __cfg_abort_vis = localStorage.getItem('cai_abort_on_visibility') || '0';
 } catch {}
 console.log('[CFG]', { timeout_analyze: __cfg_timeout, abort_on_visibility: __cfg_abort_vis });

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -25,7 +25,7 @@ console.log('ContractAI build', BUILD_ID);
 let __cfg_timeout: string | null = null;
 let __cfg_abort_vis = '0';
 try {
-  __cfg_timeout = localStorage.getItem('cai_timeout_ms:analyze');
+  __cfg_timeout = localStorage.getItem('cai.timeout.analyze.ms');
   __cfg_abort_vis = localStorage.getItem('cai_abort_on_visibility') || '0';
 } catch {}
 console.log('[CFG]', { timeout_analyze: __cfg_timeout, abort_on_visibility: __cfg_abort_vis });


### PR DESCRIPTION
## Summary
- use `cai.timeout.analyze.ms` in Word add-in taskpane
- align panel taskpane and API client with `cai.timeout.*.ms` keys

## Testing
- `pre-commit run --files word_addin_dev/app/assets/taskpane.ts contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c501f41eec832592d29092dbfea723