### PR TITLE
Add QA recheck and draft insertion tests

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -273,9 +273,17 @@ export async function apiSummary(cid) {
 export async function apiSummaryGet() {
     return req('/api/summary', { method: 'GET', key: 'summary' });
 }
-export async function apiQaRecheck(text, rules = {}) {
+export async function apiQaRecheck(input, rules = {}) {
+    let payload;
+    if (typeof input === 'string') {
+        payload = { text: input };
+    }
+    else {
+        payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
+        rules = input.rules ?? {};
+    }
     const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-    const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
+    const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
     const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
     try {
         applyMetaToBadges(meta);

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -301,9 +301,19 @@ export async function apiSummaryGet() {
   return req('/api/summary', { method: 'GET', key: 'summary' });
 }
 
-export async function apiQaRecheck(text: string, rules: any = {}) {
+export async function apiQaRecheck(
+  input: { document_id?: string; text?: string; rules?: any } | string,
+  rules: any = {},
+) {
+  let payload: any;
+  if (typeof input === 'string') {
+    payload = { text: input };
+  } else {
+    payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
+    rules = input.rules ?? {};
+  }
   const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-  const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
+  const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1066,9 +1066,16 @@ async function doQARecheck() {
   return withBusy(async () => {
     await clearHighlight();
     ensureHeaders();
-    const text = await getWholeDocText();
-    (window as any).__lastAnalyzed = text;
-    const { json } = await postJSON('/api/qa-recheck', { text, rules: {} });
+    const docId = (window as any).__docId;
+    let payload: any;
+    if (docId) {
+      payload = { document_id: docId, rules: {} };
+    } else {
+      const text = await getWholeDocText();
+      (window as any).__lastAnalyzed = text;
+      payload = { text, rules: {} };
+    }
+    const { json } = await postJSON('/api/qa-recheck', payload);
       mustGetElementById<HTMLElement>("results").dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;
     if (ok) {

--- a/word_addin_dev/app/__tests__/analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.flow.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { components } from '../../../docs/api';
+
+type AnalyzeRequest = components['schemas']['AnalyzeRequest'];
+
+describe('analyze flow', () => {
+  it('posts flat payload with schema', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
+    (globalThis as any).fetch = fetchMock;
+    (globalThis as any).window = { dispatchEvent() {} } as any;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    const { analyze } = await import('../assets/api-client.ts');
+    const payload: AnalyzeRequest = { text: 'hello', language: 'en-GB', mode: 'live', risk: null, schema: null };
+    await analyze({ text: payload.text, mode: payload.mode } as any);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, opts] = fetchMock.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body).toMatchObject({ text: 'hello', mode: 'live', schema: '1.4' });
+    expect(opts.headers['x-schema-version']).toBe('1.4');
+  });
+});

--- a/word_addin_dev/app/__tests__/insertDraftText.spec.ts
+++ b/word_addin_dev/app/__tests__/insertDraftText.spec.ts
@@ -21,27 +21,27 @@ describe('insertDraftText', () => {
     expect(run).toHaveBeenCalledTimes(1)
   })
 
-  it('inserts only changed phrase', async () => {
-    const original = 'The quick brown fox jumps over the lazy dog.'
-    const updated = 'The quick brown fox leaps over the lazy dog.'
+  it('inserts draft_text without replacing whole paragraph', async () => {
+    const draft = 'draft_text'
     const range: any = {
       isEmpty: false,
       load: vi.fn(),
-      text: original,
+      text: 'orig',
       insertText: vi.fn((txt: string) => {
         range.text = txt
         return {}
       }),
     }
-    const doc = { getSelection: () => range, body: { getRange: vi.fn() }, comments: { add: vi.fn() } }
+    const body = { getRange: vi.fn() }
+    const doc = { getSelection: () => range, body, comments: { add: vi.fn() } }
     const run = vi.fn(async (cb: any) => {
       await cb({ document: doc, sync: vi.fn() })
     })
     ;(globalThis as any).Word = { run, InsertLocation: { replace: 'Replace' } }
-    await insertDraftText(updated, 'live')
-    expect(range.insertText).toHaveBeenCalledWith(updated, 'Replace')
-    expect(range.text).toBe(updated)
-    expect(range.text.replace('leaps', 'jumps')).toBe(original)
+    await insertDraftText(draft, 'live')
+    expect(range.insertText).toHaveBeenCalledWith(draft, 'Replace')
+    expect(body.getRange).not.toHaveBeenCalled()
+    expect(range.text).toBe(draft)
   })
 
   it('logs debug info and rethrows', async () => {

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -301,9 +301,17 @@ export async function apiSummary(cid) {
 export async function apiSummaryGet() {
     return req('/api/summary', { method: 'GET', key: 'summary' });
 }
-export async function apiQaRecheck(text, rules = {}) {
+export async function apiQaRecheck(input, rules = {}) {
+    let payload;
+    if (typeof input === 'string') {
+        payload = { text: input };
+    }
+    else {
+        payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
+        rules = input.rules ?? {};
+    }
     const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-    const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
+    const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
     const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
     try {
         applyMetaToBadges(meta);

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -327,9 +327,19 @@ export async function apiSummaryGet() {
   return req('/api/summary', { method: 'GET', key: 'summary' });
 }
 
-export async function apiQaRecheck(text: string, rules: any = {}) {
+export async function apiQaRecheck(
+  input: { document_id?: string; text?: string; rules?: any } | string,
+  rules: any = {},
+) {
+  let payload: any;
+  if (typeof input === 'string') {
+    payload = { text: input };
+  } else {
+    payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
+    rules = input.rules ?? {};
+  }
   const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-  const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
+  const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1066,9 +1066,16 @@ async function doQARecheck() {
   return withBusy(async () => {
     await clearHighlight();
     ensureHeaders();
-    const text = await getWholeDocText();
-    (window as any).__lastAnalyzed = text;
-    const { json } = await postJSON('/api/qa-recheck', { text, rules: {} });
+    const docId = (window as any).__docId;
+    let payload: any;
+    if (docId) {
+      payload = { document_id: docId, rules: {} };
+    } else {
+      const text = await getWholeDocText();
+      (window as any).__lastAnalyzed = text;
+      payload = { text, rules: {} };
+    }
+    const { json } = await postJSON('/api/qa-recheck', payload);
       mustGetElementById<HTMLElement>("results").dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;
     if (ok) {


### PR DESCRIPTION
## Summary
- verify analyze flow posts flat payload via generated types
- ensure draft text inserts without replacing entire paragraph
- exercise QA recheck with document_id payload and refreshed findings

## Testing
- `npm test -- app/__tests__/analyze.flow.spec.ts app/__tests__/insertDraftText.spec.ts app/__tests__/qa.recheck.navigation.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c725023a948325b82deda7d129b5fe