### PR TITLE
docs: clarify /api/analyze request wrapper

### DIFF
--- a/docs/api_contracts.md
+++ b/docs/api_contracts.md
@@ -1,6 +1,8 @@
 # API contracts: /api/analyze
 
-Frontend sends a flat JSON body. The server tolerates the legacy wrapper `{ "payload": { ... } }` only for backward compatibility.
+Frontend sends a flat JSON body.
+
+Older deployments wrapped the payload inside a `{ "payload": { ... } }` object, but this wrapper is no longer supported. Requests using the wrapper will be rejected with a validation error.
 
 ## Request
 


### PR DESCRIPTION
## Summary
- clarify that /api/analyze no longer accepts legacy `payload` wrapper

## Testing
- `LLM_PROVIDER=mock pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `python tools/doctor.py --out /tmp/doctor_out.md`

------
https://chatgpt.com/codex/tasks/task_e_68c6c4eded5c8325bd05bc0e61efb637