### PR TITLE
panel: load prebuilt taskpane bundle and harden static serving

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/taskpane.html
+++ b/contract_review_app/contract_review_app/static/panel/taskpane.html
@@ -126,14 +126,7 @@
     window.__DEV_DEFAULT_API_KEY__ = "{{DEFAULT_API_KEY}}";
   </script>
 
-  <!-- Единый модульный загрузчик -->
-  <script type="module">
-    import { bootstrapHeaders } from './app/assets/bootstrap.js?v=DEV';
-    await bootstrapHeaders();
-    await import('./app/assets/store.js?v=DEV');
-    await import('./app/assets/api-client.js?v=DEV');
-      await import('./taskpane.bundle.js?b=build-20250914-100041');
-  </script>
+  <script src="./taskpane.bundle.js?b=build-20250914-100041"></script>
 
   <script nomodule>
     document.body.innerHTML =

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -126,14 +126,7 @@
     window.__DEV_DEFAULT_API_KEY__ = "{{DEFAULT_API_KEY}}";
   </script>
 
-  <!-- Единый модульный загрузчик -->
-  <script type="module">
-    import { bootstrapHeaders } from './app/assets/bootstrap.js?v=DEV';
-    await bootstrapHeaders();
-    await import('./app/assets/store.js?v=DEV');
-    await import('./app/assets/api-client.js?v=DEV');
-      await import('./taskpane.bundle.js?b=build-20250914-100041');
-  </script>
+  <script src="./taskpane.bundle.js?b=build-20250914-100041"></script>
 
   <script nomodule>
     document.body.innerHTML =


### PR DESCRIPTION
## Summary
- load taskpane bundle script directly to avoid runtime TypeScript imports
- guard static server so `.ts` files are served as plain text

## Testing
- `pre-commit run --files word_addin_dev/taskpane.html contract_review_app/contract_review_app/static/panel/taskpane.html contract_review_app/api/app.py`
- `npm --prefix word_addin_dev ci`
- `npm --prefix word_addin_dev run build`
- `python tools/build_panel.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c6d61f727083258cca22afe5b54c56