### PR TITLE
fix: skip invalid analyze timeout values

### DIFF
--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -125,8 +125,11 @@ export async function postJSON(path: string, body: any, timeoutOverride?: number
         ]) {
           const v = localStorage.getItem(k);
           if (v) {
-            timeoutMs = parseInt(v, 10);
-            break;
+            const parsed = parseInt(v, 10);
+            if (Number.isFinite(parsed)) {
+              timeoutMs = parsed;
+              break;
+            }
           }
         }
       } catch {}


### PR DESCRIPTION
## Summary
- skip invalid analyze timeout overrides so valid newer keys are respected

## Testing
- `pre-commit run --files word_addin_dev/app/assets/api-client.ts`
- `npm --prefix word_addin_dev test`


------
https://chatgpt.com/codex/tasks/task_e_68c50465a034832589e5282389513f59