### PR TITLE
chore: unify API header case and fetch credentials

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1242,7 +1242,7 @@ def _as_dict(model_or_obj: Any) -> Dict[str, Any]:
 
 
 def _set_schema_headers(response: Response) -> None:
-    response.headers["X-Schema-Version"] = SCHEMA_VERSION
+    response.headers["x-schema-version"] = SCHEMA_VERSION
 
 
 def _set_std_headers(

--- a/contract_review_app/api/middlewares.py
+++ b/contract_review_app/api/middlewares.py
@@ -30,7 +30,7 @@ class RequireHeadersMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
 
         if 200 <= response.status_code < 400:
-            response.headers["X-Schema-Version"] = SCHEMA_VERSION
+            response.headers["x-schema-version"] = SCHEMA_VERSION
             if request.url.path == "/api/analyze":
                 cid = response.headers.get("x-cid") or request.state.cid
                 response.headers["X-Cid"] = cid

--- a/contract_review_app/frontend/common/http.ts
+++ b/contract_review_app/frontend/common/http.ts
@@ -39,7 +39,12 @@ export async function postJSON<T>(url: string, body: unknown, extra: HeadersMap 
     'x-schema-version': getStoredSchema(),
     ...extra,
   };
-  const r = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  const r = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    credentials: 'include',
+  });
   const respSchema = r.headers.get('x-schema-version');
   if (respSchema) setStoredSchema(respSchema);
   if (!r.ok) {

--- a/tests/api/test_headers_policy.py
+++ b/tests/api/test_headers_policy.py
@@ -30,5 +30,5 @@ def test_post_analyze_ok_headers():
     headers = {"x-api-key": "k", "x-schema-version": SCHEMA_VERSION}
     r = client.post("/api/analyze", json={"text": "hi"}, headers=headers)
     assert r.status_code == 200
-    assert r.headers["X-Schema-Version"] == SCHEMA_VERSION
+    assert r.headers["x-schema-version"] == SCHEMA_VERSION
     assert r.headers.get("X-Cid")


### PR DESCRIPTION
## Summary
- set backend response header to lower-case `x-schema-version`
- include `credentials: 'include'` in frontend `postJSON`
- update header tests to match lower-case naming

## Testing
- `npx --yes jest`
- `pytest tests/api/test_headers_policy.py tests/api/test_analyze_minimal.py tests/security/test_api_key_auth.py -q`
- `pytest tests/api/test_headers_policy.py::test_post_analyze_ok_headers -vv`

------
https://chatgpt.com/codex/tasks/task_e_68c6cf0f2e908325a46ea7fed47441ae