### PR TITLE
feat: validate clause before draft request

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -574,6 +574,108 @@ export async function getClauseText(): Promise<string> {
   return text.trim();
 }
 
+function getOriginalClauseOrSelection(): string {
+  const src = $(Q.original) as HTMLTextAreaElement | null;
+  return (src?.value || '').trim();
+}
+
+async function ensureClauseForDraftOrWarn(): Promise<string | null> {
+  let clause = getOriginalClauseOrSelection();
+  if (clause.length >= 20) return clause;
+  try {
+    clause = ((await (globalThis as any).getSelectionText()) || '').trim();
+    if (clause.length >= 20) {
+      const src = $(Q.original) as HTMLTextAreaElement | null;
+      if (src) {
+        src.value = clause;
+        try { src.dispatchEvent(new Event('input', { bubbles: true })); } catch {}
+      }
+      return clause;
+    }
+  } catch {}
+  notifyWarn('Please paste the original clause (min 20 chars) or select text in the document.');
+  return null;
+}
+
+function detectContractType(): string {
+  try { return (globalThis as any).detectContractType?.() || 'unknown'; }
+  catch { return 'unknown'; }
+}
+
+function getVisibleFindingsForCurrentIssue(): any[] {
+  try {
+    const arr = (window as any).__findings || [];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function getSelectionOffsetsSafe(): { start: number; end: number } | null {
+  try { return (window as any).getSelectionOffsets?.() || null; }
+  catch { return null; }
+}
+
+async function requestDraft(mode: 'friendly' | 'strict') {
+  const clause = await ensureClauseForDraftOrWarn();
+  if (!clause) return;
+
+  const payload = {
+    mode,
+    clause,
+    context: {
+      law: 'UK',
+      language: 'en-GB',
+      contractType: detectContractType(),
+    },
+    findings: getVisibleFindingsForCurrentIssue().slice(0, 10),
+    selection: getSelectionOffsetsSafe(),
+  };
+
+  let res: Response;
+  try {
+    res = await fetch('/api/gpt/draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Api-Key': getApiKeyFromStore() || '',
+        'X-Schema-Version': '1.4',
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (e) {
+    console.warn('Draft error', e);
+    notifyWarn('Draft error');
+    return;
+  }
+
+  if (!res.ok) {
+    const t = await res.text();
+    console.warn(`Draft failed: ${res.status} ${t}`);
+    return;
+  }
+
+  const json = await res.json();
+  const proposed = (json?.proposed_text ?? json?.text ?? '').toString();
+  const dst = $(Q.proposed);
+  const w: any = window as any;
+  w.__last = w.__last || {};
+  w.__last['gpt-draft'] = { json };
+  if (dst) {
+    if (!dst.id) dst.id = 'draftText';
+    if (!dst.name) dst.name = 'proposed';
+    (dst as any).dataset.role = 'proposed-text';
+    dst.value = proposed;
+    dst.dispatchEvent(new Event('input', { bubbles: true }));
+    notifyOk('Draft ready');
+    try { await insertDraftText(proposed, currentMode, json?.meta?.rationale); } catch {}
+    onDraftReady(proposed);
+  } else {
+    notifyWarn('Proposed textarea not found');
+    onDraftReady('');
+  }
+}
+
 async function onUseWholeDoc() {
   const src = $(Q.original);
   const raw = await getWholeDocText();
@@ -592,41 +694,7 @@ async function onUseWholeDoc() {
 }
 
 export async function onSuggestEdit(ev?: Event) {
-  return withBusy(async () => {
-    let clause: string;
-    try {
-      clause = await getClauseText();
-    } catch (e) {
-      notifyWarn("Select some text or paste into 'Original clause'");
-      return;
-    }
-    if (!clause) { notifyWarn("Select some text or paste into 'Original clause'"); return; }
-    try {
-      const dst = $(Q.proposed);
-      const { json } = await postJSON('/api/gpt-draft', { cid: lastCid, clause, mode: currentMode });
-      const proposed = (json?.proposed_text ?? json?.text ?? "").toString();
-      const w: any = window as any;
-      w.__last = w.__last || {};
-      w.__last['gpt-draft'] = { json };
-      if (dst) {
-        if (!dst.id) dst.id = "draftText";
-        if (!dst.name) dst.name = "proposed";
-        (dst as any).dataset.role = "proposed-text";
-        dst.value = proposed;
-        dst.dispatchEvent(new Event("input", { bubbles: true }));
-        notifyOk("Draft ready");
-        try { await insertDraftText(proposed, currentMode, json?.meta?.rationale); } catch {}
-        onDraftReady(proposed);
-      } else {
-        notifyWarn("Proposed textarea not found");
-        onDraftReady('');
-      }
-    } catch (e) {
-      notifyWarn("Draft error");
-      console.error(e);
-      onDraftReady('');
-    }
-  });
+  return withBusy(() => requestDraft(currentMode === 'friendly' ? 'friendly' : 'strict'));
 }
 
 async function doHealth() {

--- a/word_addin_dev/app/__tests__/draft.spec.ts
+++ b/word_addin_dev/app/__tests__/draft.spec.ts
@@ -41,22 +41,22 @@ describe('get draft', () => {
     const btn = document.getElementById('btnSuggestEdit') as HTMLButtonElement;
     expect(btn.disabled).toBe(true);
     await onSuggestEdit();
-    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt-draft'));
+    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt/draft'));
     expect(calls.length).toBe(0);
   });
 
   it('selection enables and sends request with clause', async () => {
-    (globalThis as any).getSelectionText = vi.fn().mockResolvedValue('Hello');
+    (globalThis as any).getSelectionText = vi.fn().mockResolvedValue('This is a sample clause with sufficient length.');
     const { wireUI, getClauseText, onSuggestEdit } = await import('../assets/taskpane.ts');
     wireUI();
     await getClauseText();
     const btn = document.getElementById('btnSuggestEdit') as HTMLButtonElement;
     expect(btn.disabled).toBe(false);
     await onSuggestEdit();
-    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt-draft'));
+    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt/draft'));
     expect(calls.length).toBe(1);
     const body = JSON.parse(calls[0][1].body);
-    expect(body).toMatchObject({ clause: 'Hello' });
+    expect(body).toMatchObject({ clause: 'This is a sample clause with sufficient length.' });
   });
 
   it('Word API failure warns and skips request', async () => {
@@ -66,8 +66,8 @@ describe('get draft', () => {
     const { notifyWarn } = await import('../assets/notifier.ts');
     wireUI();
     await onSuggestEdit();
-    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt-draft'));
+    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt/draft'));
     expect(calls.length).toBe(0);
-    expect(notifyWarn).toHaveBeenCalledWith("Select some text or paste into 'Original clause'");
+    expect(notifyWarn).toHaveBeenCalledWith('Please paste the original clause (min 20 chars) or select text in the document.');
   });
 });

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -638,6 +638,108 @@ export async function getClauseText(): Promise<string> {
   return text.trim();
 }
 
+function getOriginalClauseOrSelection(): string {
+  const src = $(Q.original) as HTMLTextAreaElement | null;
+  return (src?.value || '').trim();
+}
+
+async function ensureClauseForDraftOrWarn(): Promise<string | null> {
+  let clause = getOriginalClauseOrSelection();
+  if (clause.length >= 20) return clause;
+  try {
+    clause = ((await (globalThis as any).getSelectionText()) || '').trim();
+    if (clause.length >= 20) {
+      const src = $(Q.original) as HTMLTextAreaElement | null;
+      if (src) {
+        src.value = clause;
+        try { src.dispatchEvent(new Event('input', { bubbles: true })); } catch {}
+      }
+      return clause;
+    }
+  } catch {}
+  notifyWarn('Please paste the original clause (min 20 chars) or select text in the document.');
+  return null;
+}
+
+function detectContractType(): string {
+  try { return (globalThis as any).detectContractType?.() || 'unknown'; }
+  catch { return 'unknown'; }
+}
+
+function getVisibleFindingsForCurrentIssue(): any[] {
+  try {
+    const arr = (window as any).__findings || [];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function getSelectionOffsetsSafe(): { start: number; end: number } | null {
+  try { return (window as any).getSelectionOffsets?.() || null; }
+  catch { return null; }
+}
+
+async function requestDraft(mode: 'friendly' | 'strict') {
+  const clause = await ensureClauseForDraftOrWarn();
+  if (!clause) return;
+
+  const payload = {
+    mode,
+    clause,
+    context: {
+      law: 'UK',
+      language: 'en-GB',
+      contractType: detectContractType(),
+    },
+    findings: getVisibleFindingsForCurrentIssue().slice(0, 10),
+    selection: getSelectionOffsetsSafe(),
+  };
+
+  let res: Response;
+  try {
+    res = await fetch('/api/gpt/draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Api-Key': getApiKeyFromStore() || '',
+        'X-Schema-Version': '1.4',
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (e) {
+    console.warn('Draft error', e);
+    notifyWarn('Draft error');
+    return;
+  }
+
+  if (!res.ok) {
+    const t = await res.text();
+    console.warn(`Draft failed: ${res.status} ${t}`);
+    return;
+  }
+
+  const json = await res.json();
+  const proposed = (json?.proposed_text ?? json?.text ?? '').toString();
+  const dst = $(Q.proposed);
+  const w: any = window as any;
+  w.__last = w.__last || {};
+  w.__last['gpt-draft'] = { json };
+  if (dst) {
+    if (!dst.id) dst.id = 'draftText';
+    if (!dst.name) dst.name = 'proposed';
+    (dst as any).dataset.role = 'proposed-text';
+    dst.value = proposed;
+    dst.dispatchEvent(new Event('input', { bubbles: true }));
+    notifyOk('Draft ready');
+    try { await insertDraftText(proposed, currentMode, json?.meta?.rationale); } catch {}
+    onDraftReady(proposed);
+  } else {
+    notifyWarn('Proposed textarea not found');
+    onDraftReady('');
+  }
+}
+
 async function onUseWholeDoc() {
   const src = $(Q.original);
   const raw = await getWholeDocText();
@@ -656,41 +758,7 @@ async function onUseWholeDoc() {
 }
 
 export async function onSuggestEdit(ev?: Event) {
-  return withBusy(async () => {
-    let clause: string;
-    try {
-      clause = await getClauseText();
-    } catch (e) {
-      notifyWarn("Select some text or paste into 'Original clause'");
-      return;
-    }
-    if (!clause) { notifyWarn("Select some text or paste into 'Original clause'"); return; }
-    try {
-      const dst = $(Q.proposed);
-      const { json } = await postJSON('/api/gpt-draft', { cid: lastCid, clause, mode: currentMode });
-      const proposed = (json?.proposed_text ?? json?.text ?? "").toString();
-      const w: any = window as any;
-      w.__last = w.__last || {};
-      w.__last['gpt-draft'] = { json };
-      if (dst) {
-        if (!dst.id) dst.id = "draftText";
-        if (!dst.name) dst.name = "proposed";
-        (dst as any).dataset.role = "proposed-text";
-        dst.value = proposed;
-        dst.dispatchEvent(new Event("input", { bubbles: true }));
-        notifyOk("Draft ready");
-        try { await insertDraftText(proposed, currentMode, json?.meta?.rationale); } catch {}
-        onDraftReady(proposed);
-      } else {
-        notifyWarn("Proposed textarea not found");
-        onDraftReady('');
-      }
-    } catch (e) {
-      notifyWarn("Draft error");
-      console.error(e);
-      onDraftReady('');
-    }
-  });
+  return withBusy(() => requestDraft(currentMode === 'friendly' ? 'friendly' : 'strict'));
 }
 
 async function doHealth() {


### PR DESCRIPTION
## Summary
- prevent empty or short clause from triggering draft requests
- send draft payload using new schema and endpoint
- update draft tests for minimum clause length and new API

## Testing
- `npm test` *(fails: Failed to load url ../assets/safeBodySearch.ts in app/src/panel/state.ts)*
- `npm test app/__tests__/draft.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c71746d85c832593fabee92132db4f