### PR TITLE
feat: add comment support override

### DIFF
--- a/word_addin_dev/README-dev.md
+++ b/word_addin_dev/README-dev.md
@@ -1,0 +1,12 @@
+# Developer Notes
+
+## Force-enable comments
+
+In some Word environments the `WordApi 1.4` requirement set is reported as unsupported even though `Word.Comment` is available.
+To force-enable comments for testing, run the following in the browser console and reload the add-in:
+
+```js
+localStorage.setItem('cai.force.comments', '1');
+```
+
+Remove the key or set it to another value to disable the override.

--- a/word_addin_dev/app/assets/__tests__/supports.test.ts
+++ b/word_addin_dev/app/assets/__tests__/supports.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { detectSupports } from '../supports.ts';
+
+describe('comments support detection', () => {
+  const store: Record<string, string> = {};
+  beforeEach(() => {
+    (globalThis as any).localStorage = {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+    };
+  });
+  afterEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+    delete (globalThis as any).Word;
+    delete (globalThis as any).Office;
+  });
+
+  it('uses Word.Comment when requirement set is unsupported', () => {
+    (globalThis as any).Word = { Comment: function() {} };
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false } } };
+    expect(detectSupports().comments).toBe(true);
+  });
+
+  it('respects localStorage override', () => {
+    (globalThis as any).localStorage.setItem('cai.force.comments', '1');
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false } } };
+    expect(detectSupports().comments).toBe(true);
+  });
+
+  it('returns false when no support and no override', () => {
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false } } };
+    expect(detectSupports().comments).toBe(false);
+  });
+});

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1059,9 +1059,15 @@ export function wireUI() {
   });
 
   const s = logSupportMatrix();
-  const disable = (id: string) => {
+  const disable = (id: string, reason?: string) => {
     const el = document.getElementById(id) as HTMLButtonElement | null;
-    if (el) { el.disabled = true; el.title = 'Not supported'; }
+    if (el) {
+      el.disabled = true;
+      el.title = reason ? `Not supported: ${reason}` : 'Not supported';
+    }
+    if (reason) {
+      try { console.log(`disabled ${id}: ${reason}`); } catch {}
+    }
   };
 
   bindClick("#btnUseWholeDoc", onUseWholeDoc);
@@ -1115,10 +1121,10 @@ export function wireUI() {
   ensureHeaders();
   updateStatusChip();
 
-  if (!s.revisions) { disable('btnApplyTracked'); disable('btnAcceptAll'); disable('btnRejectAll'); }
-  if (!s.comments) { disable('btnAcceptAll'); }
-  if (!s.search) { disable('btnPrevIssue'); disable('btnNextIssue'); disable('btnQARecheck'); }
-  if (!s.contentControls) { disable('btnAnnotate'); }
+  if (!s.revisions) { disable('btnApplyTracked', 'revisions'); disable('btnAcceptAll', 'revisions'); disable('btnRejectAll', 'revisions'); }
+  if (!s.comments) { disable('btnAcceptAll', s.commentsReason); }
+  if (!s.search) { disable('btnPrevIssue', 'search'); disable('btnNextIssue', 'search'); disable('btnQARecheck', 'search'); }
+  if (!s.contentControls) { disable('btnAnnotate', 'contentControls'); }
   if (!s.revisions || !s.comments || !s.search || !s.contentControls) {
     try { setOfficeBadge('Word ⚠'); } catch {}
   }


### PR DESCRIPTION
## Summary
- detect Word comments support with soft check and dev override
- surface comment support reason in startup log and UI disable hints
- document comment override flag and add unit tests

## Testing
- `cd word_addin_dev && npm test`
- `cd word_addin_dev && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c69101a8208325b272036cb4624ee5