### PR TITLE
Handle proposed_text drafts in frontend

### DIFF
--- a/contract_review_app/frontend/draft_panel/__tests__/draft_panel.test.tsx
+++ b/contract_review_app/frontend/draft_panel/__tests__/draft_panel.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+vi.mock('../../common/http', () => ({
+  postJSON: vi.fn(async () => ({ proposed_text: 'Hello from AI' })),
+  getHealth: vi.fn(async () => ({})),
+  ensureHeadersSet: vi.fn(),
+}));
+
+import { DraftAssistantPanel } from '../index';
+
+describe('DraftAssistantPanel', () => {
+  it('renders proposed draft text from API response', async () => {
+    (globalThis as any).localStorage = { getItem: () => '', setItem: () => {} };
+    (globalThis as any).navigator = { clipboard: { writeText: async (_: string) => {} } };
+    (globalThis as any).Office = {
+      context: {
+        document: {
+          setSelectedDataAsync: (_text: string, _opts: any, cb: any) => cb({ status: 'succeeded' }),
+        },
+      },
+      CoercionType: { Text: 'text' },
+      AsyncResultStatus: { Succeeded: 'succeeded' },
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DraftAssistantPanel initialAnalysis={{ cid: '1', text: 'clause' }} />);
+    });
+
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Get AI Draft'),
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {});
+
+    expect(container.textContent).toContain('Hello from AI');
+  });
+});

--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -36,6 +36,7 @@ interface AnalyzeEnvelope {
   [k: string]: any;
 }
 interface DraftEnvelope {
+  proposed_text?: string;
   draft_text?: string;
   [k: string]: any;
 }
@@ -177,9 +178,10 @@ const DraftAssistantPanel: React.FC<PanelProps> = ({ initialAnalysis = null, ini
         cid: (analysis as any)?.cid,
         clause: analysis?.text || clauseText,
       });
-      setDraft(env);
+      const text = env?.proposed_text || env?.draft_text || '';
+      setDraft({ ...env, proposed_text: text });
       setStatus('ready');
-      try { await insertIntoWord(env?.draft_text || ''); } catch {}
+      try { await insertIntoWord(text); } catch {}
     } catch (e: any) {
       console.error(e);
       setError(e?.message || 'Draft failed');
@@ -266,9 +268,9 @@ const DraftAssistantPanel: React.FC<PanelProps> = ({ initialAnalysis = null, ini
           {status === 'loading' ? 'Generating…' : 'Get AI Draft'}
         </button>
 
-        {draft?.draft_text && (
+        {draft?.proposed_text && (
           <button
-            onClick={() => insertIntoWord(draft.draft_text || '')}
+            onClick={() => insertIntoWord(draft.proposed_text || '')}
             style={{ background: '#28a745', color: 'white', padding: '8px 12px', border: 'none', borderRadius: 4 }}
           >
             Insert result into Word
@@ -308,11 +310,11 @@ const DraftAssistantPanel: React.FC<PanelProps> = ({ initialAnalysis = null, ini
             </div>
           )}
 
-          {draft?.draft_text && (
+          {draft?.proposed_text && (
             <div style={{ marginTop: 20 }}>
               <h3>Suggested Draft</h3>
               <pre style={{ background: '#f5f5f5', padding: '1rem', borderRadius: 4, whiteSpace: 'pre-wrap' }}>
-                {draft.draft_text}
+                {draft.proposed_text}
               </pre>
             </div>
           )}

--- a/contract_review_app/frontend/vitest.config.ts
+++ b/contract_review_app/frontend/vitest.config.ts
@@ -1,0 +1,7 @@
+export default {
+  test: {
+    environment: 'jsdom',
+    include: ['draft_panel/__tests__/**/*.test.ts?(x)'],
+    globals: true,
+  },
+};


### PR DESCRIPTION
## Summary
- handle `proposed_text` drafts in panel
- map legacy `draft_text` responses for compatibility
- add test ensuring proposed text renders

## Testing
- `pre-commit run --files contract_review_app/frontend/draft_panel/index.tsx contract_review_app/frontend/draft_panel/__tests__/draft_panel.test.tsx contract_review_app/frontend/vitest.config.ts`
- `cd contract_review_app/frontend && ../../word_addin_dev/node_modules/.bin/vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c71c7aa4b08325bd7bdc5ad0f96388