### PR TITLE
feat: allow forcing comment support in dev

### DIFF
--- a/word_addin_dev/app/assets/bootstrap.js
+++ b/word_addin_dev/app/assets/bootstrap.js
@@ -12,5 +12,6 @@ export async function bootstrapHeaders() {
     const k = window.__DEV_DEFAULT_API_KEY__;
     if (k) localStorage.setItem('api_key', k);
   }
+  localStorage.setItem('cai.force.comments', '1');
 }
 bootstrapHeaders();

--- a/word_addin_dev/app/assets/bootstrap.ts
+++ b/word_addin_dev/app/assets/bootstrap.ts
@@ -14,6 +14,7 @@ export async function bootstrapHeaders() {
     const k = (window as any).__DEV_DEFAULT_API_KEY__;
     if (k) localStorage.setItem('api_key', k);
   }
+  localStorage.setItem('cai.force.comments', '1');
 }
 // immediately bootstrap on import
 bootstrapHeaders();

--- a/word_addin_dev/app/assets/supports.ts
+++ b/word_addin_dev/app/assets/supports.ts
@@ -12,7 +12,11 @@ export function detectSupports(): FeatureSupport {
   const com = req && !!w?.Comment;
   const srch = req && !!w?.SearchOptions;
   const cc = req && !!w?.ContentControl;
-  return { revisions: rev, comments: com, search: srch, contentControls: cc };
+  const base = { revisions: rev, comments: com, search: srch, contentControls: cc };
+  if (!req && w?.Comment && localStorage.getItem('cai.force.comments') === '1') {
+    return { ...base, comments: true };
+  }
+  return base;
 }
 
 export const supports = {


### PR DESCRIPTION
## Summary
- allow Word add-in to force comment support when `cai.force.comments` flag is set
- seed the flag in the dev panel bootstrap so comments can be forced

## Testing
- `npm --prefix word_addin_dev test`
- `npm --prefix word_addin_dev run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c67d6298288325bccc8c39189207ef