### PR TITLE
docs: document /api/analyze contract

### DIFF
--- a/CONTRIBUTING_Codex.md
+++ b/CONTRIBUTING_Codex.md
@@ -33,3 +33,6 @@
 - Keep files free of conflict markers and temporary strings like `codex/...`.
 - Remove generated caches (`__pycache__`) before committing.
 - All tests and the doctor script must succeed with `LLM_PROVIDER=mock` and without external API keys.
+
+## API Contracts
+See [docs/api_contracts.md](docs/api_contracts.md) for request/response examples, such as `/api/analyze`.

--- a/docs/api_contracts.md
+++ b/docs/api_contracts.md
@@ -1,0 +1,24 @@
+# API contracts: /api/analyze
+
+Frontend sends a flat JSON body. The server tolerates the legacy wrapper `{ "payload": { ... } }` only for backward compatibility.
+
+## Request
+
+```http
+POST /api/analyze
+Content-Type: application/json
+
+{
+  "text": "Hello"
+}
+```
+
+## Response
+
+```json
+{
+  "status": "OK",
+  "analysis": {},
+  "schema_version": "1.4"
+}
+```


### PR DESCRIPTION
## Summary
- document `/api/analyze` request/response contract and note legacy `payload` wrapper
- link API contract doc from contributing guide

## Testing
- `LLM_PROVIDER=mock pytest` *(fails: 4 failed, 15 passed, 4 skipped)*
- `LLM_PROVIDER=mock python tools/doctor.py --out /tmp/doctor_out.md` *(fails: AZURE_OPENAI_API_KEY is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c1da773083258173a14cbf4591bc