### PR TITLE
fix: ensure QA recheck events reach listeners

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1208,7 +1208,7 @@ export function wireUI() {
     annotateBtn.removeAttribute("disabled");
   }
 
-  document.body.addEventListener('ca.qa', (ev: any) => {
+  (document.getElementById('results') || document.body).addEventListener('ca.qa', (ev: any) => {
     const json = ev?.detail;
     try {
       if (!json || json.error) {

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1307,7 +1307,7 @@ export function wireUI() {
     annotateBtn.classList.remove("js-disable-while-busy");
     annotateBtn.removeAttribute("disabled");
 
-  document.body.addEventListener('ca.qa', (ev: any) => {
+  mustGetElementById<HTMLElement>('results').addEventListener('ca.qa', (ev: any) => {
     const json = ev?.detail;
     try {
       if (!json || json.error) {


### PR DESCRIPTION
## Summary
- listen for `ca.qa` events on the same element that dispatches them
- allow QA recheck results to merge and render properly in panel and Word add-in

## Testing
- `pre-commit run --files word_addin_dev/app/assets/taskpane.ts contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts`
- `pytest tests/api/test_qa_recheck.py` *(fails: fastapi.exceptions.ResponseValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_68c720f38760832589a3016996f8e8a1