### PR TITLE
Handle comment insert failures gracefully

### DIFF
--- a/word_addin_dev/app/assets/__tests__/safeInsertComment.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/safeInsertComment.spec.ts
@@ -21,7 +21,7 @@ describe('safeInsertComment', () => {
     vi.stubGlobal('logRichError', logRichError);
     vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await safeInsertComment(range, 'oops');
+    await expect(safeInsertComment(range, 'oops')).rejects.toThrow('fail');
 
     expect(notifyWarn).toHaveBeenCalledWith('Failed to insert comment');
     expect(logRichError).toHaveBeenCalled();

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -37,6 +37,7 @@ export async function safeInsertComment(range: Word.Range, text: string) {
   console.warn("safeInsertComment failed", lastErr);
   g.logRichError?.(lastErr, "insertComment");
   g.notifyWarn?.("Failed to insert comment");
+  throw lastErr;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Propagate comment insertion failures so range retries still occur
- Adjust unit test to expect error propagation

## Testing
- `npm run lint`
- `npx vitest run app/assets/__tests__/safeInsertComment.spec.ts`
- `npm test` *(fails: Failed to load url ../assets/safeBodySearch.ts in app/src/panel/state.ts)*
- `npm run build` *(fails: Unexpected "<<" in app/assets/taskpane.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c720b4c5c483258fbf60a84ece2ee0