### PR TITLE
fix(word-search): handle long search strings and missing loads

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/safeBodySearch.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/safeBodySearch.ts
@@ -1,22 +1,58 @@
 export async function safeBodySearch(body: any, needle: string, options?: any): Promise<any> {
   const ctx: any = body?.context;
-  const needleClamped = (needle ?? '').slice(0, 240); // Word капризничает >255
-  let res: any;
-  try {
-    res = body.search(needleClamped, options);
-  } catch (e: any) {
-    // fallback: урезать ещё сильнее, либо отдать пусто
-    const shorter = needleClamped.slice(0, 120);
+  const txt = (needle ?? '').trim();
+  if (!txt) return { items: [] };
+
+  if (txt.length <= 240) {
     try {
-      res = body.search(shorter, options);
+      const res = body.search(txt, options);
+      res?.load?.('items');
+      await ctx?.sync?.();
+      return res;
     } catch {
       return { items: [] };
     }
   }
-  try {
-    res?.load?.('items');
-    await ctx?.sync?.();
-  } catch {}
-  return res;
-}
 
+  const anchor = txt.slice(0, 120);
+  let anchorRes: any;
+  try {
+    anchorRes = body.search(anchor, options);
+    anchorRes?.load?.('items');
+    await ctx?.sync?.();
+  } catch {
+    return { items: [] };
+  }
+
+  const matches: any[] = [];
+  const innerNeedle = txt.slice(0, 240);
+
+  for (const r of anchorRes?.items || []) {
+    let scope: any = r;
+    try {
+      scope = r.paragraphs?.getFirst?.() || r;
+      scope?.load?.('text');
+      await ctx?.sync?.();
+    } catch {}
+
+    const text: string = scope?.text || '';
+    if (text.includes(innerNeedle)) {
+      try {
+        const inner = scope.search(innerNeedle, options);
+        inner?.load?.('items');
+        await ctx?.sync?.();
+        if (inner?.items?.length) matches.push(...inner.items);
+        continue;
+      } catch {}
+    }
+
+    const tokens = innerNeedle.split(/\s+/).filter(t => t.length > 3).slice(0, 5);
+    let ok = true;
+    for (const t of tokens) {
+      if (!text.includes(t)) { ok = false; break; }
+    }
+    if (ok) matches.push(scope);
+  }
+
+  return { items: matches };
+}

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -267,22 +267,21 @@ export async function clearAnnotations() {
         ? body.search(COMMENT_PREFIX, { matchCase: false })
         : null;
       if (cmts && typeof cmts.load === 'function') cmts.load('items');
+      if (found && typeof found.load === 'function') found.load('items');
       await ctx.sync();
-      for (const c of cmts.items) {
-        try {
-          const txt = (c as any).text || "";
-          if (txt.startsWith(COMMENT_PREFIX)) c.delete();
-        } catch {}
+      if (cmts?.items) {
+        for (const c of cmts.items) {
+          try {
+            const txt = (c as any).text || "";
+            if (txt.startsWith(COMMENT_PREFIX)) c.delete();
+          } catch {}
+        }
       }
-      if (found) {
-        found.load('items');
-        await ctx.sync();
-        if (found.items && found.items.length) {
-          for (const r of found.items) {
-            try {
-              r.insertText('', Word.InsertLocation.replace);
-            } catch {}
-          }
+      if (found?.items && found.items.length) {
+        for (const r of found.items) {
+          try {
+            r.insertText('', Word.InsertLocation.replace);
+          } catch {}
         }
       }
       try { body.font.highlightColor = "NoColor" as any; } catch {}

--- a/word_addin_dev/app/assets/safeBodySearch.ts
+++ b/word_addin_dev/app/assets/safeBodySearch.ts
@@ -1,22 +1,61 @@
 export async function safeBodySearch(body: any, needle: string, options?: any): Promise<any> {
   const ctx: any = body?.context;
-  const needleClamped = (needle ?? '').slice(0, 240); // Word капризничает >255
-  let res: any;
-  try {
-    res = body.search(needleClamped, options);
-  } catch (e: any) {
-    // fallback: урезать ещё сильнее, либо отдать пусто
-    const shorter = needleClamped.slice(0, 120);
+  const txt = (needle ?? '').trim();
+  if (!txt) return { items: [] };
+
+  // Normal search for short needles
+  if (txt.length <= 240) {
     try {
-      res = body.search(shorter, options);
+      const res = body.search(txt, options);
+      res?.load?.('items');
+      await ctx?.sync?.();
+      return res;
     } catch {
       return { items: [] };
     }
   }
-  try {
-    res?.load?.('items');
-    await ctx?.sync?.();
-  } catch {}
-  return res;
-}
 
+  // Two phase search for long strings: anchor -> inner search
+  const anchor = txt.slice(0, 120);
+  let anchorRes: any;
+  try {
+    anchorRes = body.search(anchor, options);
+    anchorRes?.load?.('items');
+    await ctx?.sync?.();
+  } catch {
+    return { items: [] };
+  }
+
+  const matches: any[] = [];
+  const innerNeedle = txt.slice(0, 240);
+
+  for (const r of anchorRes?.items || []) {
+    let scope: any = r;
+    try {
+      scope = r.paragraphs?.getFirst?.() || r;
+      scope?.load?.('text');
+      await ctx?.sync?.();
+    } catch {}
+
+    const text: string = scope?.text || '';
+    if (text.includes(innerNeedle)) {
+      try {
+        const inner = scope.search(innerNeedle, options);
+        inner?.load?.('items');
+        await ctx?.sync?.();
+        if (inner?.items?.length) matches.push(...inner.items);
+        continue;
+      } catch {}
+    }
+
+    // token based fallback
+    const tokens = innerNeedle.split(/\s+/).filter(t => t.length > 3).slice(0, 5);
+    let ok = true;
+    for (const t of tokens) {
+      if (!text.includes(t)) { ok = false; break; }
+    }
+    if (ok) matches.push(scope);
+  }
+
+  return { items: matches };
+}

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -270,22 +270,21 @@ export async function clearAnnotations() {
         ? body.search(COMMENT_PREFIX, { matchCase: false })
         : null;
       if (cmts && typeof cmts.load === 'function') cmts.load('items');
+      if (found && typeof found.load === 'function') found.load('items');
       await ctx.sync();
-      for (const c of cmts.items) {
-        try {
-          const txt = (c as any).text || "";
-          if (txt.startsWith(COMMENT_PREFIX)) c.delete();
-        } catch {}
+      if (cmts?.items) {
+        for (const c of cmts.items) {
+          try {
+            const txt = (c as any).text || "";
+            if (txt.startsWith(COMMENT_PREFIX)) c.delete();
+          } catch {}
+        }
       }
-      if (found) {
-        found.load('items');
-        await ctx.sync();
-        if (found.items && found.items.length) {
-          for (const r of found.items) {
-            try {
-              r.insertText('', Word.InsertLocation.replace);
-            } catch {}
-          }
+      if (found?.items && found.items.length) {
+        for (const r of found.items) {
+          try {
+            r.insertText('', Word.InsertLocation.replace);
+          } catch {}
         }
       }
       try { body.font.highlightColor = "NoColor" as any; } catch {}


### PR DESCRIPTION
## Summary
- implement two-phase body search with anchor and token fallback
- guard comment cleanup to load and sync before accessing items

## Testing
- `pre-commit run --files word_addin_dev/app/assets/safeBodySearch.ts contract_review_app/contract_review_app/static/panel/app/assets/safeBodySearch.ts word_addin_dev/app/assets/taskpane.ts contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts`
- `pytest` *(fails: No module named 'cryptography')*
- `cd word_addin_dev && npm test` *(fails: 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c71b190cf083258ca86faa766caed2