### PR TITLE
feat: gate dev key injection behind env flag

### DIFF
--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,6 +1,12 @@
-import importlib
+import logging
+import pytest
+
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from starlette.requests import Request
+
 from contract_review_app.api.models import SCHEMA_VERSION
+from contract_review_app.api.auth import require_api_key_and_schema
 
 
 def _get_client():
@@ -9,7 +15,12 @@ def _get_client():
     return TestClient(app)
 
 
-def test_api_key_auth():
+def test_api_key_auth(monkeypatch):
+    monkeypatch.delenv("DEV_MODE", raising=False)
+    monkeypatch.delenv("ALLOW_DEV_KEY_INJECTION", raising=False)
+    monkeypatch.setenv("FEATURE_REQUIRE_API_KEY", "1")
+    monkeypatch.setenv("API_KEY", "secret")
+
     client = _get_client()
     payload = {"text": "Hello"}
 
@@ -38,3 +49,36 @@ def test_api_key_auth():
         client.post("/api/suggest_edits", json=payload, headers=headers).status_code
         == 200
     )
+
+
+def _build_request(headers: dict[str, str] | None = None) -> Request:
+    scope = {
+        "type": "http",
+        "headers": [
+            (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
+        ],
+    }
+    return Request(scope)
+
+
+def test_dev_key_injection_requires_flag(monkeypatch):
+    monkeypatch.setenv("DEV_MODE", "1")
+    monkeypatch.delenv("ALLOW_DEV_KEY_INJECTION", raising=False)
+
+    req = _build_request()
+    with pytest.raises(HTTPException) as exc:
+        require_api_key_and_schema(req)
+    assert exc.value.status_code == 401
+
+
+def test_dev_key_injection_opt_in(monkeypatch, caplog):
+    monkeypatch.setenv("DEV_MODE", "1")
+    monkeypatch.setenv("ALLOW_DEV_KEY_INJECTION", "yes")
+    monkeypatch.setenv("DEFAULT_API_KEY", "local-test-key-123")
+
+    req = _build_request()
+    with caplog.at_level(logging.WARNING):
+        require_api_key_and_schema(req)
+    assert req.state.api_key == "local-test-key-123"
+    assert req.state.schema_version == SCHEMA_VERSION
+    assert any("auto-filling" in msg for msg in caplog.messages)


### PR DESCRIPTION
## Summary
- warn when dev headers are auto-filled
- require `ALLOW_DEV_KEY_INJECTION` to enable auto API key/schema injection
- expand API key tests with opt-in flag coverage

## Testing
- `pytest tests/security/test_api_key_auth.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50aa2eab08325b53b3f31e475b2f7