### PR TITLE
feat: merge QA results on event

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1,6 +1,6 @@
 import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, postJSON, analyze } from "./api-client.ts";
 import domSchema from "../panel_dom.schema.json";
-import { normalizeText, severityRank } from "./dedupe.ts";
+import { normalizeText, severityRank, dedupeFindings } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
 import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment } from "./annotate.ts";
 import { findAnchors } from "./anchors.ts";
@@ -508,6 +508,13 @@ function renderResults(res: any) {
 
   const pre = slot("rawJson", "raw-json") as HTMLElement | null;
   if (pre) pre.textContent = JSON.stringify(res ?? {}, null, 2);
+}
+
+function mergeQaResults(json: any) {
+  const existing: AnalyzeFinding[] = (window as any).__findings || [];
+  const incoming = parseFindings(json);
+  const merged = dedupeFindings([...existing, ...incoming]);
+  return { ...(json || {}), findings: merged };
 }
 
 function wireResultsToggle() {
@@ -1078,6 +1085,24 @@ export function wireUI() {
     annotateBtn.classList.remove("js-disable-while-busy");
     annotateBtn.removeAttribute("disabled");
   }
+
+  document.body.addEventListener('ca.qa', (ev: any) => {
+    const json = ev?.detail;
+    try {
+      if (!json || json.error) {
+        renderResults(json || {});
+        renderAnalysisSummary(json || {});
+        return;
+      }
+      const merged = mergeQaResults(json);
+      renderResults(merged);
+      renderAnalysisSummary(merged);
+    } catch (e) {
+      console.warn('ca.qa handler failed', e);
+      renderResults(json || {});
+      renderAnalysisSummary(json || {});
+    }
+  });
 
   onDraftReady('');
   wireResultsToggle();

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1,6 +1,6 @@
 import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, postJSON, analyze } from "./api-client.ts";
 import domSchema from "../panel_dom.schema.json";
-import { normalizeText, severityRank } from "./dedupe.ts";
+import { normalizeText, severityRank, dedupeFindings } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
 import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment } from "./annotate.ts";
 import { findAnchors } from "./anchors.ts";
@@ -547,6 +547,13 @@ function renderResults(res: any) {
 
   const pre = slot("rawJson", "raw-json") as HTMLElement | null;
   if (pre) pre.textContent = JSON.stringify(res ?? {}, null, 2);
+}
+
+function mergeQaResults(json: any) {
+  const existing: AnalyzeFinding[] = (window as any).__findings || [];
+  const incoming = parseFindings(json);
+  const merged = dedupeFindings([...existing, ...incoming]);
+  return { ...(json || {}), findings: merged };
 }
 
 function wireResultsToggle() {
@@ -1134,6 +1141,24 @@ export function wireUI() {
     annotateBtn.classList.remove("js-disable-while-busy");
     annotateBtn.removeAttribute("disabled");
   }
+
+  document.body.addEventListener('ca.qa', (ev: any) => {
+    const json = ev?.detail;
+    try {
+      if (!json || json.error) {
+        renderResults(json || {});
+        renderAnalysisSummary(json || {});
+        return;
+      }
+      const merged = mergeQaResults(json);
+      renderResults(merged);
+      renderAnalysisSummary(merged);
+    } catch (e) {
+      console.warn('ca.qa handler failed', e);
+      renderResults(json || {});
+      renderAnalysisSummary(json || {});
+    }
+  });
 
   onDraftReady('');
   wireResultsToggle();


### PR DESCRIPTION
## Summary
- merge incoming QA findings into existing list
- re-render results when `ca.qa` event fires

## Testing
- `pre-commit run --files word_addin_dev/app/assets/taskpane.ts contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts`
- `pytest tests/api/test_qa_recheck.py` *(fails: ResponseValidationError: validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c71c28e4b48325bf83a9eacbbb210a