### PR TITLE
Handle QA recheck findings consistently

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -861,10 +861,49 @@ async function doQARecheck() {
   return withBusy(async () => {
     ensureHeaders();
     const text = await getWholeDocText();
+    (window as any).__lastAnalyzed = text;
     const { json } = await postJSON('/api/qa-recheck', { text, rules: {} });
     (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;
     if (ok) {
+      const prev: AnnotationPlan[] = (window as any).__findings || [];
+      const prevIdx = (window as any).__findingIdx ?? 0;
+      const key = (f: any) => f?.code || f?.rule_id || `${f?.rule_id}|${f?.raw || f?.snippet || ''}`;
+      const prevKey = prev[prevIdx] ? key(prev[prevIdx]) : null;
+
+      const parsed = parseFindings(json);
+      const thr = getRiskThreshold();
+      const filtered = filterByThreshold(parsed, thr);
+      const ops = planAnnotations(filtered);
+      const uniq = new Map<string, AnnotationPlan>();
+      ops.forEach(op => {
+        const k = key(op);
+        if (k && !uniq.has(k)) uniq.set(k, op);
+      });
+      const deduped = Array.from(uniq.values());
+      (window as any).__findings = deduped;
+
+      let newIdx = 0;
+      if (prevKey) {
+        const found = deduped.findIndex(o => key(o) === prevKey);
+        if (found >= 0) newIdx = found;
+      }
+      if (newIdx >= deduped.length) newIdx = 0;
+      (window as any).__findingIdx = newIdx;
+
+      const list = document.getElementById("findingsList");
+      if (list) {
+        const frag = document.createDocumentFragment();
+        deduped.forEach((op, i) => {
+          const li = document.createElement("li");
+          li.textContent = `${op.rule_id}: ${op.raw}`;
+          if (i === newIdx) li.classList.add("active");
+          frag.appendChild(li);
+        });
+        list.innerHTML = "";
+        list.appendChild(frag);
+      }
+
       notifyOk("QA recheck OK");
     } else {
       const msg = json?.error || json?.message || 'unknown';

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -916,10 +916,49 @@ async function doQARecheck() {
   return withBusy(async () => {
     ensureHeaders();
     const text = await getWholeDocText();
+    (window as any).__lastAnalyzed = text;
     const { json } = await postJSON('/api/qa-recheck', { text, rules: {} });
     (document.getElementById("results") || document.body).dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;
     if (ok) {
+      const prev: AnnotationPlan[] = (window as any).__findings || [];
+      const prevIdx = (window as any).__findingIdx ?? 0;
+      const key = (f: any) => f?.code || f?.rule_id || `${f?.rule_id}|${f?.raw || f?.snippet || ''}`;
+      const prevKey = prev[prevIdx] ? key(prev[prevIdx]) : null;
+
+      const parsed = parseFindings(json);
+      const thr = getRiskThreshold();
+      const filtered = filterByThreshold(parsed, thr);
+      const ops = planAnnotations(filtered);
+      const uniq = new Map<string, AnnotationPlan>();
+      ops.forEach(op => {
+        const k = key(op);
+        if (k && !uniq.has(k)) uniq.set(k, op);
+      });
+      const deduped = Array.from(uniq.values());
+      (window as any).__findings = deduped;
+
+      let newIdx = 0;
+      if (prevKey) {
+        const found = deduped.findIndex(o => key(o) === prevKey);
+        if (found >= 0) newIdx = found;
+      }
+      if (newIdx >= deduped.length) newIdx = 0;
+      (window as any).__findingIdx = newIdx;
+
+      const list = document.getElementById("findingsList");
+      if (list) {
+        const frag = document.createDocumentFragment();
+        deduped.forEach((op, i) => {
+          const li = document.createElement("li");
+          li.textContent = `${op.rule_id}: ${op.raw}`;
+          if (i === newIdx) li.classList.add("active");
+          frag.appendChild(li);
+        });
+        list.innerHTML = "";
+        list.appendChild(frag);
+      }
+
       notifyOk("QA recheck OK");
     } else {
       const msg = json?.error || json?.message || 'unknown';


### PR DESCRIPTION
## Summary
- Parse and deduplicate QA recheck findings
- Update findings list with a document fragment and maintain index
- Reset selection if the previous finding disappears

## Testing
- `pre-commit run --files word_addin_dev/app/assets/taskpane.ts contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c71c2750248325821e35c0f5ee116c