### PR TITLE
feat: add robust comment insertion fallback

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -2,9 +2,7 @@ import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, A
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, severityRank } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
-import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX } from "./annotate.ts";
-import { findAnchors } from "./anchors.ts";
-import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX } from "./annotate.ts";
+import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment } from "./annotate.ts";
 import { findAnchors } from "./anchors.ts";
 import { safeBodySearch } from "./safeBodySearch.ts";  // ← это оставить
 import { insertDraftText } from "./insert.ts";         // ← это оставить
@@ -356,7 +354,7 @@ export async function applyOpsTracked(
 
         target.insertText(op.replacement, 'Replace');
         const comment = `${COMMENT_PREFIX} ${op.rationale || op.source || 'AI edit'}`;
-        try { target.insertComment(comment); } catch {}
+        try { await safeInsertComment(target, comment); } catch {}
       } else {
         console.warn('[applyOpsTracked] match not found', { snippet, occIdx });
       }
@@ -850,7 +848,7 @@ async function onAcceptAll() {
       const range = ctx.document.getSelection();
       (ctx.document as any).trackRevisions = true;
       range.insertText(proposed, Word.InsertLocation.replace);
-      try { range.insertComment(`${COMMENT_PREFIX} ${link}`); } catch {}
+      try { await safeInsertComment(range, `${COMMENT_PREFIX} ${link}`); } catch {}
       await ctx.sync();
     });
 

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -8,6 +8,30 @@ export interface CommentItem {
   message: string;
 }
 
+export async function safeInsertComment(range: Word.Range, text: string) {
+  const context = range.context;
+  try {
+    const anyDoc = (context.document as any);
+    if (anyDoc?.comments?.add) {
+      anyDoc.comments.add(range, text);
+      await context.sync();
+      return;
+    }
+  } catch (_) {}
+  try {
+    range.insertComment(text);
+    await context.sync();
+    return;
+  } catch (_) {}
+  const cc = range.insertContentControl();
+  cc.tag = "CAI_COMMENT";
+  cc.title = "Contract AI — comment";
+  cc.color = "yellow";
+  cc.appearance = "BoundingBox";
+  cc.insertText(`COMMENT: ${text}`, Word.InsertLocation.replace);
+  await context.sync();
+}
+
 /**
  * Insert comments for provided ranges. Operations are batched: ``context.sync``
  * is called after every 20 successful insertions and once at the end. If
@@ -19,18 +43,17 @@ export interface CommentItem {
  */
 export async function insertComments(ctx: any, items: CommentItem[]): Promise<number> {
   let inserted = 0;
-  let pending = 0;
   for (const it of items) {
     let r = it.range;
     const msg = it.message;
     try {
-      r.insertComment(msg);
+      await safeInsertComment(r, msg);
       inserted++;
     } catch (e: any) {
       if (String(e).includes("0xA7210002")) {
         try {
           r = r.expandTo ? r.expandTo(ctx.document.body) : r;
-          r.insertComment(msg);
+          await safeInsertComment(r, msg);
           inserted++;
         } catch (e2) {
           console.warn("annotate retry failed", e2);
@@ -39,13 +62,6 @@ export async function insertComments(ctx: any, items: CommentItem[]): Promise<nu
         console.warn("annotate error", e);
       }
     }
-    pending++;
-    if (pending % 20 === 0) {
-      await ctx.sync();
-    }
-  }
-  if (pending % 20 !== 0) {
-    await ctx.sync();
   }
   return inserted;
 }
@@ -171,7 +187,7 @@ export async function annotateFindingsIntoWord(findings: AnalyzeFinding[]): Prom
         if (isDryRunAnnotateEnabled()) {
           try { target.select(); } catch {}
         } else if (op.msg) {
-          target.insertComment(op.msg);
+          await safeInsertComment(target, op.msg);
         }
         used.push({ start, end });
         inserted++;
@@ -188,5 +204,3 @@ export async function annotateFindingsIntoWord(findings: AnalyzeFinding[]): Prom
     return 0;
   });
 }
-
-

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -2,9 +2,7 @@ import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, A
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, severityRank } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
-import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX } from "./annotate.ts";
-import { findAnchors } from "./anchors.ts";
-import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX } from "./annotate.ts";
+import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment } from "./annotate.ts";
 import { findAnchors } from "./anchors.ts";
 import { safeBodySearch } from "./safeBodySearch.ts";
 import { insertDraftText } from "./insert.ts";
@@ -359,7 +357,7 @@ export async function applyOpsTracked(
 
         target.insertText(op.replacement, 'Replace');
         const comment = `${COMMENT_PREFIX} ${op.rationale || op.source || 'AI edit'}`;
-        try { target.insertComment(comment); } catch {}
+        try { await safeInsertComment(target, comment); } catch {}
       } else {
         console.warn('[applyOpsTracked] match not found', { snippet, occIdx });
       }
@@ -905,7 +903,7 @@ async function onAcceptAll() {
       const range = ctx.document.getSelection();
       (ctx.document as any).trackRevisions = true;
       range.insertText(proposed, Word.InsertLocation.replace);
-      try { range.insertComment(`${COMMENT_PREFIX} ${link}`); } catch {}
+      try { await safeInsertComment(range, `${COMMENT_PREFIX} ${link}`); } catch {}
       await ctx.sync();
     });
 


### PR DESCRIPTION
## Summary
- add safeInsertComment helper with multi-level fallbacks for Word comment insertion
- use safeInsertComment across annotation and taskpane workflows
- switch panel state comment helper to async safeInsertComment

## Testing
- `pre-commit run --files contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts word_addin_dev/app/assets/annotate.ts word_addin_dev/app/assets/taskpane.ts word_addin_dev/app/src/panel/state.ts word_addin_dev/app/src/panel/state.spec.ts`
- `npm --prefix word_addin_dev test` *(fails: "annotate scheduler" and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c7173e4e288325b5401e176326789d