### PR TITLE
Add UK regulation retriever with sample UK sources

### DIFF
--- a/data/uk_regulations.yaml
+++ b/data/uk_regulations.yaml
@@ -1,0 +1,25 @@
+- source: "OGUK Standard"
+  source_type: "OGUK"
+  jurisdiction: "UK"
+  topics: ["oil and gas", "master service agreement"]
+  excerpt: "OGUK standard requires specific indemnities for offshore services."
+- source: "ICO Guidance on Data Protection"
+  source_type: "ICO"
+  jurisdiction: "UK"
+  topics: ["data protection", "uk gdpr"]
+  excerpt: "Organisations must implement appropriate technical and organisational measures to ensure data security."
+- source: "FCA Regulations on Financial Promotions"
+  source_type: "FCA"
+  jurisdiction: "UK"
+  topics: ["financial", "promotions"]
+  excerpt: "Financial promotions must be fair, clear and not misleading."
+- source: "UK Legislation: Data Protection Act 2018"
+  source_type: "legislation"
+  jurisdiction: "UK"
+  topics: ["data protection", "uk gdpr"]
+  excerpt: "The Data Protection Act 2018 is the UK's implementation of the General Data Protection Regulation."
+- source: "US Export Control"
+  source_type: "EAR"
+  jurisdiction: "US"
+  topics: ["export", "sanctions"]
+  excerpt: "Placeholder rule used to ensure non-UK sources are ignored."

--- a/src/uk_regulation_retriever.py
+++ b/src/uk_regulation_retriever.py
@@ -1,0 +1,49 @@
+"""Utilities for retrieving UK legal references for contract analysis."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Dict, Any
+
+import yaml
+
+DATA_FILE = Path(__file__).resolve().parent.parent / "data" / "uk_regulations.yaml"
+
+
+class UKRegulationRetriever:
+    """Load a small knowledge base of UK regulations and retrieve entries.
+
+    The data file contains dictionaries with keys:
+    ``source``, ``source_type``, ``jurisdiction``, ``topics`` and ``excerpt``.
+    Retrieval filters by ``jurisdiction='UK'`` and optional ``source_type`` values.
+    """
+
+    def __init__(self, data_file: Path = DATA_FILE) -> None:
+        self.data_file = data_file
+        with open(data_file, "r", encoding="utf-8") as fh:
+            self.entries: List[Dict[str, Any]] = yaml.safe_load(fh) or []
+
+    def retrieve(self, topic: str, source_types: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        """Return entries matching ``topic`` and optional ``source_types``.
+
+        Parameters
+        ----------
+        topic:
+            Topic keyword used for matching against the ``topics`` field of entries.
+        source_types:
+            Optional list of source type identifiers (e.g. ``["ICO", "FCA"]``).
+
+        Returns
+        -------
+        List of matching entries sorted in the original order of the data file.
+        """
+        topic_lower = topic.lower()
+        results: List[Dict[str, Any]] = []
+        for entry in self.entries:
+            if entry.get("jurisdiction") != "UK":
+                continue
+            if source_types and entry.get("source_type") not in source_types:
+                continue
+            topics = [t.lower() for t in entry.get("topics", [])]
+            if topic_lower in topics:
+                results.append(entry)
+        return results

--- a/tests/test_uk_regulation_retriever.py
+++ b/tests/test_uk_regulation_retriever.py
@@ -1,0 +1,15 @@
+from src.uk_regulation_retriever import UKRegulationRetriever
+
+
+def test_retrieve_by_topic_and_type():
+    retriever = UKRegulationRetriever()
+    results = retriever.retrieve("data protection", ["ICO"])
+    assert results, "Expected at least one ICO result"
+    assert all(r["source_type"] == "ICO" for r in results)
+
+
+def test_non_uk_sources_filtered_out():
+    retriever = UKRegulationRetriever()
+    # The topic 'export' only exists for a non-UK entry and should be filtered out
+    results = retriever.retrieve("export")
+    assert results == []


### PR DESCRIPTION
## Summary
- add UKRegulationRetriever for retrieving UK legal references filtered by jurisdiction and source type
- provide sample UK regulatory data for OGUK, ICO, FCA and legislation
- test retrieval and filtering behavior

## Testing
- `pytest tests/test_uk_regulation_retriever.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c716ecc8b08325b93a8c901fba2c55