### PR TITLE
feat(frontend): better analyze validation UX

### DIFF
--- a/contract_review_app/frontend/common/http.ts
+++ b/contract_review_app/frontend/common/http.ts
@@ -42,7 +42,34 @@ export async function postJSON<T>(url: string, body: unknown, extra: HeadersMap 
   const r = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
   const respSchema = r.headers.get('x-schema-version');
   if (respSchema) setStoredSchema(respSchema);
-  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  if (!r.ok) {
+    let msg = `HTTP ${r.status}`;
+    let parsed: any = null;
+    try {
+      parsed = await r.json();
+      const detail = parsed?.detail;
+      if (r.status === 422 && detail) {
+        if (Array.isArray(detail)) {
+          msg = detail
+            .map((d: any) => {
+              const loc = Array.isArray(d?.loc) ? d.loc.join('.') : '';
+              const m = d?.msg || d?.message || '';
+              return loc ? `${loc}: ${m}` : m;
+            })
+            .filter(Boolean)
+            .join('; ');
+        } else if (typeof detail === 'string') {
+          msg = detail;
+        }
+      }
+    } catch {
+      // ignore
+    }
+    const err: any = new Error(msg);
+    err.status = r.status;
+    err.body = parsed;
+    throw err;
+  }
   const data = (await r.json()) as T & { schema?: string };
   if (data?.schema) setStoredSchema(data.schema);
   return data;


### PR DESCRIPTION
## Summary
- show toast and block analyze when text is empty
- surface backend 422 validation details in analyze toast

## Testing
- `npm run build`
- `pytest` *(fails: test_analyze_returns_normalized_snippet, test_std_headers_present_and_valid[/api/analyze], test_std_headers_present_and_valid[/api/gpt-draft])*

------
https://chatgpt.com/codex/tasks/task_e_68c6c181e64c8325a108184d20ccab97