### PR TITLE
fix: sync schema version between header and body

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -81,7 +81,8 @@ export async function postJSON(path, body, timeoutOverride) {
         const key = getApiKeyFromStore();
         if (key)
             headers['x-api-key'] = key;
-        const bodyStr = JSON.stringify(body || {});
+        const bodyWithSchema = Object.assign({}, body || {}, { schema });
+        const bodyStr = JSON.stringify(bodyWithSchema);
         const sizeBytes = new TextEncoder().encode(bodyStr).length;
         let timeoutMs = timeoutOverride;
         let retryCount = ANALYZE_RETRY_COUNT;
@@ -193,7 +194,9 @@ async function req(path, { method = 'GET', body = null, key = path, timeoutMs = 
         const apiKey = getApiKeyFromStore();
         if (apiKey)
             headers['x-api-key'] = apiKey;
-        headers['x-schema-version'] = getSchemaFromStore() || '1.4';
+        const schema = getSchemaFromStore() || '1.4';
+        headers['x-schema-version'] = schema;
+        const payload = body && method !== 'GET' ? Object.assign({}, body, { schema }) : method !== 'GET' ? { schema } : undefined;
         const ctrl = new AbortController();
         const t = setTimeout(() => ctrl.abort('timeout'), timeoutMs);
         registerFetch(ctrl);
@@ -203,7 +206,7 @@ async function req(path, { method = 'GET', body = null, key = path, timeoutMs = 
             r = await fetch(base() + path, {
                 method,
                 headers,
-                body: body ? JSON.stringify(body) : undefined,
+                body: payload ? JSON.stringify(payload) : undefined,
                 credentials: 'include',
                 signal: ctrl.signal,
             });
@@ -223,7 +226,7 @@ async function req(path, { method = 'GET', body = null, key = path, timeoutMs = 
             const w = window;
             if (!w.__last)
                 w.__last = {};
-            w.__last[key] = { status: r.status, req: { path, method, body }, json };
+            w.__last[key] = { status: r.status, req: { path, method, body: payload }, json };
         }
         catch { }
         return { ok: r.ok, json, resp: r, meta };

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -123,7 +123,8 @@ export async function postJSON(path: string, body: any, timeoutOverride?: number
     const key = getApiKeyFromStore();
     if (key) headers['x-api-key'] = key;
 
-    const bodyStr = JSON.stringify(body || {});
+    const bodyWithSchema = { ...(body || {}), schema };
+    const bodyStr = JSON.stringify(bodyWithSchema);
     const sizeBytes = new TextEncoder().encode(bodyStr).length;
 
     let timeoutMs = timeoutOverride;
@@ -224,7 +225,10 @@ async function req(path: string, { method='GET', body=null, key=path, timeoutMs=
     const headers: Record<string, string> = { 'Content-Type':'application/json' };
     const apiKey = getApiKeyFromStore();
     if (apiKey) headers['x-api-key'] = apiKey;
-    headers['x-schema-version'] = getSchemaFromStore() || '1.4';
+    const schema = getSchemaFromStore() || '1.4';
+    headers['x-schema-version'] = schema;
+
+    const payload = body && method !== 'GET' ? { ...body, schema } : method !== 'GET' ? { schema } : undefined;
 
     const ctrl = new AbortController();
     const t = setTimeout(() => ctrl.abort('timeout'), timeoutMs);
@@ -235,7 +239,7 @@ async function req(path: string, { method='GET', body=null, key=path, timeoutMs=
       r = await fetch(base()+path, {
         method,
         headers,
-        body: body ? JSON.stringify(body) : undefined,
+        body: payload ? JSON.stringify(payload) : undefined,
         credentials: 'include',
         signal: ctrl.signal,
       });
@@ -250,7 +254,7 @@ async function req(path: string, { method='GET', body=null, key=path, timeoutMs=
     try {
       const w = window as any;
       if (!w.__last) w.__last = {};
-      w.__last[key] = { status: r.status, req: { path, method, body }, json };
+      w.__last[key] = { status: r.status, req: { path, method, body: payload }, json };
     } catch {}
     return { ok: r.ok, json, resp: r, meta };
   });

--- a/contract_review_app/frontend/common/http.ts
+++ b/contract_review_app/frontend/common/http.ts
@@ -33,13 +33,15 @@ export function ensureHeadersSet() {
 }
 
 export async function postJSON<T>(url: string, body: unknown, extra: HeadersMap = {}): Promise<T> {
+  const schema = getStoredSchema() || '1.4';
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
     'x-api-key': getStoredKey(),
-    'x-schema-version': getStoredSchema(),
+    'x-schema-version': schema,
     ...extra,
   };
-  const r = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  const payload = { ...(body as any || {}), schema };
+  const r = await fetch(url, { method: 'POST', headers, body: JSON.stringify(payload) });
   const respSchema = r.headers.get('x-schema-version');
   if (respSchema) setStoredSchema(respSchema);
   if (!r.ok) {

--- a/word_addin_dev/app/__tests__/analyze.payload.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.payload.spec.ts
@@ -11,7 +11,7 @@ describe('analyze payload wrapper', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
-    expect(body).toMatchObject({ mode: 'live', text: 'hello' });
-    expect(body.schema).toBeUndefined();
+    expect(body).toMatchObject({ mode: 'live', text: 'hello', schema: '1.4' });
+    expect(opts.headers['x-schema-version']).toBe('1.4');
   });
 });

--- a/word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts
+++ b/word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts
@@ -38,10 +38,11 @@ describe('ensure text for analyze', () => {
     expect(getWholeDocText).toHaveBeenCalledOnce();
     const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
     expect(analyzeCalls.length).toBe(1);
-    const body = JSON.parse(analyzeCalls[0][1].body);
+    const opts = analyzeCalls[0][1];
+    const body = JSON.parse(opts.body);
     expect(body.text.length).toBeGreaterThan(0);
-    expect(body).toMatchObject({ mode: 'live' });
-    expect(body.schema).toBeUndefined();
+    expect(body).toMatchObject({ mode: 'live', schema: '1.4' });
+    expect(opts.headers['x-schema-version']).toBe('1.4');
   });
 
   it('warns when document empty', async () => {

--- a/word_addin_dev/app/__tests__/postRedlines.spec.ts
+++ b/word_addin_dev/app/__tests__/postRedlines.spec.ts
@@ -12,6 +12,8 @@ describe('postRedlines', () => {
     const mod = await import('../assets/api-client');
     await mod.postRedlines('a', 'b');
     const [, opts] = (globalThis.fetch as any).mock.calls[0];
-    expect(JSON.parse(opts.body)).toEqual({ before_text: 'a', after_text: 'b' });
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({ before_text: 'a', after_text: 'b', schema: '1.4' });
+    expect(opts.headers['x-schema-version']).toBe('1.4');
   });
 });

--- a/word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts
@@ -64,9 +64,10 @@ describe('use whole doc + analyze flow', () => {
     expect(book.classList.contains('hidden')).toBe(true);
     const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
     expect(analyzeCalls.length).toBe(1);
-    const body = JSON.parse(analyzeCalls[0][1].body);
-    expect(body).toMatchObject({ mode: 'live', text: 'TEST BODY' });
-    expect(body.schema).toBeUndefined();
+    const opts = analyzeCalls[0][1];
+    const body = JSON.parse(opts.body);
+    expect(body).toMatchObject({ mode: 'live', text: 'TEST BODY', schema: '1.4' });
+    expect(opts.headers['x-schema-version']).toBe('1.4');
     vi.useRealTimers();
   }, 10000);
 });

--- a/word_addin_dev/app/assets/__tests__/analyze.body.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/analyze.body.spec.ts
@@ -9,9 +9,10 @@ describe('analyze request body', () => {
     (globalThis as any).fetch = fetchMock;
     const { analyze } = await import('../api-client.ts');
     await analyze({ text: 'hi' });
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body).toMatchObject({ text: 'hi', mode: 'live' });
-    expect(body.schema).toBeUndefined();
+    const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
+    const body = JSON.parse(bodyStr);
+    expect(body).toMatchObject({ text: 'hi', mode: 'live', schema: '1.4' });
+    expect(headers['x-schema-version']).toBe('1.4');
   });
 
   it('ignores provided schema but preserves mode', async () => {
@@ -19,8 +20,9 @@ describe('analyze request body', () => {
     (globalThis as any).fetch = fetchMock;
     const { analyze } = await import('../api-client.ts');
     await analyze({ schema: '1.4', mode: 'test', text: 'hi' });
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body).toMatchObject({ text: 'hi', mode: 'test' });
-    expect(body.schema).toBeUndefined();
+    const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
+    const body = JSON.parse(bodyStr);
+    expect(body).toMatchObject({ text: 'hi', mode: 'test', schema: '1.4' });
+    expect(headers['x-schema-version']).toBe('1.4');
   });
 });

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -81,7 +81,8 @@ export async function postJSON(path, body, timeoutOverride) {
         const key = getApiKeyFromStore();
         if (key)
             headers['x-api-key'] = key;
-        const bodyStr = JSON.stringify(body || {});
+        const bodyWithSchema = Object.assign({}, body || {}, { schema });
+        const bodyStr = JSON.stringify(bodyWithSchema);
         const sizeBytes = new TextEncoder().encode(bodyStr).length;
         let timeoutMs = timeoutOverride;
         let retryCount = ANALYZE_RETRY_COUNT;
@@ -193,7 +194,9 @@ async function req(path, { method = 'GET', body = null, key = path, timeoutMs = 
         const apiKey = getApiKeyFromStore();
         if (apiKey)
             headers['x-api-key'] = apiKey;
-        headers['x-schema-version'] = getSchemaFromStore() || '1.4';
+        const schema = getSchemaFromStore() || '1.4';
+        headers['x-schema-version'] = schema;
+        const payload = body && method !== 'GET' ? Object.assign({}, body, { schema }) : method !== 'GET' ? { schema } : undefined;
         const ctrl = new AbortController();
         const t = setTimeout(() => ctrl.abort('timeout'), timeoutMs);
         registerFetch(ctrl);
@@ -203,7 +206,7 @@ async function req(path, { method = 'GET', body = null, key = path, timeoutMs = 
             r = await fetch(base() + path, {
                 method,
                 headers,
-                body: body ? JSON.stringify(body) : undefined,
+                body: payload ? JSON.stringify(payload) : undefined,
                 credentials: 'include',
                 signal: ctrl.signal,
             });
@@ -223,7 +226,7 @@ async function req(path, { method = 'GET', body = null, key = path, timeoutMs = 
             const w = window;
             if (!w.__last)
                 w.__last = {};
-            w.__last[key] = { status: r.status, req: { path, method, body }, json };
+            w.__last[key] = { status: r.status, req: { path, method, body: payload }, json };
         }
         catch { }
         return { ok: r.ok, json, resp: r, meta };

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -123,7 +123,8 @@ export async function postJSON(path: string, body: any, timeoutOverride?: number
     const key = getApiKeyFromStore();
     if (key) headers['x-api-key'] = key;
 
-    const bodyStr = JSON.stringify(body || {});
+    const bodyWithSchema = { ...(body || {}), schema };
+    const bodyStr = JSON.stringify(bodyWithSchema);
     const sizeBytes = new TextEncoder().encode(bodyStr).length;
 
     let timeoutMs = timeoutOverride;
@@ -224,7 +225,10 @@ async function req(path: string, { method='GET', body=null, key=path, timeoutMs=
     const headers: Record<string, string> = { 'Content-Type':'application/json' };
     const apiKey = getApiKeyFromStore();
     if (apiKey) headers['x-api-key'] = apiKey;
-    headers['x-schema-version'] = getSchemaFromStore() || '1.4';
+    const schema = getSchemaFromStore() || '1.4';
+    headers['x-schema-version'] = schema;
+
+    const payload = body && method !== 'GET' ? { ...body, schema } : method !== 'GET' ? { schema } : undefined;
 
     const ctrl = new AbortController();
     const t = setTimeout(() => ctrl.abort('timeout'), timeoutMs);
@@ -235,7 +239,7 @@ async function req(path: string, { method='GET', body=null, key=path, timeoutMs=
       r = await fetch(base()+path, {
         method,
         headers,
-        body: body ? JSON.stringify(body) : undefined,
+        body: payload ? JSON.stringify(payload) : undefined,
         credentials: 'include',
         signal: ctrl.signal,
       });
@@ -250,7 +254,7 @@ async function req(path: string, { method='GET', body=null, key=path, timeoutMs=
     try {
       const w = window as any;
       if (!w.__last) w.__last = {};
-      w.__last[key] = { status: r.status, req: { path, method, body }, json };
+      w.__last[key] = { status: r.status, req: { path, method, body: payload }, json };
     } catch {}
     return { ok: r.ok, json, resp: r, meta };
   });

--- a/word_addin_dev/app/src/panel/analyze.flow.spec.ts
+++ b/word_addin_dev/app/src/panel/analyze.flow.spec.ts
@@ -19,7 +19,8 @@ describe('analyze flow', () => {
     const { postJson } = await import('../../assets/api-client.ts');
     await postJson('/api/analyze', { text: 'hello' });
     const body = JSON.parse(captured.body);
-    expect(body).toEqual({ text: 'hello' });
+    expect(body).toEqual({ text: 'hello', schema: '1.2' });
+    expect(captured.headers['x-schema-version']).toBe('1.2');
     expect(body).not.toHaveProperty('mode');
   });
 });

--- a/word_addin_dev/app/src/panel/postJson.spec.ts
+++ b/word_addin_dev/app/src/panel/postJson.spec.ts
@@ -38,5 +38,7 @@ describe('postJson', () => {
     await postJson('/test', { a: 1 });
     expect(captured.headers['x-api-key']).toBe('KEY');
     expect(captured.headers['x-schema-version']).toBe('1.2');
+    const parsed = JSON.parse(captured.body);
+    expect(parsed).toMatchObject({ a: 1, schema: '1.2' });
   });
 });


### PR DESCRIPTION
## Summary
- read schema version from store and attach to request header and body
- cover schema version consistency with tests

## Testing
- `pre-commit run --files word_addin_dev/app/assets/api-client.ts contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts word_addin_dev/app/assets/api-client.js contract_review_app/contract_review_app/static/panel/app/assets/api-client.js contract_review_app/frontend/common/http.ts word_addin_dev/app/assets/__tests__/analyze.body.spec.ts word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts word_addin_dev/app/__tests__/analyze.payload.spec.ts word_addin_dev/app/src/panel/postJson.spec.ts word_addin_dev/app/src/panel/analyze.flow.spec.ts`
- `pre-commit run --files word_addin_dev/app/__tests__/postRedlines.spec.ts`
- `cd word_addin_dev && npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c6cee764788325a6e2ffc706b4e726