### PR TITLE
Skip redundant replacements in Word add-in

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -95,6 +95,10 @@ import { getWholeDocText, getSelectionText } from "./office.ts"; // у вас у
 g.getWholeDocText = g.getWholeDocText || getWholeDocText;
 g.getSelectionText = g.getSelectionText || getSelectionText;
 
+// track already processed ranges to avoid reapplying the same ops
+const appliedRangeHashes: Set<string> = g.__appliedRangeHashes || new Set<string>();
+g.__appliedRangeHashes = appliedRangeHashes;
+
 type Mode = "live" | "friendly" | "doctor";
 let currentMode: Mode = 'live';
 
@@ -329,6 +333,9 @@ export async function applyOpsTracked(
     };
 
     for (const op of cleaned) {
+      const hashKey = `${op.start}:${op.end}:${op.replacement}`;
+      if (appliedRangeHashes.has(hashKey)) continue;
+
       const snippet = last.slice(op.start, op.end);
       const occIdx = (() => {
         let idx = -1, n = 0;
@@ -368,10 +375,14 @@ export async function applyOpsTracked(
       }
 
       if (target) {
-
-        target.insertText(op.replacement, 'Replace');
-        const comment = `${COMMENT_PREFIX} ${op.rationale || op.source || 'AI edit'}`;
-        try { await safeInsertComment(target, comment); } catch {}
+        target.load('text');
+        await ctx.sync();
+        if (target.text !== op.replacement) {
+          target.insertText(op.replacement, 'Replace');
+          const comment = `${COMMENT_PREFIX} ${op.rationale || op.source || 'AI edit'}`;
+          try { await safeInsertComment(target, comment); } catch {}
+        }
+        appliedRangeHashes.add(hashKey);
       } else {
         console.warn('[applyOpsTracked] match not found', { snippet, occIdx });
       }


### PR DESCRIPTION
## Summary
- Skip inserting text when the target already matches the replacement in `applyOpsTracked`
- Track hashed ranges to avoid reprocessing duplicate operations

## Testing
- `npm test` *(fails: 4 tests)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c71bd93ad883259150057a5dc5d369