### PR TITLE
feat: add environment-aware notifier

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.422.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.422.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 (globalThis as any).window = { addEventListener() {}, dispatchEvent() {} } as any;
 (globalThis as any).document = { addEventListener() {}, querySelectorAll() { return [] as any; } } as any;
 
-vi.mock('../notifier.ts', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
+vi.mock('../notifier', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
 
 describe('analyze 422 diagnostics', () => {
   it('logs detail and notifies', async () => {
@@ -15,8 +15,8 @@ describe('analyze 422 diagnostics', () => {
     });
     (globalThis as any).fetch = fetchMock;
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { analyze } = await import('../api-client.ts');
-    const { notifyWarn } = await import('../notifier.ts');
+    const { analyze } = await import('../api-client');
+    const { notifyWarn } = await import('../notifier');
     await analyze({ text: 'x' });
     expect(warnSpy).toHaveBeenCalledWith('[analyze] 422', [{ loc: ['body','text'], msg: 'bad' }]);
     expect(notifyWarn).toHaveBeenCalledWith('Validation error: bad');

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -1,7 +1,7 @@
 import { getApiKeyFromStore, getSchemaFromStore } from "./store.ts";
 import { registerFetch, deregisterFetch, registerTimer, deregisterTimer, withBusy } from './pending.ts';
 import { checkHealth } from './health.ts';
-import { notifyWarn } from './notifier.ts';
+import { notifyWarn } from './notifier';
 export function parseFindings(resp) {
     const arr = resp?.analysis?.findings ?? resp?.findings ?? resp?.issues ?? [];
     return Array.isArray(arr) ? arr.filter(Boolean) : [];

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -13,7 +13,7 @@ export type Meta = {
 import { getApiKeyFromStore, getSchemaFromStore } from "./store.ts";
 import { registerFetch, deregisterFetch, registerTimer, deregisterTimer, withBusy } from './pending.ts';
 import { checkHealth } from './health.ts';
-import { notifyWarn } from './notifier.ts';
+import { notifyWarn } from './notifier';
 
 export type AnalyzeFinding = {
   rule_id: string;

--- a/contract_review_app/contract_review_app/static/panel/app/assets/notifier.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/notifier.js
@@ -1,23 +1,55 @@
-function notifyOk(msg) {
-  try {
-    console.log("[OK]", msg);
-  } catch {
+const env = (() => {
+  if (typeof process !== "undefined" && (process.env === null || process.env === void 0 ? void 0 : process.env.NODE_ENV)) {
+    return process.env.NODE_ENV;
   }
-}
-function notifyErr(msg) {
   try {
-    console.error("[ERR]", msg);
-  } catch {
-  }
-}
-function notifyWarn(msg) {
+    if (typeof localStorage !== "undefined") {
+      return localStorage.getItem("NODE_ENV") || "";
+    }
+  } catch {}
+  return "development";
+})();
+const isProd = env === "production";
+function toast(msg, level) {
   try {
-    console.warn("[WARN]", msg);
-  } catch {
-  }
+    const el = document.getElementById("console");
+    if (!el) return;
+    el.textContent = msg;
+    el.setAttribute("data-level", level);
+    setTimeout(() => {
+      el.textContent = "";
+      el.removeAttribute("data-level");
+    }, 3000);
+  } catch {}
 }
-export {
-  notifyErr,
-  notifyOk,
-  notifyWarn
-};
+function notifyOk(msg, ctx) {
+  toast(msg, "ok");
+  try {
+    if (isProd) {
+      console.log("[OK]", msg);
+    } else {
+      console.log("[OK]", msg, ctx);
+    }
+  } catch {}
+}
+function notifyErr(msg, err) {
+  toast(msg, "error");
+  try {
+    if (isProd) {
+      console.error("[ERR]", msg);
+    } else {
+      console.error("[ERR]", msg, err);
+    }
+  } catch {}
+}
+function notifyWarn(msg, ctx) {
+  toast(msg, "warn");
+  try {
+    if (isProd) {
+      console.warn("[WARN]", msg);
+    } else {
+      console.warn("[WARN]", msg, ctx);
+    }
+  } catch {}
+}
+export { notifyErr, notifyOk, notifyWarn };

--- a/contract_review_app/contract_review_app/static/panel/app/assets/notifier.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/notifier.ts
@@ -1,3 +1,59 @@
-export function notifyOk(msg: string)   { try { console.log("[OK]", msg); } catch {} }
-export function notifyErr(msg: string)  { try { console.error("[ERR]", msg); } catch {} }
-export function notifyWarn(msg: string) { try { console.warn("[WARN]", msg); } catch {} }
+const env = (() => {
+  if (typeof process !== "undefined" && process.env?.NODE_ENV) {
+    return process.env.NODE_ENV;
+  }
+  try {
+    if (typeof localStorage !== "undefined") {
+      return localStorage.getItem("NODE_ENV") || "";
+    }
+  } catch {}
+  return "development";
+})();
+
+const isProd = env === "production";
+
+function toast(msg: string, level: string) {
+  try {
+    const el = document.getElementById("console");
+    if (!el) return;
+    el.textContent = msg;
+    el.setAttribute("data-level", level);
+    setTimeout(() => {
+      el.textContent = "";
+      el.removeAttribute("data-level");
+    }, 3000);
+  } catch {}
+}
+
+export function notifyOk(msg: string, ctx?: unknown) {
+  toast(msg, "ok");
+  try {
+    if (isProd) {
+      console.log("[OK]", msg);
+    } else {
+      console.log("[OK]", msg, ctx);
+    }
+  } catch {}
+}
+
+export function notifyErr(msg: string, err?: unknown) {
+  toast(msg, "error");
+  try {
+    if (isProd) {
+      console.error("[ERR]", msg);
+    } else {
+      console.error("[ERR]", msg, err);
+    }
+  } catch {}
+}
+
+export function notifyWarn(msg: string, ctx?: unknown) {
+  toast(msg, "warn");
+  try {
+    if (isProd) {
+      console.warn("[WARN]", msg);
+    } else {
+      console.warn("[WARN]", msg, ctx);
+    }
+  } catch {}
+}

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -90,7 +90,7 @@ g.applyMetaToBadges = g.applyMetaToBadges || applyMetaToBadges;
 g.getApiKeyFromStore = g.getApiKeyFromStore || getApiKeyFromStore;
 g.getSchemaFromStore = g.getSchemaFromStore || getSchemaFromStore;
 g.logRichError = g.logRichError || logRichError;
-import { notifyOk, notifyErr, notifyWarn } from "./notifier.ts";
+import { notifyOk, notifyErr, notifyWarn } from "./notifier";
 import { getWholeDocText, getSelectionText } from "./office.ts"; // у вас уже есть хелперы; если имя иное — поправьте импорт.
 g.getWholeDocText = g.getWholeDocText || getWholeDocText;
 g.getSelectionText = g.getSelectionText || getSelectionText;

--- a/word_addin_dev/app/__tests__/draft.spec.ts
+++ b/word_addin_dev/app/__tests__/draft.spec.ts
@@ -61,9 +61,9 @@ describe('get draft', () => {
 
   it('Word API failure warns and skips request', async () => {
     (globalThis as any).getSelectionText = vi.fn().mockRejectedValue(new Error('fail'));
-    vi.mock('../assets/notifier.ts', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
-    const { wireUI, onSuggestEdit } = await import('../assets/taskpane.ts');
-    const { notifyWarn } = await import('../assets/notifier.ts');
+    vi.mock('../assets/notifier', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
+    const { wireUI, onSuggestEdit } = await import('../assets/taskpane');
+    const { notifyWarn } = await import('../assets/notifier');
     wireUI();
     await onSuggestEdit();
     const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt/draft'));

--- a/word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts
+++ b/word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts
@@ -48,9 +48,9 @@ describe('ensure text for analyze', () => {
   it('warns when document empty', async () => {
     const getWholeDocText = vi.fn().mockResolvedValue('');
     (globalThis as any).getWholeDocText = getWholeDocText;
-    vi.mock('../assets/notifier.ts', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
-    const { onAnalyze } = await import('../assets/taskpane.ts');
-    const { notifyWarn } = await import('../assets/notifier.ts');
+    vi.mock('../assets/notifier', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
+    const { onAnalyze } = await import('../assets/taskpane');
+    const { notifyWarn } = await import('../assets/notifier');
     await onAnalyze();
     expect(getWholeDocText).toHaveBeenCalledOnce();
     const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));

--- a/word_addin_dev/app/assets/__tests__/analyze.422.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/analyze.422.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 (globalThis as any).window = { addEventListener() {}, dispatchEvent() {} } as any;
 (globalThis as any).document = { addEventListener() {}, querySelectorAll() { return [] as any; } } as any;
 
-vi.mock('../notifier.ts', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
+vi.mock('../notifier', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
 
 describe('analyze 422 diagnostics', () => {
   it('logs detail and notifies', async () => {
@@ -15,8 +15,8 @@ describe('analyze 422 diagnostics', () => {
     });
     (globalThis as any).fetch = fetchMock;
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { analyze } = await import('../api-client.ts');
-    const { notifyWarn } = await import('../notifier.ts');
+    const { analyze } = await import('../api-client');
+    const { notifyWarn } = await import('../notifier');
     await analyze({ text: 'x' });
     expect(warnSpy).toHaveBeenCalledWith('[analyze] 422', [{ loc: ['body','text'], msg: 'bad' }]);
     expect(notifyWarn).toHaveBeenCalledWith('Validation error: bad');

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -1,7 +1,7 @@
 import { getApiKeyFromStore, getSchemaFromStore } from "./store.ts";
 import { registerFetch, deregisterFetch, registerTimer, deregisterTimer, withBusy } from './pending.ts';
 import { checkHealth } from './health.ts';
-import { notifyWarn } from './notifier.ts';
+import { notifyWarn } from './notifier';
 const DEV_MODE = (() => {
     try {
         const ls = localStorage.getItem('cai_dev');

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -13,7 +13,7 @@ export type Meta = {
 import { getApiKeyFromStore, getSchemaFromStore } from "./store.ts";
 import { registerFetch, deregisterFetch, registerTimer, deregisterTimer, withBusy } from './pending.ts';
 import { checkHealth } from './health.ts';
-import { notifyWarn } from './notifier.ts';
+import { notifyWarn } from './notifier';
 
 const DEV_MODE = (() => {
   try {

--- a/word_addin_dev/app/assets/notifier.js
+++ b/word_addin_dev/app/assets/notifier.js
@@ -1,23 +1,55 @@
-function notifyOk(msg) {
-  try {
-    console.log("[OK]", msg);
-  } catch {
+const env = (() => {
+  if (typeof process !== "undefined" && (process.env === null || process.env === void 0 ? void 0 : process.env.NODE_ENV)) {
+    return process.env.NODE_ENV;
   }
-}
-function notifyErr(msg) {
   try {
-    console.error("[ERR]", msg);
-  } catch {
-  }
-}
-function notifyWarn(msg) {
+    if (typeof localStorage !== "undefined") {
+      return localStorage.getItem("NODE_ENV") || "";
+    }
+  } catch {}
+  return "development";
+})();
+const isProd = env === "production";
+function toast(msg, level) {
   try {
-    console.warn("[WARN]", msg);
-  } catch {
-  }
+    const el = document.getElementById("console");
+    if (!el) return;
+    el.textContent = msg;
+    el.setAttribute("data-level", level);
+    setTimeout(() => {
+      el.textContent = "";
+      el.removeAttribute("data-level");
+    }, 3000);
+  } catch {}
 }
-export {
-  notifyErr,
-  notifyOk,
-  notifyWarn
-};
+function notifyOk(msg, ctx) {
+  toast(msg, "ok");
+  try {
+    if (isProd) {
+      console.log("[OK]", msg);
+    } else {
+      console.log("[OK]", msg, ctx);
+    }
+  } catch {}
+}
+function notifyErr(msg, err) {
+  toast(msg, "error");
+  try {
+    if (isProd) {
+      console.error("[ERR]", msg);
+    } else {
+      console.error("[ERR]", msg, err);
+    }
+  } catch {}
+}
+function notifyWarn(msg, ctx) {
+  toast(msg, "warn");
+  try {
+    if (isProd) {
+      console.warn("[WARN]", msg);
+    } else {
+      console.warn("[WARN]", msg, ctx);
+    }
+  } catch {}
+}
+export { notifyErr, notifyOk, notifyWarn };

--- a/word_addin_dev/app/assets/notifier.ts
+++ b/word_addin_dev/app/assets/notifier.ts
@@ -1,3 +1,59 @@
-export function notifyOk(msg: string)   { try { console.log("[OK]", msg); } catch {} }
-export function notifyErr(msg: string)  { try { console.error("[ERR]", msg); } catch {} }
-export function notifyWarn(msg: string) { try { console.warn("[WARN]", msg); } catch {} }
+const env = (() => {
+  if (typeof process !== "undefined" && process.env?.NODE_ENV) {
+    return process.env.NODE_ENV;
+  }
+  try {
+    if (typeof localStorage !== "undefined") {
+      return localStorage.getItem("NODE_ENV") || "";
+    }
+  } catch {}
+  return "development";
+})();
+
+const isProd = env === "production";
+
+function toast(msg: string, level: string) {
+  try {
+    const el = document.getElementById("console");
+    if (!el) return;
+    el.textContent = msg;
+    el.setAttribute("data-level", level);
+    setTimeout(() => {
+      el.textContent = "";
+      el.removeAttribute("data-level");
+    }, 3000);
+  } catch {}
+}
+
+export function notifyOk(msg: string, ctx?: unknown) {
+  toast(msg, "ok");
+  try {
+    if (isProd) {
+      console.log("[OK]", msg);
+    } else {
+      console.log("[OK]", msg, ctx);
+    }
+  } catch {}
+}
+
+export function notifyErr(msg: string, err?: unknown) {
+  toast(msg, "error");
+  try {
+    if (isProd) {
+      console.error("[ERR]", msg);
+    } else {
+      console.error("[ERR]", msg, err);
+    }
+  } catch {}
+}
+
+export function notifyWarn(msg: string, ctx?: unknown) {
+  toast(msg, "warn");
+  try {
+    if (isProd) {
+      console.warn("[WARN]", msg);
+    } else {
+      console.warn("[WARN]", msg, ctx);
+    }
+  } catch {}
+}

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -90,7 +90,7 @@ g.applyMetaToBadges = g.applyMetaToBadges || applyMetaToBadges;
 g.getApiKeyFromStore = g.getApiKeyFromStore || getApiKeyFromStore;
 g.getSchemaFromStore = g.getSchemaFromStore || getSchemaFromStore;
 g.logRichError = g.logRichError || logRichError;
-import { notifyOk, notifyErr, notifyWarn } from "./notifier.ts";
+import { notifyOk, notifyErr, notifyWarn } from "./notifier";
 import { getWholeDocText, getSelectionText } from "./office.ts"; // у вас уже есть хелперы; если имя иное — поправьте импорт.
 g.getWholeDocText = g.getWholeDocText || getWholeDocText;
 g.getSelectionText = g.getSelectionText || getSelectionText;


### PR DESCRIPTION
## Summary
- add environment-aware toast and console logging in notifier
- switch imports to updated notifier module

## Testing
- `pre-commit run --files contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.422.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/api-client.js contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts contract_review_app/contract_review_app/static/panel/app/assets/notifier.js contract_review_app/contract_review_app/static/panel/app/assets/notifier.ts contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts word_addin_dev/app/__tests__/draft.spec.ts word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts word_addin_dev/app/assets/__tests__/analyze.422.spec.ts word_addin_dev/app/assets/api-client.js word_addin_dev/app/assets/api-client.ts word_addin_dev/app/assets/notifier.js word_addin_dev/app/assets/notifier.ts word_addin_dev/app/assets/taskpane.ts`
- `npx --yes vitest run word_addin_dev/app/__tests__/draft.spec.ts word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts word_addin_dev/app/assets/__tests__/analyze.422.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.422.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c71c0ebcc48325b07ffa747dc04a3e