### PR TITLE
fix: use clause field in draft request

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -598,7 +598,7 @@ export async function onSuggestEdit(ev?: Event) {
     if (!clause) { notifyWarn("Select some text or paste into 'Original clause'"); return; }
     try {
       const dst = $(Q.proposed);
-      const { json } = await postJSON('/api/gpt-draft', { cid: lastCid, text: clause, mode: 'friendly' });
+      const { json } = await postJSON('/api/gpt-draft', { cid: lastCid, clause, mode: 'friendly' });
       const proposed = (json?.proposed_text ?? json?.text ?? "").toString();
       const w: any = window as any;
       w.__last = w.__last || {};

--- a/word_addin_dev/app/__tests__/draft.spec.ts
+++ b/word_addin_dev/app/__tests__/draft.spec.ts
@@ -45,7 +45,7 @@ describe('get draft', () => {
     expect(calls.length).toBe(0);
   });
 
-  it('selection enables and sends request with text', async () => {
+  it('selection enables and sends request with clause', async () => {
     (globalThis as any).getSelectionText = vi.fn().mockResolvedValue('Hello');
     const { wireUI, getClauseText, onSuggestEdit } = await import('../assets/taskpane.ts');
     wireUI();
@@ -56,7 +56,7 @@ describe('get draft', () => {
     const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt-draft'));
     expect(calls.length).toBe(1);
     const body = JSON.parse(calls[0][1].body);
-    expect(body).toMatchObject({ text: 'Hello' });
+    expect(body).toMatchObject({ clause: 'Hello' });
   });
 
   it('Word API failure warns and skips request', async () => {

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -598,7 +598,7 @@ export async function onSuggestEdit(ev?: Event) {
     if (!clause) { notifyWarn("Select some text or paste into 'Original clause'"); return; }
     try {
       const dst = $(Q.proposed);
-      const { json } = await postJSON('/api/gpt-draft', { cid: lastCid, text: clause, mode: 'friendly' });
+      const { json } = await postJSON('/api/gpt-draft', { cid: lastCid, clause, mode: 'friendly' });
       const proposed = (json?.proposed_text ?? json?.text ?? "").toString();
       const w: any = window as any;
       w.__last = w.__last || {};


### PR DESCRIPTION
## Summary
- send `clause` field when requesting draft to match backend expectations
- update draft request test to assert on `clause` payload

## Testing
- `pre-commit run --files contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts word_addin_dev/app/assets/taskpane.ts word_addin_dev/app/__tests__/draft.spec.ts`
- `npm --prefix word_addin_dev test`


------
https://chatgpt.com/codex/tasks/task_e_68c6df57bee483258b18535354ec9546