### PR TITLE
Log learning log write failures and add error test

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -2966,14 +2966,17 @@ async def api_calloff_validate(
 @router.post("/api/learning/log", status_code=204)
 async def api_learning_log(body: Any = Body(...)) -> Response:
     t0 = _now_ms()
+    ok = True
     try:
         LEARNING_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
         secure_write(
             LEARNING_LOG_PATH, json.dumps(body, ensure_ascii=False), append=True
         )
-    except Exception:
-        pass
+    except Exception as exc:  # pragma: no cover - best effort logging
+        log.warning("failed to write learning log: %s", exc, exc_info=True)
+        ok = False
     resp = Response(status_code=204)
+    resp.headers["x-learning-log-status"] = "ok" if ok else "error"
     _set_schema_headers(resp)
     _set_std_headers(
         resp,

--- a/tests/api/test_learning_log.py
+++ b/tests/api/test_learning_log.py
@@ -1,0 +1,17 @@
+import logging
+from contract_review_app.api.models import SCHEMA_VERSION
+
+
+def test_learning_log_write_error(api, monkeypatch, caplog):
+    monkeypatch.setenv("API_KEY", "secret")
+    headers = {"x-api-key": "secret", "x-schema-version": SCHEMA_VERSION}
+    def fail_write(*args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr("contract_review_app.api.app.secure_write", fail_write)
+    with caplog.at_level(logging.WARNING, logger="contract_ai"):
+        resp = api.post("/api/learning/log", json={"foo": "bar"}, headers=headers)
+    assert resp.status_code == 204
+    assert resp.headers.get("x-learning-log-status") == "error"
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("failed to write learning log" in m for m in messages)


### PR DESCRIPTION
## Summary
- warn when writing the learning log fails and note success via `x-learning-log-status`
- test that learning log write errors are logged and still return 204

## Testing
- `pytest tests/api/test_learning_log.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50ab13be483259ac5f2265f83342c