### PR TITLE
Route analyze via API client payload wrapper

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1,4 +1,4 @@
-import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, postJSON } from "./api-client.ts";
+import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, postJSON, analyze } from "./api-client.ts";
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, dedupeFindings, severityRank } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
@@ -91,6 +91,7 @@ import { getWholeDocText } from "./office.ts"; // у вас уже есть хе
 g.getWholeDocText = g.getWholeDocText || getWholeDocText;
 
 type Mode = "live" | "friendly" | "doctor";
+let currentMode: Mode = 'live';
 
 const Q = {
   proposed: 'textarea#proposedText, textarea#draftText, textarea[name="proposed"], textarea[data-role="proposed-text"]',
@@ -862,7 +863,7 @@ async function doAnalyze() {
       const orig = document.getElementById("originalText") as HTMLTextAreaElement | null;
       if (orig) orig.value = base;
 
-      const { resp, json } = await postJSON('/api/analyze', { text: base });
+      const { resp, json } = await analyze({ text: base, mode: currentMode });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const respSchema = resp.headers.get('x-schema-version');
       if (respSchema) setSchemaVersion(respSchema);

--- a/tests/panel/helpers.py
+++ b/tests/panel/helpers.py
@@ -4,7 +4,7 @@ from contract_review_app.api.app import app
 client = TestClient(app)
 
 def analyze_and_render(text: str) -> str:
-    resp = client.post("/api/analyze", json={"text": text})
+    resp = client.post("/api/analyze", json={"payload": {"schema": "1.4", "mode": "live", "text": text}})
     assert resp.status_code == 200
     data = resp.json()
     out = []

--- a/tests/panel/test_analyze_payload.py
+++ b/tests/panel/test_analyze_payload.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+from contract_review_app.api.app import app
+
+client = TestClient(app)
+
+
+def test_analyze_payload_wrapper_ok():
+    r = client.post('/api/analyze', json={'payload': {'schema': '1.4', 'mode': 'live', 'text': 'Ping'}}, headers={'x-api-key': 'k', 'x-schema-version': '1.4'})
+    assert r.status_code == 200
+
+
+def test_analyze_flat_body_rejected():
+    r = client.post('/api/analyze', json={'schema': '1.4', 'text': 'Ping'}, headers={'x-api-key': 'k', 'x-schema-version': '1.4'})
+    assert r.status_code == 422

--- a/tests/panel/test_gpt_draft_payload.py
+++ b/tests/panel/test_gpt_draft_payload.py
@@ -6,10 +6,14 @@ client = TestClient(app)
 
 
 def test_gpt_draft_payload_and_response():
-    r_an = client.post("/api/analyze", json={"text": "Ping"})
+    r_an = client.post(
+        "/api/analyze",
+        json={"payload": {"schema": "1.4", "mode": "live", "text": "Ping"}},
+        headers={"x-api-key": "k", "x-schema-version": "1.4"},
+    )
     cid = r_an.headers.get("x-cid")
     payload = {"cid": cid, "clause": "Ping", "mode": "friendly"}
-    r = client.post("/api/gpt-draft", json=payload)
+    r = client.post("/api/gpt-draft", json=payload, headers={"x-api-key": "k", "x-schema-version": "1.4"})
     assert r.status_code == 200
     data = r.json()
     for k in ("cid", "clause", "mode"):

--- a/word_addin_dev/app/__tests__/analyze.payload.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.payload.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('analyze payload wrapper', () => {
+  it('wraps text under payload with schema and mode', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    (globalThis as any).fetch = fetchMock;
+    (globalThis as any).window = { } as any;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    const { analyze } = await import('../assets/api-client.ts');
+    await analyze({ text: 'hello', mode: 'live' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, opts] = fetchMock.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body).toHaveProperty('payload');
+    expect(body.payload).toMatchObject({ schema: '1.4', mode: 'live', text: 'hello' });
+  });
+});

--- a/word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts
@@ -64,6 +64,9 @@ describe('use whole doc + analyze flow', () => {
     expect(book.classList.contains('hidden')).toBe(true);
     const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
     expect(analyzeCalls.length).toBe(1);
+    const body = JSON.parse(analyzeCalls[0][1].body);
+    expect(body).toHaveProperty('payload');
+    expect(body.payload).toMatchObject({ schema: '1.4', mode: 'live', text: 'TEST BODY' });
     vi.useRealTimers();
   }, 10000);
 });

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1,4 +1,4 @@
-import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, postJSON } from "./api-client.ts";
+import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, postJSON, analyze } from "./api-client.ts";
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, dedupeFindings, severityRank } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
@@ -91,6 +91,7 @@ import { getWholeDocText } from "./office.ts"; // у вас уже есть хе
 g.getWholeDocText = g.getWholeDocText || getWholeDocText;
 
 type Mode = "live" | "friendly" | "doctor";
+let currentMode: Mode = 'live';
 
 const Q = {
   proposed: 'textarea#proposedText, textarea#draftText, textarea[name="proposed"], textarea[data-role="proposed-text"]',
@@ -862,7 +863,7 @@ async function doAnalyze() {
       const orig = document.getElementById("originalText") as HTMLTextAreaElement | null;
       if (orig) orig.value = base;
 
-      const { resp, json } = await postJSON('/api/analyze', { text: base });
+      const { resp, json } = await analyze({ text: base, mode: currentMode });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const respSchema = resp.headers.get('x-schema-version');
       if (respSchema) setSchemaVersion(respSchema);


### PR DESCRIPTION
## Summary
- wrap analyze requests in payload object and set schema/mode headers via apiClient
- use shared analyze() helper in taskpane instead of direct postJSON
- add tests covering analyze payload shape and request body checks

## Testing
- `npm test`
- `pytest tests/panel/test_analyze_payload.py tests/panel/test_gpt_draft_payload.py` *(fails: expected 200/422 but got 422/400)*

------
https://chatgpt.com/codex/tasks/task_e_68c690d141408325a3c60e422e46081f