### PR TITLE
Add panel simulator for rule operations

### DIFF
--- a/sim/.gitignore
+++ b/sim/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+sim_report_*.json
+disagreements_*.md
+patched_*.txt

--- a/sim/package.json
+++ b/sim/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "panel-sim",
+  "private": true,
+  "scripts": {
+    "start": "../node_modules/.bin/ts-node panel-sim.ts"
+  }
+}

--- a/sim/panel-sim.ts
+++ b/sim/panel-sim.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+
+type Op = { op:'replace'|'insertBefore'|'insertAfter'|'comment',
+            anchor:{text:string,fingerprint?:string,offsetHint?:number},
+            before?:string, after?:string, text?:string };
+
+function applyOpsToPlainText(text: string, ops: Op[]) {
+  const applied: any[] = [], failed: any[] = [], comments: any[] = [];
+  let current = text;
+
+  for (const op of ops) {
+    const idx = current.indexOf(op.anchor.text);
+    if (idx < 0) { failed.push({op, reason:'anchor not found'}); continue; }
+
+    if (op.op === 'replace' && op.before) {
+      const seg = current.substr(idx, op.before.length);
+      if (seg !== op.before) { failed.push({op, reason:'before mismatch'}); continue; }
+      current = current.slice(0, idx) + (op.after ?? '') + current.slice(idx + op.before.length);
+      applied.push(op); continue;
+    }
+    if (op.op === 'insertBefore') {
+      current = current.slice(0, idx) + (op.text ?? '') + current.slice(idx);
+      applied.push(op); continue;
+    }
+    if (op.op === 'insertAfter') {
+      const afterIdx = idx + op.anchor.text.length;
+      current = current.slice(0, afterIdx) + (op.text ?? '') + current.slice(afterIdx);
+      applied.push(op); continue;
+    }
+    if (op.op === 'comment') {
+      comments.push(op);
+      applied.push({ ...op, note: 'comment (no-op in plain text)' });
+      continue;
+    }
+  }
+  return { text: current, applied, failed, comments };
+}
+
+(async () => {
+  const stamp = Date.now();
+  try {
+    const original = fs.readFileSync('samples/nda_en.txt', 'utf8');
+    const resA = await fetch('https://localhost:9443/api/analyze', {
+      method:'POST', headers: {'Content-Type':'application/json','X-Api-Key':'local-test-key-123','X-Schema-Version':'1.4'},
+      body: JSON.stringify({ mode:'live', doc:{ text:original, locale:'en-GB', docType:'NDA' } })
+    });
+    const A: any = await resA.json();
+    const ids = A.findings.map((f:any)=>f.id);
+
+    const resD = await fetch('https://localhost:9443/api/draft', {
+      method:'POST', headers: {'Content-Type':'application/json','X-Api-Key':'local-test-key-123','X-Schema-Version':'1.4'},
+      body: JSON.stringify({ mode:'friendly', docFingerprint:A.docFingerprint, findingIds: ids })
+    });
+    const D: any = await resD.json();
+
+    let text = original, appliedAll:any[]=[] , failedAll:any[]=[], commentsAll:any[]=[];
+    for (const d of D.drafts) {
+      const { text: t, applied, failed, comments } = applyOpsToPlainText(text, d.ops);
+      text = t; appliedAll.push(...applied); failedAll.push(...failed); commentsAll.push(...comments);
+    }
+
+    fs.writeFileSync(`sim_report_${stamp}.json`, JSON.stringify({
+      totalOps: appliedAll.length + failedAll.length,
+      applied: appliedAll.length,
+      failed: failedAll.length,
+      failedOps: failedAll,
+      comments: commentsAll
+    }, null, 2));
+
+    const reportLines = ['# Disagreements', ''];
+    if (failedAll.length === 0) {
+      reportLines.push('No failed operations.');
+    } else {
+      for (const f of failedAll) {
+        reportLines.push(`- ${f.reason}: ${JSON.stringify(f.op)}`);
+      }
+    }
+    fs.writeFileSync(`disagreements_${stamp}.md`, reportLines.join('\n'));
+    fs.writeFileSync(`patched_${stamp}.txt`, text, 'utf8');
+  } catch (err:any) {
+    fs.writeFileSync(`sim_report_${stamp}.json`, JSON.stringify({ error: err?.message || String(err) }, null, 2));
+    console.error('Simulation failed', err);
+  }
+})();

--- a/sim/samples/nda_en.txt
+++ b/sim/samples/nda_en.txt
@@ -1,0 +1,2 @@
+This Non-Disclosure Agreement ("Agreement") is made between the Disclosing Party and the Receiving Party.
+The parties agree to keep all confidential information secret.


### PR DESCRIPTION
## Summary
- add `sim/panel-sim.ts` to call analyze/draft endpoints and apply ops to plain text
- log applied, failed, and comment operations into JSON and markdown reports
- include `sim` package config and sample NDA text

## Testing
- `npm --prefix sim run start` *(fails: fetch failed to connect to https://localhost:9443)*

------
https://chatgpt.com/codex/tasks/task_e_68c71229bb7c8325a1f4949b402f55b9