### PR TITLE
Clamp long snippet in Word search

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -339,7 +339,10 @@ export async function applyOpsTracked(
         const sFull = await safeBodySearch(body, searchText, searchOpts);
         const fullRange = pick(sFull, occIdx);
         if (fullRange) {
-          const inner: any = fullRange.search(snippet, searchOpts);
+          // Clamp snippet before searching to avoid Word's
+          // SearchStringInvalidOrTooLong errors (limit ~255 chars).
+          const needle = snippet.slice(0, 240);
+          const inner: any = fullRange.search(needle, searchOpts);
           if (inner && typeof inner.load === 'function') inner.load('items');
           await ctx.sync();
           target = pick(inner, 0);

--- a/word_addin_dev/app/__tests__/applyOpsTracked.long.spec.ts
+++ b/word_addin_dev/app/__tests__/applyOpsTracked.long.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+
+;(globalThis as any).window = globalThis
+;(globalThis as any).document = { readyState: 'complete', addEventListener: vi.fn() }
+;(globalThis as any).Office = { onReady: vi.fn() }
+
+vi.mock('../assets/pending.ts', async () => {
+  const actual = await vi.importActual('../assets/pending.ts')
+  return { ...actual, withBusy: async (fn: any) => await fn() }
+})
+
+vi.mock('../assets/annotate.ts', async () => {
+  const actual = await vi.importActual('../assets/annotate.ts')
+  return { ...actual, COMMENT_PREFIX: '[CAI]', safeInsertComment: vi.fn() }
+})
+
+const innerRange = { insertText: vi.fn() }
+const innerCollection = { items: [innerRange], load: vi.fn() }
+const fullSearch = vi.fn().mockReturnValue(innerCollection)
+
+vi.mock('../assets/safeBodySearch.ts', () => ({
+  safeBodySearch: vi.fn().mockResolvedValue({ items: [{ search: fullSearch }] })
+}))
+
+
+describe('applyOpsTracked long replacements', () => {
+  it('clamps snippet before searching full range', async () => {
+    const longText = 'x'.repeat(500)
+    ;(globalThis as any).__lastAnalyzed = longText
+
+    const run = vi.fn(async (cb: any) => {
+      await cb({ document: { body: {} }, sync: vi.fn() })
+    })
+    ;(globalThis as any).Word = { run }
+
+    const mod = await import('../assets/taskpane.ts')
+    await mod.applyOpsTracked([{ start: 0, end: 500, replacement: 'R', context_before: 'a' }])
+
+    expect(fullSearch).toHaveBeenCalledTimes(1)
+    expect(fullSearch.mock.calls[0][0]).toBe(longText.slice(0, 240))
+  })
+})

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -342,7 +342,10 @@ export async function applyOpsTracked(
         const sFull = await safeBodySearch(body, searchText, searchOpts);
         const fullRange = pick(sFull, occIdx);
         if (fullRange) {
-          const inner: any = fullRange.search(snippet, searchOpts);
+          // Clamp snippet before searching to avoid Word's
+          // SearchStringInvalidOrTooLong errors (limit ~255 chars).
+          const needle = snippet.slice(0, 240);
+          const inner: any = fullRange.search(needle, searchOpts);
           if (inner && typeof inner.load === 'function') inner.load('items');
           await ctx.sync();
           target = pick(inner, 0);


### PR DESCRIPTION
## Summary
- clamp snippets to 240 chars before calling `fullRange.search`
- document clamp rationale in taskpane code
- add regression test for long snippet replacements

## Testing
- `npx vitest run app/__tests__/applyOpsTracked.long.spec.ts`
- `npx vitest run app/__tests__/safeBodySearch.spec.ts` *(fails: expected 1 to be undefined)*
- `pytest tests/panel/test_apply_ops_tracked.py::test_apply_ops_nth_occurrence -q` *(fails: subprocess.CalledProcessError)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c71c7d0e80832585d9a351edb5d6bd