### PR TITLE
feat(panel): send flat analyze payload

### DIFF
--- a/word_addin_dev/app/__tests__/analyze.payload.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.payload.spec.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 
 describe('analyze payload wrapper', () => {
-  it('wraps text under payload with schema and mode', async () => {
+  it('sends flat payload with schema and mode', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
     (globalThis as any).fetch = fetchMock;
-    (globalThis as any).window = { } as any;
+    (globalThis as any).window = { dispatchEvent() {} } as any;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
     const { analyze } = await import('../assets/api-client.ts');
     await analyze({ text: 'hello', mode: 'live' });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
-    expect(body).toHaveProperty('payload');
-    expect(body.payload).toMatchObject({ schema: '1.4', mode: 'live', text: 'hello' });
+    expect(body).toMatchObject({ schema: '1.4', mode: 'live', text: 'hello' });
   });
 });

--- a/word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts
+++ b/word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts
@@ -39,8 +39,8 @@ describe('ensure text for analyze', () => {
     const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
     expect(analyzeCalls.length).toBe(1);
     const body = JSON.parse(analyzeCalls[0][1].body);
-    expect(Object.keys(body)).toEqual(['payload']);
-    expect(body.payload.text.length).toBeGreaterThan(0);
+    expect(body.text.length).toBeGreaterThan(0);
+    expect(body).toMatchObject({ schema: '1.4', mode: 'live' });
   });
 
   it('warns when document empty', async () => {

--- a/word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts
@@ -65,8 +65,7 @@ describe('use whole doc + analyze flow', () => {
     const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
     expect(analyzeCalls.length).toBe(1);
     const body = JSON.parse(analyzeCalls[0][1].body);
-    expect(body).toHaveProperty('payload');
-    expect(body.payload).toMatchObject({ schema: '1.4', mode: 'live', text: 'TEST BODY' });
+    expect(body).toMatchObject({ schema: '1.4', mode: 'live', text: 'TEST BODY' });
     vi.useRealTimers();
   }, 10000);
 });

--- a/word_addin_dev/app/assets/__tests__/analyze.wrap.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/analyze.wrap.spec.ts
@@ -4,23 +4,21 @@ import { describe, it, expect, vi } from 'vitest';
 (globalThis as any).document = { addEventListener() {}, querySelectorAll() { return [] as any; } } as any;
 
 describe('analyze payload wrapping', () => {
-  it('wraps plain payload once', async () => {
+  it('sends flat payload when given text only', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, headers: new Headers(), json: async () => ({}) });
     (globalThis as any).fetch = fetchMock;
     const { analyze } = await import('../api-client.ts');
     await analyze({ text: 'hi' });
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(Object.keys(body)).toEqual(['payload']);
-    expect(body.payload.text).toBe('hi');
+    expect(body).toMatchObject({ text: 'hi', mode: 'live', schema: '1.4' });
   });
 
-  it('does not double wrap existing payload', async () => {
+  it('does not modify provided schema or mode', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, headers: new Headers(), json: async () => ({}) });
     (globalThis as any).fetch = fetchMock;
     const { analyze } = await import('../api-client.ts');
-    await analyze({ schema: '1.4', mode: 'live', text: 'hi' });
+    await analyze({ schema: '1.4', mode: 'test', text: 'hi' });
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(Object.keys(body)).toEqual(['payload']);
-    expect(body.payload.text).toBe('hi');
+    expect(body).toMatchObject({ text: 'hi', mode: 'test', schema: '1.4' });
   });
 });


### PR DESCRIPTION
## Summary
- use postJSON for analyze requests
- send flat `{text, mode, schema}` body
- update tests for new analyze payload

## Testing
- `npm --prefix word_addin_dev run lint`
- `npm --prefix word_addin_dev test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c150881883259173eb97d4ca854c