### PR TITLE
fix: use selected schema in analyze requests

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -144,7 +144,10 @@ async function apiHealth() {
   return req("/health", { key: "health" });
 }
 async function analyze(args = {}) {
-  const body = { mode: args.mode ?? "live", schema: args.schema ?? "1.4" };
+  const body = {
+    mode: args.mode ?? "live",
+    schema: args.schema ?? (window.CAI?.Store?.get?.()?.schemaVersion || localStorage.getItem("schema_version") || "1.4")
+  };
   if (args.text != null) body.text = args.text;
   const { resp, json } = await postJson("/api/analyze", body);
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -263,7 +263,7 @@ export async function apiHealth(backend?: string) {
 export async function analyze(args: { text?: string; mode?: string; schema?: string } = {}) {
   const body: any = {
     mode: args.mode ?? 'live',
-    schema: args.schema ?? '1.4',
+    schema: args.schema ?? getSchemaFromStore(),
   };
   if (args.text != null) body.text = args.text;
 

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -144,7 +144,10 @@ async function apiHealth() {
   return req("/health", { key: "health" });
 }
 async function analyze(args = {}) {
-  const body = { mode: args.mode ?? "live", schema: args.schema ?? "1.4" };
+  const body = {
+    mode: args.mode ?? "live",
+    schema: args.schema ?? (window.CAI?.Store?.get?.()?.schemaVersion || localStorage.getItem("schema_version") || "1.4")
+  };
   if (args.text != null) body.text = args.text;
   const { resp, json } = await postJson("/api/analyze", body);
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -263,7 +263,7 @@ export async function apiHealth(backend?: string) {
 export async function analyze(args: { text?: string; mode?: string; schema?: string } = {}) {
   const body: any = {
     mode: args.mode ?? 'live',
-    schema: args.schema ?? '1.4',
+    schema: args.schema ?? getSchemaFromStore(),
   };
   if (args.text != null) body.text = args.text;
 


### PR DESCRIPTION
## Summary
- ensure analyze request body uses schema from store to match header
- mirror schema version change in built panel scripts

## Testing
- `pre-commit run --files contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts word_addin_dev/app/assets/api-client.ts contract_review_app/contract_review_app/static/panel/app/assets/api-client.js word_addin_dev/app/assets/api-client.js`
- `npm run build:panel`
- `pytest` *(fails: assert 422 == 200; missing pytest-watch module)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c8d39f6883258f84f09bcb98efa3