### PR TITLE
Stream request body and enforce size limit

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1058,7 +1058,17 @@ def _trace_push(cid: str, event: Dict[str, Any]) -> None:
 
 @app.middleware("http")
 async def add_response_headers(request: Request, call_next):
-    body = await request.body()
+    try:
+        body = await _read_body_guarded(request)
+    except HTTPException:
+        cid = getattr(request.state, "cid", request.headers.get("x-cid") or _PROCESS_CID)
+        return _problem_response(
+            413,
+            "Payload too large",
+            error_code="payload_too_large",
+            detail="Request body exceeds limits",
+            cid=cid,
+        )
     started_at = time.perf_counter()
 
     async def receive():
@@ -1320,10 +1330,14 @@ async def _read_body_guarded(request: Request) -> bytes:
     clen = request.headers.get("content-length")
     if clen and clen.isdigit() and int(clen) > MAX_BODY_BYTES:
         raise HTTPException(status_code=413, detail="Payload too large")
-    body = await request.body()
-    if len(body) > MAX_BODY_BYTES:
-        raise HTTPException(status_code=413, detail="Payload too large")
-    return body
+
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > MAX_BODY_BYTES:
+            raise HTTPException(status_code=413, detail="Payload too large")
+        body.extend(chunk)
+
+    return bytes(body)
 
 
 def _count_placeholders(text: str) -> int:

--- a/tests/api/test_body_reader.py
+++ b/tests/api/test_body_reader.py
@@ -1,0 +1,32 @@
+import asyncio
+import httpx
+import pytest
+
+import contract_review_app.api.app as api_mod
+
+
+@pytest.mark.asyncio
+async def test_streaming_body_reader_no_content_length(monkeypatch):
+    monkeypatch.setattr(api_mod, "MAX_BODY_BYTES", 1024)
+
+    chunk = b"x" * 600
+    sent = 0
+
+    async def gen():
+        nonlocal sent
+        for _ in range(100):
+            sent += len(chunk)
+            yield chunk
+            await asyncio.sleep(0)
+
+    transport = httpx.ASGITransport(app=api_mod.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/api/calloff/validate",
+            content=gen(),
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.status_code == 413
+    assert "content-length" not in response.request.headers
+    assert sent <= api_mod.MAX_BODY_BYTES + len(chunk)


### PR DESCRIPTION
## Summary
- Stream request bodies to enforce MAX_BODY_BYTES without buffering
- Reject oversized bodies early in middleware with 413 responses
- Add regression test for chunked requests without Content-Length

## Testing
- `ruff check contract_review_app/api/app.py tests/api/test_body_reader.py`
- `pytest tests/api/test_body_reader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c50aa92db08325a846ed63f9aee894