### PR TITLE
Add test for deduplicating identical findings

### DIFF
--- a/word_addin_dev/app/__tests__/annotate_plan.test.ts
+++ b/word_addin_dev/app/__tests__/annotate_plan.test.ts
@@ -25,6 +25,15 @@ describe('annotate scheduler', () => {
     expect(map['r2']).toBe(1);
   });
 
+  it('deduplicates identical findings', () => {
+    const findings: AnalyzeFinding[] = [
+      { start: 0, end: 3, snippet: 'abc', rule_id: 'r1' },
+      { start: 0, end: 3, snippet: 'abc', rule_id: 'r1' },
+    ];
+    const ops = planAnnotations(findings);
+    expect(ops.length).toBe(1);
+  });
+
   it('returns empty array for invalid findings', () => {
     const findings: AnalyzeFinding[] = [
       { start: undefined, end: undefined, snippet: '', rule_id: 'r1' },


### PR DESCRIPTION
## Summary
- test: ensure `planAnnotations` deduplicates findings with identical ranges and rule IDs

## Testing
- `npm test` *(fails: expected +0 to be 1, missing headers { apiKey: false, schema: true })*

------
https://chatgpt.com/codex/tasks/task_e_68c71c0233b88325834b87a0d443734f