### PR TITLE
feat: accept legacy analyze payload

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1800,8 +1800,12 @@ def api_admin_purge(dry: int = 1):
     response_model=AnalyzeResponse,
 )
 def api_analyze(
-    request: Request, req: AnalyzeRequest = Body(..., example={"text": "Hello"})
+    request: Request, body: dict = Body(..., example={"text": "Hello"})
 ):
+    try:
+        req = AnalyzeRequest.model_validate(body.get("payload", body))
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors())
     txt = req.text
     debug = request.query_params.get("debug")  # noqa: F841
     risk_param = (

--- a/tests/panel/test_analyze_payload.py
+++ b/tests/panel/test_analyze_payload.py
@@ -8,7 +8,13 @@ def test_analyze_payload_wrapper_ok():
     r = client.post('/api/analyze', json={'payload': {'schema': '1.4', 'mode': 'live', 'text': 'Ping'}}, headers={'x-api-key': 'k', 'x-schema-version': '1.4'})
     assert r.status_code == 200
 
-
-def test_analyze_flat_body_rejected():
+def test_analyze_flat_body_ok():
     r = client.post('/api/analyze', json={'schema': '1.4', 'text': 'Ping'}, headers={'x-api-key': 'k', 'x-schema-version': '1.4'})
+    assert r.status_code == 200
+
+
+def test_analyze_broken_body_422_with_details():
+    r = client.post('/api/analyze', json={'text': 123}, headers={'x-api-key': 'k', 'x-schema-version': '1.4'})
     assert r.status_code == 422
+    detail = r.json().get('detail')
+    assert isinstance(detail, list) and any('loc' in d and 'msg' in d for d in detail)


### PR DESCRIPTION
## Summary
- allow /api/analyze to accept either flat bodies or legacy `payload` wrapper
- surface pydantic validation errors in 422 responses
- adjust tests for backwards compatibility and detailed errors

## Testing
- `pytest tests/panel/test_analyze_payload.py tests/integration/test_panel_selftest_like.py tests/test_routes_smoke.py -q` *(fails: AZURE_OPENAI_API_KEY missing / authorization 401)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c158ec288325ac478ef69bed6cd4