### PR TITLE
feat: embed normative reference in annotations

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -34,6 +34,9 @@ export type AnalyzeFinding = {
   ops?: { start?: number; end?: number; replacement?: string }[];
   scope?: { unit?: string; nth?: number };
   occurrences?: number;
+  norm_quote?: string;
+  clause_url?: string;
+  clause_id?: string;
 };
 
 export type AnalyzeResponse = {

--- a/word_addin_dev/app/__tests__/annotate_plan.test.ts
+++ b/word_addin_dev/app/__tests__/annotate_plan.test.ts
@@ -39,6 +39,23 @@ describe('annotate scheduler', () => {
     expect(ops.length).toBe(0);
   });
 
+  it('includes quote and clause link in comment', () => {
+    const findings: AnalyzeFinding[] = [
+      {
+        start: 0,
+        end: 3,
+        snippet: 'abc',
+        rule_id: 'r1',
+        norm_quote: 'norm',
+        clause_url: 'http://example.com/clause/1',
+        clause_id: '1'
+      }
+    ];
+    const ops = planAnnotations(findings);
+    expect(ops[0].msg).toContain('norm');
+    expect(ops[0].msg).toContain('http://example.com/clause/1');
+  });
+
   it('merges overlapping anchors', async () => {
     const body = {
       context: { sync: async () => {}, trackedObjects: { add: () => {} } },

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -91,6 +91,12 @@ function buildLegalComment(f: AnalyzeFinding): string {
   const parts = [f.rule_id];
   if (f.advice) parts.push(f.advice);
   if (f.law_refs?.length) parts.push(f.law_refs.join("; "));
+  if (f.norm_quote) parts.push(`"${f.norm_quote}"`);
+  if (f.clause_url || f.clause_id) {
+    const linkText = f.clause_id ? `Clause ${f.clause_id}` : "Clause";
+    if (f.clause_url) parts.push(`${linkText}: ${f.clause_url}`);
+    else parts.push(linkText);
+  }
   return `${COMMENT_PREFIX} ${parts.join("\n")}`;
 }
 

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -53,6 +53,9 @@ export type AnalyzeFinding = {
   ops?: { start?: number; end?: number; replacement?: string }[];
   scope?: { unit?: string; nth?: number };
   occurrences?: number;
+  norm_quote?: string;
+  clause_url?: string;
+  clause_id?: string;
 };
 
 export type AnalyzeResponse = {


### PR DESCRIPTION
## Summary
- include normative quotes and clause links in auto-generated comment text
- extend AnalyzeFinding schema with fields for norm quote and clause URL/ID
- test annotation comment building with normative citation

## Testing
- `npm test` *(fails: annotate scheduler annotates findings, bootstrap test, insertIntoWord test, dev bootstrap error: Failed to load url ../assets/safeBodySearch.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c71bc0df84832595e8c02d47a09618