### PR TITLE
feat: guard draft with empty text and add safe search

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts
@@ -1,4 +1,5 @@
 import { normalizeText } from "./dedupe.ts";
+import { safeBodySearch } from "./safe-search.ts";
 
 interface RangeLike {
   start?: number;
@@ -25,7 +26,7 @@ export async function findAnchors(body: BodyLike, snippetRaw: string): Promise<R
   const opt = { matchCase: false, matchWholeWord: false };
 
   const attempt = (txt: string) => {
-    const res = body.search(txt, opt) as any;
+    const res = safeBodySearch(body, txt, opt) as any;
     if (res && typeof res.load === "function") res.load("items");
     return res;
   };

--- a/contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts
@@ -1,5 +1,6 @@
 import { AnalyzeFinding } from "./api-client.ts";
 import { dedupeFindings, normalizeText } from "./dedupe.ts";
+import { safeBodySearch } from "./safe-search.ts";
 
 /** Utilities for inserting comments into Word with batching and retries. */
 export interface CommentItem {
@@ -157,7 +158,7 @@ export async function findingsToWord(findings: AnalyzeFinding[]): Promise<number
     for (const op of ops) {
       let target: any = null;
 
-      const sRaw = body.search(op.raw, searchOpts);
+      const sRaw = safeBodySearch(body, op.raw, searchOpts);
       sRaw.load("items");
       await ctx.sync();
       target = pick(sRaw, op.occIdx);
@@ -165,7 +166,7 @@ export async function findingsToWord(findings: AnalyzeFinding[]): Promise<number
       if (!target) {
         const fb = op.normalized_fallback && op.normalized_fallback !== op.norm ? op.normalized_fallback : op.norm;
         if (fb && fb.trim()) {
-          const sNorm = body.search(fb, searchOpts);
+          const sNorm = safeBodySearch(body, fb, searchOpts);
           sNorm.load("items");
           await ctx.sync();
           target = pick(sNorm, op.occIdx);
@@ -179,7 +180,7 @@ export async function findingsToWord(findings: AnalyzeFinding[]): Promise<number
           return null;
         })();
         if (token) {
-          const sTok = body.search(token, searchOpts);
+          const sTok = safeBodySearch(body, token, searchOpts);
           sTok.load("items");
           await ctx.sync();
           target = pick(sTok, 0);

--- a/contract_review_app/contract_review_app/static/panel/app/assets/safe-search.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/safe-search.ts
@@ -1,0 +1,25 @@
+export interface BodyLike {
+  search: (s: string, opts: any) => any;
+}
+
+export function safeBodySearch(body: BodyLike, s: string, opts: any): any {
+  const empty = { items: [] as any[], load: () => {} };
+  if (!s) return empty;
+  let needle = s;
+  if (needle.length > 200) {
+    needle = needle.slice(0, 100).trim();
+    if (needle.length > 200) {
+      needle = needle.slice(0, 120);
+    }
+  }
+  try {
+    return body.search(needle, opts);
+  } catch (e: any) {
+    const code = e?.code || e?.name || '';
+    if (code === 'SearchStringInvalidOrTooLong' || code === 'InvalidArgument') {
+      try { console.warn('[WARN] safeBodySearch', code); } catch {}
+      return empty;
+    }
+    throw e;
+  }
+}

--- a/contract_review_app/contract_review_app/static/panel/taskpane.html
+++ b/contract_review_app/contract_review_app/static/panel/taskpane.html
@@ -267,7 +267,7 @@
     <div class="muted" style="margin-bottom:6px">Original clause:</div>
     <textarea id="originalClause" placeholder="Paste text or load from selection/document…"></textarea>
     <div class="row flex" style="margin-top:8px">
-      <button id="btnSuggestEdit" class="btn btn-primary btn-sm">Get draft</button>
+      <button id="btnSuggestEdit" class="btn btn-primary btn-sm" disabled>Get draft</button>
     </div>
     <div class="row">
       <span class="badge" id="scoreBadge">score: —</span>

--- a/word_addin_dev/app/__tests__/draft.spec.ts
+++ b/word_addin_dev/app/__tests__/draft.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+const html = readFileSync(
+  new URL('../../../contract_review_app/contract_review_app/static/panel/taskpane.html', import.meta.url),
+  'utf-8',
+);
+
+describe('get draft', () => {
+  let fetchMock: any;
+  beforeEach(() => {
+    vi.resetModules();
+    const dom = new JSDOM(html, { url: 'https://localhost:9443' });
+    (globalThis as any).window = dom.window as any;
+    (globalThis as any).document = dom.window.document as any;
+    (globalThis as any).Event = dom.window.Event;
+    (globalThis as any).CustomEvent = dom.window.CustomEvent;
+    (globalThis as any).localStorage = {
+      store: {} as Record<string, string>,
+      getItem(key: string) { return this.store[key] || null; },
+      setItem(key: string, value: string) { this.store[key] = value; }
+    };
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    (globalThis as any).fetch = fetchMock;
+    (globalThis as any).Office = {
+      onReady: (cb: any) => cb({ host: 'Word' }),
+      context: {
+        requirements: { isSetSupported: () => true },
+        host: 'Word',
+        document: { addHandlerAsync: (_: any, cb: any) => { (globalThis as any).__selHandler = cb; } },
+      },
+      EventType: { DocumentSelectionChanged: 'DocumentSelectionChanged' },
+    };
+    (globalThis as any).__CAI_TESTING__ = true;
+  });
+
+  it('btnDraft disabled with empty text and no selection', async () => {
+    const { wireUI, onSuggestEdit } = await import('../assets/taskpane.ts');
+    wireUI();
+    const btn = document.getElementById('btnSuggestEdit') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    await onSuggestEdit();
+    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt-draft'));
+    expect(calls.length).toBe(0);
+  });
+
+  it('selection enables and sends request with text', async () => {
+    (globalThis as any).getSelectionText = vi.fn().mockResolvedValue('Hello');
+    const { wireUI, getClauseText, onSuggestEdit } = await import('../assets/taskpane.ts');
+    wireUI();
+    await getClauseText();
+    const btn = document.getElementById('btnSuggestEdit') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    await onSuggestEdit();
+    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt-draft'));
+    expect(calls.length).toBe(1);
+    const body = JSON.parse(calls[0][1].body);
+    expect(body).toMatchObject({ text: 'Hello' });
+  });
+
+  it('Word API failure warns and skips request', async () => {
+    (globalThis as any).getSelectionText = vi.fn().mockRejectedValue(new Error('fail'));
+    vi.mock('../assets/notifier.ts', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
+    const { wireUI, onSuggestEdit } = await import('../assets/taskpane.ts');
+    const { notifyWarn } = await import('../assets/notifier.ts');
+    wireUI();
+    await onSuggestEdit();
+    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt-draft'));
+    expect(calls.length).toBe(0);
+    expect(notifyWarn).toHaveBeenCalledWith("Select some text or paste into 'Original clause'");
+  });
+});

--- a/word_addin_dev/app/__tests__/safeBodySearch.spec.ts
+++ b/word_addin_dev/app/__tests__/safeBodySearch.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { safeBodySearch } from '../assets/safe-search.ts';
+
+describe('safeBodySearch', () => {
+  it('handles SearchStringInvalidOrTooLong gracefully', () => {
+    const body = {
+      search: vi.fn().mockImplementation(() => { const err: any = new Error('fail'); err.code = 'SearchStringInvalidOrTooLong'; throw err; }),
+    };
+    const res = safeBodySearch(body, 'x', {});
+    expect(res.items.length).toBe(0);
+    expect(body.search).toHaveBeenCalledOnce();
+  });
+
+  it('truncates long strings', () => {
+    const long = 'a'.repeat(5000);
+    const body = { search: vi.fn().mockReturnValue({ items: [] }) };
+    safeBodySearch(body, long, {});
+    const arg = body.search.mock.calls[0][0];
+    expect(arg.length).toBeLessThanOrEqual(200);
+  });
+
+  it('passes short strings through', () => {
+    const body = { search: vi.fn().mockReturnValue({ items: [1] }) };
+    const res = safeBodySearch(body, 'short', {});
+    expect(res.items[0]).toBe(1);
+    expect(body.search).toHaveBeenCalledWith('short', {});
+  });
+});

--- a/word_addin_dev/app/assets/anchors.ts
+++ b/word_addin_dev/app/assets/anchors.ts
@@ -1,4 +1,5 @@
 import { normalizeText } from "./dedupe.ts";
+import { safeBodySearch } from "./safe-search.ts";
 
 interface RangeLike {
   start?: number;
@@ -25,7 +26,7 @@ export async function findAnchors(body: BodyLike, snippetRaw: string): Promise<R
   const opt = { matchCase: false, matchWholeWord: false };
 
   const attempt = (txt: string) => {
-    const res = body.search(txt, opt) as any;
+    const res = safeBodySearch(body, txt, opt) as any;
     if (res && typeof res.load === "function") res.load("items");
     return res;
   };

--- a/word_addin_dev/app/assets/safe-search.ts
+++ b/word_addin_dev/app/assets/safe-search.ts
@@ -1,0 +1,25 @@
+export interface BodyLike {
+  search: (s: string, opts: any) => any;
+}
+
+export function safeBodySearch(body: BodyLike, s: string, opts: any): any {
+  const empty = { items: [] as any[], load: () => {} };
+  if (!s) return empty;
+  let needle = s;
+  if (needle.length > 200) {
+    needle = needle.slice(0, 100).trim();
+    if (needle.length > 200) {
+      needle = needle.slice(0, 120);
+    }
+  }
+  try {
+    return body.search(needle, opts);
+  } catch (e: any) {
+    const code = e?.code || e?.name || '';
+    if (code === 'SearchStringInvalidOrTooLong' || code === 'InvalidArgument') {
+      try { console.warn('[WARN] safeBodySearch', code); } catch {}
+      return empty;
+    }
+    throw e;
+  }
+}

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -267,7 +267,7 @@
     <div class="muted" style="margin-bottom:6px">Original clause:</div>
     <textarea id="originalClause" placeholder="Paste text or load from selection/document…"></textarea>
     <div class="row flex" style="margin-top:8px">
-      <button id="btnSuggestEdit" class="btn btn-primary btn-sm">Get draft</button>
+      <button id="btnSuggestEdit" class="btn btn-primary btn-sm" disabled>Get draft</button>
     </div>
     <div class="row">
       <span class="badge" id="scoreBadge">score: —</span>


### PR DESCRIPTION
## Summary
- disable draft generation when no clause text is provided and auto-fill from selection
- add safeBodySearch utility to avoid SearchStringInvalidOrTooLong and use it across word searches
- cover draft button behaviour and safeBodySearch with vitest tests

## Testing
- `npm --prefix word_addin_dev test`

------
https://chatgpt.com/codex/tasks/task_e_68c6dbf9f5b08325be294201be3b2a1b