### PR TITLE
Fix recommendations list ID and reveal summary blocks

### DIFF
--- a/tests/panel/test_slots_exist.py
+++ b/tests/panel/test_slots_exist.py
@@ -16,7 +16,7 @@ def test_findings_list_slot_exists():
 
 
 def test_recommendations_list_slot_exists():
-    assert _exists('recsList', 'recommendations')
+    assert _exists('recommendationsList', 'recommendations')
 
 
 def test_raw_json_toggle_slot_exists():

--- a/word_addin_dev/app/__tests__/renderAnalysisSummary.spec.ts
+++ b/word_addin_dev/app/__tests__/renderAnalysisSummary.spec.ts
@@ -6,7 +6,9 @@ describe('renderAnalysisSummary', () => {
       clauseTypeOut: { textContent: '' },
       visibleHiddenOut: { textContent: '' },
       findingsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
-      recsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
+      recommendationsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
+      findingsBlock: { style: { display: 'none' } },
+      recommendationsBlock: { style: { display: 'none' } },
       resultsBlock: { style: { display: 'none', removeProperty(prop: string){ delete (this as any)[prop] } } }
     }
     ;(globalThis as any).document = {
@@ -21,7 +23,7 @@ describe('renderAnalysisSummary', () => {
     expect(elements.clauseTypeOut.textContent).toBe('—')
     expect(elements.visibleHiddenOut.textContent).toBe('0 / 0')
     expect(elements.findingsList.children.length).toBe(0)
-    expect(elements.recsList.children.length).toBe(0)
+    expect(elements.recommendationsList.children.length).toBe(0)
     expect(elements.resultsBlock.style.display).toBeUndefined()
   })
 
@@ -30,7 +32,9 @@ describe('renderAnalysisSummary', () => {
       clauseTypeOut: { textContent: '' },
       visibleHiddenOut: { textContent: '' },
       findingsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
-      recsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
+      recommendationsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
+      findingsBlock: { style: { display: 'none' } },
+      recommendationsBlock: { style: { display: 'none' } },
       resultsBlock: { style: { display: 'none', removeProperty(prop: string){ delete (this as any)[prop] } } }
     }
     ;(globalThis as any).document = {

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -202,6 +202,12 @@ function slot(id: string, role: string): HTMLElement | null {
   ) || document.getElementById(id);
 }
 
+function mustGetElementById<T extends HTMLElement = HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`Element not found: ${id}`);
+  return el as T;
+}
+
 export function getRiskThreshold(): "low" | "medium" | "high" {
   const sel = document.getElementById("selectRiskThreshold") as HTMLSelectElement | null;
   const v = sel?.value?.toLowerCase();
@@ -466,6 +472,7 @@ export function renderAnalysisSummary(json: any) {
   setText("visibleHiddenOut", `${visible} / ${hidden}`);
 
   // Заполняем findings
+  const findingsBlock = mustGetElementById('findingsBlock');
   const fCont = document.getElementById("findingsList");
   if (fCont) {
     fCont.innerHTML = "";
@@ -496,17 +503,20 @@ export function renderAnalysisSummary(json: any) {
       fCont.appendChild(li);
     }
   }
+  findingsBlock.style.display = visibleFindings.length ? '' : 'none';
 
   // Заполняем рекомендации
-  const rCont = document.getElementById("recsList");
-  if (rCont) {
-    rCont.innerHTML = "";
+  const recommendationsBlock = mustGetElementById('recommendationsBlock');
+  const recommendationsList = document.getElementById("recommendationsList");
+  if (recommendationsList) {
+    recommendationsList.innerHTML = "";
     for (const r of recs) {
       const li = document.createElement("li");
       li.textContent = r?.text || r?.advice || r?.message || "Recommendation";
-      rCont.appendChild(li);
+      recommendationsList.appendChild(li);
     }
   }
+  recommendationsBlock.style.display = recs.length ? '' : 'none';
 
   // Показать блок результатов (если был скрыт стилями)
   const rb = document.getElementById("resultsBlock") as HTMLElement | null;
@@ -529,17 +539,21 @@ function renderResults(res: any) {
       findingsList.appendChild(li);
     });
   }
+  const findingsBlock = mustGetElementById('findingsBlock');
+  findingsBlock.style.display = findingsArr.length ? '' : 'none';
 
   const recoArr = Array.isArray(res?.recommendations) ? res.recommendations : [];
-  const recoList = slot("recoList", "recommendations") as HTMLElement | null;
-  if (recoList) {
-    recoList.innerHTML = "";
+  const recommendationsList = slot("recommendationsList", "recommendations") as HTMLElement | null;
+  if (recommendationsList) {
+    recommendationsList.innerHTML = "";
     recoArr.forEach((r: any) => {
       const li = document.createElement("li");
       li.textContent = typeof r === "string" ? r : JSON.stringify(r);
-      recoList.appendChild(li);
+      recommendationsList.appendChild(li);
     });
   }
+  const recommendationsBlock = mustGetElementById('recommendationsBlock');
+  recommendationsBlock.style.display = recoArr.length ? '' : 'none';
 
   const count = slot("resFindingsCount", "findings-count");
   if (count) count.textContent = String(findingsArr.length);

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -328,10 +328,10 @@
       <ol class="list" id="findingsList" data-role="findings"></ol>
     </div>
 
-    <div class="row" id="recommendationsBlock">
-      <strong>Recommendations</strong>
-      <ol class="list" id="recsList" data-role="recommendations"></ol>
-    </div>
+      <div class="row" id="recommendationsBlock">
+        <strong>Recommendations</strong>
+        <ol class="list" id="recommendationsList" data-role="recommendations"></ol>
+      </div>
 
     <div class="row">
       <span class="toggle" id="toggleRaw" data-role="toggle-raw-json">Show raw JSON</span>


### PR DESCRIPTION
## Summary
- rename `recsList` to `recommendationsList` in taskpane HTML and TypeScript
- add `mustGetElementById` helper and show/hide findings and recommendations blocks when populated
- update tests for new recommendations list ID

## Testing
- `npm test` *(fails: annotate scheduler, bootstrap, insert, analyze flow, safeBodySearch)*
- `npm run lint`
- `pytest tests/panel/test_slots_exist.py`


------
https://chatgpt.com/codex/tasks/task_e_68c71c6a74708325ad004cc6a07a03da