### PR TITLE
feat: improve error logging and debug mode

### DIFF
--- a/contract_review_app/engine/executor.py
+++ b/contract_review_app/engine/executor.py
@@ -1,9 +1,10 @@
 # contract_review_app/engine/executor.py
 from __future__ import annotations
 
-import logging
 from time import monotonic
 from typing import Dict, List, Optional
+
+from loguru import logger
 
 from contract_review_app.core.schemas import (
     AnalysisInput,
@@ -29,8 +30,6 @@ try:
 except Exception:  # pragma: no cover
     def cross_check_clauses(inputs, outputs):  # type: ignore
         return outputs
-
-logger = logging.getLogger("contract_review_app.engine.executor")
 
 # deterministic scoring weights per finding severity
 _SEV_WEIGHT = {

--- a/contract_review_app/utils/logging.py
+++ b/contract_review_app/utils/logging.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+"""Central logging configuration using loguru and optional Sentry."""
+
+import os
+import sys
+from loguru import logger
+
+
+def init_logging() -> logger.__class__:
+    """Configure loguru logger and optional Sentry integration.
+
+    The log level is controlled by the ``CAI_DEBUG`` environment variable.
+    When ``SENTRY_DSN`` is provided, Sentry is initialised for error reporting.
+    """
+    debug = os.getenv("CAI_DEBUG") == "1"
+    logger.remove()
+    logger.add(sys.stderr, level="DEBUG" if debug else "INFO", backtrace=True, diagnose=debug)
+
+    dsn = os.getenv("SENTRY_DSN")
+    if dsn:
+        try:  # optional dependency
+            import sentry_sdk  # type: ignore
+            sentry_sdk.init(dsn=dsn)
+            logger.debug("Sentry initialised")
+        except Exception as e:  # pragma: no cover - diagnostics only
+            logger.warning("Failed to init Sentry: {0}", e)
+
+    return logger
+
+
+__all__ = ["init_logging", "logger"]

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """Demo entry point for Contract AI rule analysis."""
 
-import logging
 import os
 import sys
 
@@ -10,6 +9,7 @@ from contract_review_app.core.schemas import AnalysisInput
 from contract_review_app.generate_report import generate_report
 from contract_review_app.legal_rules.legal_rules import analyze as run_rule
 from contract_review_app.legal_rules.registry import RULES_REGISTRY
+from contract_review_app.utils.logging import init_logging
 
 # спробуємо взяти зручний лоадер DOCX, якщо є
 try:
@@ -17,8 +17,7 @@ try:
 except Exception:
     load_docx_text = None  # впадемо на fallback
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("main")
+logger = init_logging()
 
 DEMO_TEXT = """\
 THIS SAMPLE CONTRACT (demo) — minimal text to let rules run.
@@ -79,7 +78,7 @@ def main():
             print(f"  ✔ {inp.clause_type}: {out.status} (score={getattr(out, 'score', '?')})")
         except Exception as e:
             # Безпечно фіксуємо збій одного правила, щоб інші не постраждали
-            logging.exception("Rule '%s' crashed; continuing…", inp.clause_type)
+            logger.exception("Rule '%s' crashed; continuing…", inp.clause_type)
 
     # Генеруємо звіт
     out_file = os.path.abspath("report.html")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,5 @@ build>=1.2.1
 fpdf2>=2.7
 openapi-spec-validator>=0.7
 pytest-watch>=4.2.0
+loguru>=0.7,<1.0
+sentry-sdk>=1.39,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pyyaml
 pytest-cov
 requests
 SQLAlchemy>=2.0,<3.0
+loguru>=0.7,<1.0
+sentry-sdk>=1.39,<2


### PR DESCRIPTION
## Summary
- add centralized loguru logger with optional Sentry and debug flag
- log frontend API failures and surface generic UI warning
- capture panel comment insertion errors

## Testing
- `pytest`
- `npm run lint` (failed: tests rely on window object)
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c71706aad08325b89458e587a709b5