### PR TITLE
feat: highlight findings with clearable range

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -380,10 +380,27 @@ export async function applyOpsTracked(
 
 g.applyOpsTracked = g.applyOpsTracked || applyOpsTracked;
 
+function clearHighlightInCtx(ctx: Word.RequestContext, w: any) {
+  if (w.__highlight) {
+    try { w.__highlight.font.highlightColor = 'NoColor' as any; } catch {}
+    ctx.trackedObjects.remove(w.__highlight);
+    w.__highlight = null;
+  }
+}
 
+export async function clearHighlight() {
+  const w: any = window as any;
+  if (!w.__highlight) return;
+  await Word.run(async ctx => {
+    clearHighlightInCtx(ctx, w);
+    await ctx.sync();
+  });
+}
 
 async function highlightFinding(op: AnnotationPlan) {
   await Word.run(async ctx => {
+    const w: any = window as any;
+    clearHighlightInCtx(ctx, w);
     const body = ctx.document.body as any;
     let anchors = await findAnchors(body, op.raw);
     let target: any = anchors[Math.min(op.occIdx, anchors.length - 1)] || null;
@@ -392,7 +409,10 @@ async function highlightFinding(op: AnnotationPlan) {
       target = anchors[Math.min(op.occIdx, anchors.length - 1)] || null;
     }
     if (target) {
+      w.__highlight = target;
+      ctx.trackedObjects.add(target);
       try { target.select(); } catch {}
+      try { target.font.highlightColor = '#ffff00' as any; } catch {}
     }
     await ctx.sync();
   });
@@ -421,6 +441,7 @@ function onPrevIssue() { navigateFinding(-1); }
 function onNextIssue() { navigateFinding(1); }
 
 export function renderAnalysisSummary(json: any) {
+  clearHighlight().catch(() => {});
   // аккуратно вытаскиваем ключевые поля
   const clauseType =
     json?.summary?.clause_type ||
@@ -449,14 +470,24 @@ export function renderAnalysisSummary(json: any) {
   const fCont = document.getElementById("findingsList");
   if (fCont) {
     fCont.innerHTML = "";
-    for (const f of findings) {
+    findings.forEach((f, idx) => {
       const li = document.createElement("li");
       const title =
         f?.title || f?.finding?.title || f?.rule_id || "Issue";
       const snippet = f?.snippet || f?.evidence?.text || "";
       li.textContent = snippet ? `${title}: ${snippet}` : String(title);
+
+      li.addEventListener('click', () => {
+        const items = Array.from(fCont.querySelectorAll('li'));
+        items.forEach((el, i) => {
+          (el as HTMLElement).classList.toggle('active', i === idx);
+        });
+        (window as any).__findingIdx = idx;
+        highlightFinding(f).catch(() => {});
+      });
+
       fCont.appendChild(li);
-    }
+    });
   }
 
   // Заполняем рекомендации
@@ -780,6 +811,7 @@ export async function onAnalyze() {
 
 async function doAnalyze() {
   return withBusy(async () => {
+    await clearHighlight();
     const btn = document.getElementById("btnAnalyze") as HTMLButtonElement | null;
     const busy = document.getElementById("busyBar") as HTMLElement | null;
     if (btn) btn.disabled = true;
@@ -859,6 +891,7 @@ async function doAnalyze() {
 
 async function doQARecheck() {
   return withBusy(async () => {
+    await clearHighlight();
     ensureHeaders();
     const text = await getWholeDocText();
     const { json } = await postJSON('/api/qa-recheck', { text, rules: {} });

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -383,10 +383,27 @@ export async function applyOpsTracked(
 
 g.applyOpsTracked = g.applyOpsTracked || applyOpsTracked;
 
+function clearHighlightInCtx(ctx: Word.RequestContext, w: any) {
+  if (w.__highlight) {
+    try { w.__highlight.font.highlightColor = 'NoColor' as any; } catch {}
+    ctx.trackedObjects.remove(w.__highlight);
+    w.__highlight = null;
+  }
+}
 
+export async function clearHighlight() {
+  const w: any = window as any;
+  if (!w.__highlight) return;
+  await Word.run(async ctx => {
+    clearHighlightInCtx(ctx, w);
+    await ctx.sync();
+  });
+}
 
 async function highlightFinding(op: AnnotationPlan) {
   await Word.run(async ctx => {
+    const w: any = window as any;
+    clearHighlightInCtx(ctx, w);
     const body = ctx.document.body as any;
     let anchors = await findAnchors(body, op.raw);
     let target: any = anchors[Math.min(op.occIdx, anchors.length - 1)] || null;
@@ -395,7 +412,10 @@ async function highlightFinding(op: AnnotationPlan) {
       target = anchors[Math.min(op.occIdx, anchors.length - 1)] || null;
     }
     if (target) {
+      w.__highlight = target;
+      ctx.trackedObjects.add(target);
       try { target.select(); } catch {}
+      try { target.font.highlightColor = '#ffff00' as any; } catch {}
     }
     await ctx.sync();
   });
@@ -442,6 +462,7 @@ function onPrevIssue() { navigateFinding(-1); }
 function onNextIssue() { navigateFinding(1); }
 
 export function renderAnalysisSummary(json: any) {
+  clearHighlight().catch(() => {});
   // аккуратно вытаскиваем ключевые поля
   const clauseType =
     json?.summary?.clause_type ||
@@ -470,12 +491,21 @@ export function renderAnalysisSummary(json: any) {
   const fCont = document.getElementById("findingsList");
   if (fCont) {
     fCont.innerHTML = "";
-    for (const f of visibleFindings) {
+    visibleFindings.forEach((f, idx) => {
       const li = document.createElement("li");
       const title =
         f?.title || f?.finding?.title || f?.rule_id || "Issue";
       const snippet = f?.snippet || f?.evidence?.text || "";
       li.textContent = snippet ? `${title}: ${snippet}` : String(title);
+
+      li.addEventListener('click', () => {
+        const items = Array.from(fCont.querySelectorAll('li'));
+        items.forEach((el, i) => {
+          (el as HTMLElement).classList.toggle('active', i === idx);
+        });
+        (window as any).__findingIdx = idx;
+        highlightFinding(f).catch(() => {});
+      });
 
       const links = Array.isArray((f as any).links)
         ? (f as any).links.filter((l: any) => l?.type === 'conflict' && l?.targetFindingId)
@@ -483,19 +513,19 @@ export function renderAnalysisSummary(json: any) {
       if (links.length) {
         const div = document.createElement('div');
         div.textContent = `Conflicts: ${links.length} `;
-        links.forEach((lnk: any, idx: number) => {
+        links.forEach((lnk: any, lidx: number) => {
           const a = document.createElement('a');
           a.href = '#';
           a.textContent = 'Jump to';
           a.addEventListener('click', ev => { ev.preventDefault(); jumpToFinding(lnk.targetFindingId); });
           div.appendChild(a);
-          if (idx < links.length - 1) div.append(' ');
+          if (lidx < links.length - 1) div.append(' ');
         });
         li.appendChild(div);
       }
 
       fCont.appendChild(li);
-    }
+    });
   }
 
   // Заполняем рекомендации
@@ -844,6 +874,7 @@ export async function onAnalyze() {
 
 async function doAnalyze() {
   return withBusy(async () => {
+    await clearHighlight();
     const btn = document.getElementById("btnAnalyze") as HTMLButtonElement | null;
     const busy = document.getElementById("busyBar") as HTMLElement | null;
     if (btn) btn.disabled = true;
@@ -914,6 +945,7 @@ async function doAnalyze() {
 
 async function doQARecheck() {
   return withBusy(async () => {
+    await clearHighlight();
     ensureHeaders();
     const text = await getWholeDocText();
     const { json } = await postJSON('/api/qa-recheck', { text, rules: {} });


### PR DESCRIPTION
## Summary
- highlight finding ranges in Word with tracked object
- sync list click with highlight and clear on re-check

## Testing
- `npm --prefix word_addin_dev test` *(fails: annotate scheduler annotates findings)*
- `npm --prefix word_addin_dev run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c71c25c4ec8325b9470a1233061fa9