### PR TITLE
Support clause type query parameter for analyze

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -892,6 +892,7 @@ class AnalyzeRequest(BaseModel):
     language: str = "en-GB"
     mode: Optional[str] = None
     risk: Optional[str] = None
+    clause_type: Optional[str] = None
     schema_: Optional[str] = Field(default=None, alias="schema")
 
     @field_validator("text")
@@ -1823,6 +1824,9 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
         req = AnalyzeRequest.model_validate(body.get("payload", body))
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors())
+    clause_type = request.query_params.get("clause_type")
+    if clause_type:
+        req.clause_type = clause_type
     txt = req.text
     debug = request.query_params.get("debug")  # noqa: F841
     risk_param = (

--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -41,6 +41,7 @@ class AnalyzeRequest(_DTOBase):
     language: str = "en-GB"
     mode: str | None = None
     risk: str | None = None
+    clause_type: str | None = None
     schema_: str | None = Field(None, alias="schema")
 
     @field_validator("language", mode="before")
@@ -51,7 +52,7 @@ class AnalyzeRequest(_DTOBase):
             return "en-GB"
         return v
 
-    @field_validator("mode", "risk", mode="before")
+    @field_validator("mode", "risk", "clause_type", mode="before")
     @classmethod
     def _blank_to_none(cls, v: str | None):
         if isinstance(v, str) and not v.strip():

--- a/contract_review_app/core/schemas.py
+++ b/contract_review_app/core/schemas.py
@@ -185,6 +185,7 @@ class AnalyzeIn(AppBaseModel):
     document_name: Optional[str] = None
     text: str
     language: str = "en-GB"
+    clause_type: Optional[str] = None
 
     # segment context (optional; used by pipeline/template selection)
     jurisdiction: Optional[str] = None

--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -149,7 +149,8 @@ const DraftAssistantPanel: React.FC<PanelProps> = ({ initialAnalysis = null, ini
     setDraft(null);
     try {
       const base = getBackend().replace(/\/+$/, '');
-      const env = await postJSON<AnalyzeEnvelope>(`${base}/api/analyze`, { text, clause_type: clauseType || undefined });
+      const url = `${base}/api/analyze${clauseType ? `?clause_type=${encodeURIComponent(clauseType)}` : ''}`;
+      const env = await postJSON<AnalyzeEnvelope>(url, { text });
       const a = (env?.analysis ?? env) as any;
       a.cid = a.cid || (env as any)?.cid;
       a.clause_type = a.clause_type || clauseType || undefined;

--- a/tests/panel/test_draft_panel_analyze.py
+++ b/tests/panel/test_draft_panel_analyze.py
@@ -1,0 +1,24 @@
+import os
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
+
+client = TestClient(app)
+
+
+def _headers():
+    return {
+        "x-api-key": os.getenv("API_KEY", "local-test-key-123"),
+        "x-schema-version": SCHEMA_VERSION,
+    }
+
+
+def test_draft_panel_analyze_ok():
+    resp = client.post(
+        "/api/analyze?clause_type=nda",
+        json={"text": "Hello"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 200
+    assert "analysis" in resp.json()


### PR DESCRIPTION
## Summary
- send clause type as query parameter from draft panel analyze calls
- accept clause type in API analyze endpoint and models
- test draft panel analyze request succeeds

## Testing
- `pytest tests/panel/test_draft_panel_analyze.py tests/panel/test_panel_analyze_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68c71c7b7a3483258c1d44bc45d37a80