### PR TITLE
refactor: guard DOM queries with mustGetElementById

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -113,7 +113,7 @@ let analyzeBound = false;
 let analyzeInProgress = false;
 const REQUIRED_IDS: string[] = (domSchema as any).required_ids || [];
 
-function mustGetElementById<T extends HTMLElement>(id: string): T {
+export function mustGetElementById<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
   if (!el) {
     throw new Error(`missing element #${id}`);
@@ -499,10 +499,10 @@ async function navigateFinding(dir: number) {
     isNavigating = false;
     return;
   }
-  const prevBtn = document.getElementById("btnPrevIssue") as HTMLButtonElement | null;
-  const nextBtn = document.getElementById("btnNextIssue") as HTMLButtonElement | null;
-  if (prevBtn) prevBtn.disabled = true;
-  if (nextBtn) nextBtn.disabled = true;
+  const prevBtn = mustGetElementById<HTMLButtonElement>("btnPrevIssue");
+  const nextBtn = mustGetElementById<HTMLButtonElement>("btnNextIssue");
+  prevBtn.disabled = true;
+  nextBtn.disabled = true;
   const w: any = window as any;
   w.__findingIdx = (w.__findingIdx ?? 0) + dir;
   if (w.__findingIdx < 0) w.__findingIdx = arr.length - 1;
@@ -564,58 +564,54 @@ export function renderAnalysisSummary(json: any) {
   // Заполняем findings
 
   const findingsBlock = mustGetElementById('findingsBlock');
-  const fCont = document.getElementById("findingsList");
-  if (fCont) {
-    fCont.innerHTML = "";
-    visibleFindings.forEach((f, idx) => {
-      const li = document.createElement("li");
-      const title =
-        f?.title || f?.finding?.title || f?.rule_id || "Issue";
-      const snippet = f?.snippet || f?.evidence?.text || "";
-      li.textContent = snippet ? `${title}: ${snippet}` : String(title);
+  const fCont = mustGetElementById<HTMLElement>("findingsList");
+  fCont.innerHTML = "";
+  visibleFindings.forEach((f, idx) => {
+    const li = document.createElement("li");
+    const title =
+      f?.title || f?.finding?.title || f?.rule_id || "Issue";
+    const snippet = f?.snippet || f?.evidence?.text || "";
+    li.textContent = snippet ? `${title}: ${snippet}` : String(title);
 
-      li.addEventListener('click', () => {
-        const items = Array.from(fCont.querySelectorAll('li'));
-        items.forEach((el, i) => {
-          (el as HTMLElement).classList.toggle('active', i === idx);
-        });
-        (window as any).__findingIdx = idx;
-        highlightFinding(f).catch(() => {});
+    li.addEventListener('click', () => {
+      const items = Array.from(fCont.querySelectorAll('li'));
+      items.forEach((el, i) => {
+        (el as HTMLElement).classList.toggle('active', i === idx);
       });
-
-      const links = Array.isArray((f as any).links)
-        ? (f as any).links.filter((l: any) => l?.type === 'conflict' && l?.targetFindingId)
-        : [];
-      if (links.length) {
-        const div = document.createElement('div');
-        div.textContent = `Conflicts: ${links.length} `;
-        links.forEach((lnk: any, lidx: number) => {
-          const a = document.createElement('a');
-          a.href = '#';
-          a.textContent = 'Jump to';
-          a.addEventListener('click', ev => { ev.preventDefault(); jumpToFinding(lnk.targetFindingId); });
-          div.appendChild(a);
-          if (lidx < links.length - 1) div.append(' ');
-        });
-        li.appendChild(div);
-      }
-
-      fCont.appendChild(li);
+      (window as any).__findingIdx = idx;
+      highlightFinding(f).catch(() => {});
     });
-  }
+
+    const links = Array.isArray((f as any).links)
+      ? (f as any).links.filter((l: any) => l?.type === 'conflict' && l?.targetFindingId)
+      : [];
+    if (links.length) {
+      const div = document.createElement('div');
+      div.textContent = `Conflicts: ${links.length} `;
+      links.forEach((lnk: any, lidx: number) => {
+        const a = document.createElement('a');
+        a.href = '#';
+        a.textContent = 'Jump to';
+        a.addEventListener('click', ev => { ev.preventDefault(); jumpToFinding(lnk.targetFindingId); });
+        div.appendChild(a);
+        if (lidx < links.length - 1) div.append(' ');
+      });
+      li.appendChild(div);
+    }
+
+    fCont.appendChild(li);
+  });
   findingsBlock.style.display = visibleFindings.length ? '' : 'none';
 
   // Заполняем рекомендации
 
   const recommendationsBlock = mustGetElementById('recommendationsBlock');
-  const recommendationsList = document.getElementById("recommendationsList");
-  if (recommendationsList) {
-    recommendationsList.innerHTML = "";
-    for (const r of recs) {
-      const li = document.createElement("li");
-      li.textContent = r?.text || r?.advice || r?.message || "Recommendation";
-      recommendationsList.appendChild(li);
-    }
+  const recommendationsList = mustGetElementById<HTMLElement>("recommendationsList");
+  recommendationsList.innerHTML = "";
+  for (const r of recs) {
+    const li = document.createElement("li");
+    li.textContent = r?.text || r?.advice || r?.message || "Recommendation";
+    recommendationsList.appendChild(li);
   }
   recommendationsBlock.style.display = recs.length ? '' : 'none';
 
@@ -1011,18 +1007,16 @@ async function doAnalyze() {
         const ops = planAnnotations(filtered);
         (window as any).__findings = ops;
         (window as any).__findingIdx = 0;
-        const list = document.getElementById("findingsList");
-        if (list) {
-          const frag = document.createDocumentFragment();
-          ops.forEach((op, i) => {
-            const li = document.createElement("li");
-            li.textContent = `${op.rule_id}: ${op.raw}`;
-            if (i === 0) li.classList.add("active");
-            frag.appendChild(li);
-          });
-          list.innerHTML = "";
-          list.appendChild(frag);
-        }
+        const list = mustGetElementById<HTMLElement>("findingsList");
+        const frag = document.createDocumentFragment();
+        ops.forEach((op, i) => {
+          const li = document.createElement("li");
+          li.textContent = `${op.rule_id}: ${op.raw}`;
+          if (i === 0) li.classList.add("active");
+          frag.appendChild(li);
+        });
+        list.innerHTML = "";
+        list.appendChild(frag);
         if (isAddCommentsOnAnalyzeEnabled() && filtered.length) {
           await annotateFindingsIntoWord(filtered);
         }
@@ -1097,18 +1091,16 @@ async function doQARecheck() {
       if (newIdx >= deduped.length) newIdx = 0;
       (window as any).__findingIdx = newIdx;
 
-      const list = document.getElementById("findingsList");
-      if (list) {
-        const frag = document.createDocumentFragment();
-        deduped.forEach((op, i) => {
-          const li = document.createElement("li");
-          li.textContent = `${op.rule_id}: ${op.raw}`;
-          if (i === newIdx) li.classList.add("active");
-          frag.appendChild(li);
-        });
-        list.innerHTML = "";
-        list.appendChild(frag);
-      }
+      const list = mustGetElementById<HTMLElement>("findingsList");
+      const frag = document.createDocumentFragment();
+      deduped.forEach((op, i) => {
+        const li = document.createElement("li");
+        li.textContent = `${op.rule_id}: ${op.raw}`;
+        if (i === newIdx) li.classList.add("active");
+        frag.appendChild(li);
+      });
+      list.innerHTML = "";
+      list.appendChild(frag);
 
       notifyOk("QA recheck OK");
     } else {
@@ -1343,8 +1335,8 @@ export function wireUI() {
   wireResultsToggle();
 
   console.log("Panel UI wired [OK]");
-  const ab = document.getElementById("btnAnalyze") as HTMLButtonElement | null;
-  if (ab) ab.disabled = true;
+  const ab = mustGetElementById<HTMLButtonElement>("btnAnalyze");
+  ab.disabled = true;
   ensureHeaders();
   updateStatusChip();
   updateAnchorBadge();


### PR DESCRIPTION
## Summary
- export `mustGetElementById` helper for safe DOM access
- use `mustGetElementById` for navigation buttons and lists in taskpane
- drop obsolete null checks after adding guards

## Testing
- `npm run build:panel` *(fails: missing element #recommendationsList and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c72500315c8325b6b9ef1011cd4320