### PR TITLE
fix: guard body search in clear annotations

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -265,6 +265,9 @@ export async function clearAnnotations() {
     await Word.run(async ctx => {
       const body = ctx.document.body;
       const cmts: any = (ctx.document as any).comments;
+      const found = typeof (body as any).search === 'function'
+        ? body.search(COMMENT_PREFIX, { matchCase: false })
+        : null;
       if (cmts && typeof cmts.load === 'function') cmts.load('items');
       await ctx.sync();
       for (const c of cmts.items) {
@@ -272,6 +275,17 @@ export async function clearAnnotations() {
           const txt = (c as any).text || "";
           if (txt.startsWith(COMMENT_PREFIX)) c.delete();
         } catch {}
+      }
+      if (found) {
+        found.load('items');
+        await ctx.sync();
+        if (found.items && found.items.length) {
+          for (const r of found.items) {
+            try {
+              r.insertText('', Word.InsertLocation.replace);
+            } catch {}
+          }
+        }
       }
       try { body.font.highlightColor = "NoColor" as any; } catch {}
       await ctx.sync();

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -268,6 +268,9 @@ export async function clearAnnotations() {
     await Word.run(async ctx => {
       const body = ctx.document.body;
       const cmts: any = (ctx.document as any).comments;
+      const found = typeof (body as any).search === 'function'
+        ? body.search(COMMENT_PREFIX, { matchCase: false })
+        : null;
       if (cmts && typeof cmts.load === 'function') cmts.load('items');
       await ctx.sync();
       for (const c of cmts.items) {
@@ -275,6 +278,17 @@ export async function clearAnnotations() {
           const txt = (c as any).text || "";
           if (txt.startsWith(COMMENT_PREFIX)) c.delete();
         } catch {}
+      }
+      if (found) {
+        found.load('items');
+        await ctx.sync();
+        if (found.items && found.items.length) {
+          for (const r of found.items) {
+            try {
+              r.insertText('', Word.InsertLocation.replace);
+            } catch {}
+          }
+        }
       }
       try { body.font.highlightColor = "NoColor" as any; } catch {}
       await ctx.sync();


### PR DESCRIPTION
## Summary
- guard Word body search before loading found items to avoid runtime errors when clearing annotations
- remove leftover merge markers

## Testing
- `git grep -n -E "^(<<<<<<<|=======|>>>>>>>)" -- ':!node_modules' ':!word_addin_dev/dist' ':!*.bundle.js'`
- `cd word_addin_dev && npx vitest run app/__tests__/clear_annotations.test.ts`
- `cd word_addin_dev && npm test` *(fails: Failed to load url ../assets/safeBodySearch.ts)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c7174fe5508325833fac60ba60adf6