### PR TITLE
feat: add draft alias and supports endpoint

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1648,6 +1648,13 @@ async def health() -> JSONResponse:
     return _finalize_json("/health", payload, headers, status_code=status_code)
 
 
+@router.get("/api/supports")
+async def api_supports() -> JSONResponse:
+    payload = {"status": "ok", "supports": {"comments": True, "content_controls": True}}
+    headers = {"x-schema-version": SCHEMA_VERSION}
+    return _finalize_json("/api/supports", payload, headers)
+
+
 @router.get("/api/trace")
 async def list_trace():
     return {"cids": TRACE.list()[-50:]}
@@ -2674,7 +2681,7 @@ async def health_alias():
 
 @app.post("/analyze")
 def analyze_alias(req: AnalyzeRequest, request: Request):
-    return api_analyze(request, req)
+    return api_analyze(request, req.model_dump())
 
 
 @router.post("/suggest_edits")
@@ -2682,6 +2689,11 @@ async def suggest_edits_alias(
     request: Request, response: Response, x_cid: Optional[str] = Header(None)
 ):
     return await api_suggest_edits(request, response, x_cid)
+
+
+@router.post("/api/draft", responses={422: {"model": ProblemDetail}})
+async def draft_alias(request: Request, body: dict = Body(...)):
+    return await gpt_draft(request, body)
 
 
 @app.get("/llm/ping")

--- a/openapi.json
+++ b/openapi.json
@@ -786,6 +786,147 @@
         }
       }
     },
+    "/api/supports": {
+      "get": {
+        "summary": "Api Supports",
+        "operationId": "api_supports_api_supports_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "504": {
+            "description": "Gateway Timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/trace": {
       "get": {
         "summary": "List Trace",
@@ -3554,9 +3695,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DraftOut"
-                },
+                "schema": {},
                 "examples": {
                   "default": {
                     "summary": "Example",
@@ -4171,6 +4310,180 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "504": {
+            "description": "Gateway Timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/draft": {
+      "post": {
+        "summary": "Draft Alias",
+        "operationId": "draft_alias_api_draft_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Body"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "headers": {
+              "x-schema-version": {
+                "$ref": "#/components/headers/XSchemaVersion"
+              },
+              "x-latency-ms": {
+                "$ref": "#/components/headers/XLatencyMs"
+              },
+              "x-cid": {
+                "$ref": "#/components/headers/XCid"
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
             },
@@ -6354,79 +6667,6 @@
           "coverage"
         ],
         "title": "Coverage"
-      },
-      "DraftOut": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "mode": {
-            "type": "string",
-            "title": "Mode"
-          },
-          "proposed_text": {
-            "type": "string",
-            "title": "Proposed Text"
-          },
-          "rationale": {
-            "type": "string",
-            "title": "Rationale"
-          },
-          "evidence": {
-            "anyOf": [
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "additionalProperties": true,
-                "type": "object"
-              }
-            ],
-            "title": "Evidence"
-          },
-          "before_text": {
-            "type": "string",
-            "title": "Before Text"
-          },
-          "after_text": {
-            "type": "string",
-            "title": "After Text"
-          },
-          "diff": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Diff"
-          },
-          "x_schema_version": {
-            "type": "string",
-            "title": "X Schema Version"
-          },
-          "context_before": {
-            "type": "string",
-            "title": "Context Before"
-          },
-          "context_after": {
-            "type": "string",
-            "title": "Context After"
-          }
-        },
-        "type": "object",
-        "required": [
-          "status",
-          "mode",
-          "proposed_text",
-          "rationale",
-          "evidence",
-          "before_text",
-          "after_text",
-          "diff",
-          "x_schema_version",
-          "context_before",
-          "context_after"
-        ],
-        "title": "DraftOut"
       },
       "HTTPValidationError": {
         "properties": {

--- a/tests/api/test_openapi_schema.py
+++ b/tests/api/test_openapi_schema.py
@@ -12,6 +12,8 @@ def test_openapi_contains_paths_and_models():
     paths = spec['paths']
     assert '/api/summary' in paths
     assert '/api/gpt-draft' in paths
+    assert '/api/draft' in paths
+    assert '/api/supports' in paths
     assert '/api/companies/search' in paths
     schemas = spec['components']['schemas']
     for name in ('SummaryIn', 'DraftRequest', '_CompanySearchIn'):

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -1,8 +1,13 @@
 from fastapi.testclient import TestClient
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
 
 client = TestClient(app)
+
+
+def _headers():
+    return {"x-api-key": "local-test-key-123", "x-schema-version": SCHEMA_VERSION}
 
 
 def test_health_ok():
@@ -21,25 +26,31 @@ def test_llm_ping_ok():
 
 def test_analyze_ok():
     payload = {"text": "Hello world"}
-    r = client.post("/api/analyze", json=payload)
+    r = client.post("/api/analyze", json=payload, headers=_headers())
     assert r.status_code == 200
-    r2 = client.post("/analyze", json=payload)
+    r2 = client.post("/analyze", json=payload, headers=_headers())
     assert r2.status_code == 200
 
 
 def test_suggest_ok():
     payload = {"text": "Hello world"}
-    r = client.post("/api/suggest_edits", json=payload)
+    r = client.post("/api/suggest_edits", json=payload, headers=_headers())
     assert r.status_code == 200
-    r2 = client.post("/suggest_edits", json=payload)
+    r2 = client.post("/suggest_edits", json=payload, headers=_headers())
     assert r2.status_code == 200
 
 
 def test_gpt_draft_ok():
-    r_an = client.post("/api/analyze", json={"text": "Hi"})
+    r_an = client.post("/api/analyze", json={"text": "Hi"}, headers=_headers())
     cid = r_an.headers.get("x-cid")
     payload = {"cid": cid, "clause": "Draft confidentiality clause"}
-    r = client.post("/api/gpt-draft", json=payload)
+    r = client.post("/api/gpt-draft", json=payload, headers=_headers())
     assert r.status_code == 200
+    r_alias = client.post("/api/draft", json=payload, headers=_headers())
+    assert r_alias.status_code == 200
     for p in ["/api/gpt/draft", "/gpt-draft", "/api/gpt_draft"]:
-        assert client.post(p, json=payload).status_code == 404
+        assert client.post(p, json=payload, headers=_headers()).status_code == 404
+
+
+def test_supports_ok():
+    assert client.get("/api/supports").status_code == 200


### PR DESCRIPTION
## Summary
- expose /api/draft as alias to gpt-draft and update analyze alias
- provide /api/supports endpoint for capability flags
- regenerate OpenAPI spec and expand smoke tests

## Testing
- `pytest tests/test_routes_smoke.py::test_analyze_ok tests/test_routes_smoke.py::test_suggest_ok tests/test_routes_smoke.py::test_gpt_draft_ok tests/test_routes_smoke.py::test_supports_ok tests/api/test_openapi_schema.py::test_openapi_contains_paths_and_models tests/api/test_openapi_clean.py::test_no_duplicate_paths_or_operation_ids`

------
https://chatgpt.com/codex/tasks/task_e_68c711e64fe883258095bbd251ef91f0