### PR TITLE
Handle client disconnects in error handlers

### DIFF
--- a/contract_review_app/api/error_handlers.py
+++ b/contract_review_app/api/error_handlers.py
@@ -43,9 +43,8 @@ def register_error_handlers(app: FastAPI) -> None:
         )
         return resp
 
-    @app.exception_handler(ConnectionResetError)
     @app.exception_handler(ClientDisconnect)
-    async def _disconnect_error(request: Request, exc: Exception):
+    async def _disconnect_error(request: Request, exc: ClientDisconnect):
         log.info("client disconnected")
         resp = JSONResponse({"detail": "client disconnected"}, status_code=499)
         apply_std_headers(
@@ -56,7 +55,7 @@ def register_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(Exception)
     async def _unhandled_error(request: Request, exc: Exception):
         # HTTPException carries explicit status/detail; everything else maps to 500
-        if isinstance(exc, (ConnectionResetError, ClientDisconnect)):
+        if isinstance(exc, ClientDisconnect):
             # disconnects are routine; return 499-like status without error logging
             status = 499
             detail = "client disconnected"


### PR DESCRIPTION
## Summary
- add dedicated handler for client disconnects returning 499
- prevent generic handler from logging disconnects
- restrict disconnect handling to `ClientDisconnect` to avoid masking server resets

## Testing
- `pre-commit run --files contract_review_app/api/error_handlers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c720bea7e48325b94c28476e7b959d