### PR TITLE
feat: support schema field in gpt draft requests

### DIFF
--- a/contract_review_app/api/models.py
+++ b/contract_review_app/api/models.py
@@ -124,6 +124,7 @@ class DraftRequest(_DTOBase):
     )
     mode: str | None = None
     cid: str | None = None
+    schema_: str | None = Field(None, alias="schema")
 
     @field_validator("mode", "cid", mode="before")
     @classmethod

--- a/openapi.json
+++ b/openapi.json
@@ -7136,6 +7136,18 @@
             ],
             "default": null,
             "title": "Cid"
+          },
+          "schema": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Schema"
           }
         },
         "required": [

--- a/tests/panel/test_gpt_draft_payload.py
+++ b/tests/panel/test_gpt_draft_payload.py
@@ -1,11 +1,13 @@
 import json
+import pytest
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
 
 client = TestClient(app)
 
 
-def test_gpt_draft_payload_and_response():
+@pytest.mark.parametrize("extra", [{}, {"schema": "1.4"}])
+def test_gpt_draft_payload_and_response(extra):
     r_an = client.post(
         "/api/analyze",
         json={"mode": "live", "text": "Ping"},
@@ -13,7 +15,12 @@ def test_gpt_draft_payload_and_response():
     )
     cid = r_an.headers.get("x-cid")
     payload = {"cid": cid, "clause": "Ping", "mode": "friendly"}
-    r = client.post("/api/gpt-draft", json=payload, headers={"x-api-key": "k", "x-schema-version": "1.4"})
+    payload.update(extra)
+    r = client.post(
+        "/api/gpt-draft",
+        json=payload,
+        headers={"x-api-key": "k", "x-schema-version": "1.4"},
+    )
     assert r.status_code == 200
     data = r.json()
     for k in ("cid", "clause", "mode"):


### PR DESCRIPTION
## Summary
- allow DraftRequest to accept an optional `schema` attribute
- document the field in OpenAPI spec
- test gpt-draft endpoint with and without `schema`

## Testing
- `pytest tests/panel/test_gpt_draft_payload.py -q` *(fails: 'NoneType' object has no attribute 'get')*

------
https://chatgpt.com/codex/tasks/task_e_68c71c7932a08325acf4ccc2a0fce503