### PR TITLE
Add panel state navigation utilities

### DIFF
--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -1,6 +1,15 @@
 import { notifyOk, notifyWarn } from '../../assets/notifier';
 import { insertDraftText } from '../../assets/insert';
 import { ensureHeadersSet as ensureHeadersAuto } from '../../../../contract_review_app/frontend/common/http';
+export {
+  PanelState,
+  addCommentAtRange,
+  prevFinding,
+  nextFinding,
+  getDraft,
+  applyDraft,
+  rejectFinding,
+} from './state';
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string) =>
   document.querySelector(sel) as T | null;

--- a/word_addin_dev/app/src/panel/state.spec.ts
+++ b/word_addin_dev/app/src/panel/state.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PanelState, nextFinding, prevFinding, addCommentAtRange } from './state';
+
+vi.mock('../assets/safeBodySearch.ts', () => ({
+  safeBodySearch: vi.fn(async () => ({ items: [{ select: vi.fn(), font: {} }] }))
+}));
+
+vi.mock('../assets/api-client.ts', () => ({
+  postJSON: vi.fn(async () => ({ plainText: '', ops: [] }))
+}));
+
+describe('navigation', () => {
+  it('moves selection with next/prev', async () => {
+    const state: PanelState = {
+      mode: 'friendly',
+      items: [
+        { id: 'a', anchor: 'one' },
+        { id: 'b', anchor: 'two' }
+      ],
+      cachedDrafts: new Map(),
+      correlationId: 'cid'
+    };
+    const doc = { body: {} } as any;
+    await nextFinding(state, doc);
+    expect(state.selectedId).toBe('a');
+    await nextFinding(state, doc);
+    expect(state.selectedId).toBe('b');
+    await prevFinding(state, doc);
+    expect(state.selectedId).toBe('a');
+  });
+});
+
+describe('addCommentAtRange', () => {
+  it('falls back to paragraph comment on error', () => {
+    const pIns = vi.fn();
+    const range: any = {
+      insertComment: () => { throw new Error('fail'); },
+      paragraphs: { getFirst: () => ({ insertComment: pIns }) }
+    };
+    addCommentAtRange(range, 'hi');
+    expect(pIns).toHaveBeenCalledWith('hi');
+  });
+});

--- a/word_addin_dev/app/src/panel/state.ts
+++ b/word_addin_dev/app/src/panel/state.ts
@@ -1,0 +1,110 @@
+import { safeBodySearch } from '../assets/safeBodySearch.ts';
+import { postJSON } from '../assets/api-client.ts';
+
+export interface Finding {
+  id: string;
+  anchor: string;
+  snippet?: string;
+  skipped?: boolean;
+}
+
+export interface DraftOp {
+  anchor: string;
+  replace?: { before?: string; after: string };
+}
+
+export interface Draft {
+  plainText: string;
+  ops: DraftOp[];
+}
+
+export type PanelState = {
+  mode: 'friendly' | 'strict';
+  items: Finding[];
+  selectedId?: string;
+  cachedDrafts: Map<string, Draft>;
+  correlationId: string;
+};
+
+/**
+ * Safely add a comment at the provided Word range. If inserting the comment
+ * directly fails, the comment is added to the first paragraph of the range.
+ */
+export function addCommentAtRange(range: Word.Range, text: string) {
+  try {
+    range.insertComment(text);
+  } catch {
+    try {
+      const p = range.paragraphs.getFirst();
+      p.insertComment(text);
+    } catch {}
+  }
+}
+
+function itemIndex(state: PanelState, id?: string) {
+  return state.items.findIndex(f => f.id === id);
+}
+
+async function focusRange(body: Word.Body, anchor: string) {
+  const searchOpts = { matchCase: false, matchWholeWord: false };
+  const res = await safeBodySearch(body, anchor, searchOpts);
+  const range = res?.items?.[0];
+  if (range) {
+    try {
+      range.select();
+      if (range.font) range.font.highlightColor = '#ffff00';
+    } catch {}
+  }
+}
+
+async function move(state: PanelState, dir: -1 | 1, doc: Word.Document) {
+  if (!state.items.length) return;
+  let idx = itemIndex(state, state.selectedId);
+  if (idx === -1) idx = dir === 1 ? 0 : state.items.length - 1;
+  else idx = Math.min(Math.max(idx + dir, 0), state.items.length - 1);
+  const target = state.items[idx];
+  state.selectedId = target.id;
+  await focusRange(doc.body, target.anchor || target.snippet || '');
+}
+
+export async function prevFinding(state: PanelState, doc: Word.Document) {
+  await move(state, -1, doc);
+}
+
+export async function nextFinding(state: PanelState, doc: Word.Document) {
+  await move(state, 1, doc);
+}
+
+export async function getDraft(state: PanelState, id: string): Promise<Draft> {
+  const cached = state.cachedDrafts.get(id);
+  if (cached) return cached;
+  const resp = await postJSON<Draft>('/api/draft', { id });
+  state.cachedDrafts.set(id, resp);
+  return resp;
+}
+
+export async function applyDraft(state: PanelState, id: string, draft: Draft, doc: Word.Document) {
+  for (const op of draft.ops) {
+    const res = await safeBodySearch(doc.body, op.anchor, { matchCase: false, matchWholeWord: false });
+    const range = res?.items?.[0];
+    if (!range) continue;
+    if (op.replace) {
+      const current = range.text;
+      if (op.replace.before && current !== op.replace.before) {
+        console.warn('text drift', { id });
+      }
+      range.insertText(op.replace.after, 'Replace');
+    }
+  }
+  try {
+    const raw = localStorage.getItem('cai_history') || '[]';
+    const hist = JSON.parse(raw);
+    hist.push({ id, ts: Date.now(), ops: draft.ops });
+    localStorage.setItem('cai_history', JSON.stringify(hist));
+  } catch {}
+}
+
+export function rejectFinding(state: PanelState, id: string) {
+  const idx = itemIndex(state, id);
+  if (idx !== -1) state.items[idx].skipped = true;
+}


### PR DESCRIPTION
## Summary
- add PanelState model and helpers for comment insertion, navigation, and draft application
- expose panel state utilities from panel entry point
- test navigation and comment fallback behaviour

## Testing
- `pytest`
- `npm test` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c711f3db308325bcfc35d5d6c91ae7