### PR TITLE
Rename draft request fields and update types

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6803,9 +6803,13 @@
             "title": "Mode",
             "type": "string"
           },
-          "clause": {
+          "clause_id": {
+            "title": "Clauseid",
+            "type": "string"
+          },
+          "text": {
             "minLength": 20,
-            "title": "Clause",
+            "title": "Text",
             "type": "string"
           },
           "context": {
@@ -6832,7 +6836,7 @@
         },
         "required": [
           "mode",
-          "clause",
+          "text",
           "context"
         ],
         "title": "DraftRequest",
@@ -6840,9 +6844,9 @@
       },
       "DraftResponse": {
         "properties": {
-          "draft": {
+          "draft_text": {
             "type": "string",
-            "title": "Draft"
+            "title": "Drafttext"
           },
           "notes": {
             "items": {

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -258,8 +258,8 @@ export async function analyze(opts = {}) {
 export async function apiAnalyze(text) {
     return analyze({ text });
 }
-export async function apiGptDraft(cid, clause, mode = 'friendly') {
-    const { resp, json } = await postJSON('/api/gpt-draft', { cid, clause, mode });
+export async function apiGptDraft(clause_id, text, mode = 'friendly') {
+    const { resp, json } = await postJSON('/api/gpt-draft', { clause_id, text, mode });
     const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
     try {
         applyMetaToBadges(meta);

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -286,8 +286,8 @@ export async function apiAnalyze(text: string) {
   return analyze({ text });
 }
 
-export async function apiGptDraft(cid: string, clause: string, mode = 'friendly') {
-  const { resp, json } = await postJSON('/api/gpt-draft', { cid, clause, mode });
+export async function apiGptDraft(clause_id: string, text: string, mode = 'friendly') {
+  const { resp, json } = await postJSON('/api/gpt-draft', { clause_id, text, mode });
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -819,7 +819,8 @@ async function requestDraft(mode: 'friendly' | 'strict') {
 
   const payload = {
     mode,
-    clause,
+    clause_id: lastCid || undefined,
+    text: clause,
     context: {
       law: 'UK',
       language: 'en-GB',
@@ -853,7 +854,7 @@ async function requestDraft(mode: 'friendly' | 'strict') {
   }
 
   const json = await res.json();
-  const proposed = (json?.proposed_text ?? json?.text ?? '').toString();
+  const proposed = (json?.draft_text || '').toString();
   const dst = $(Q.proposed);
   const w: any = window as any;
   w.__last = w.__last || {};

--- a/contract_review_app/frontend/draft_panel/__tests__/draft_panel.test.tsx
+++ b/contract_review_app/frontend/draft_panel/__tests__/draft_panel.test.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 
 vi.mock('../../common/http', () => ({
-  postJSON: vi.fn(async () => ({ proposed_text: 'Hello from AI' })),
+  postJSON: vi.fn(async () => ({ draft_text: 'Hello from AI' })),
   getHealth: vi.fn(async () => ({})),
   ensureHeadersSet: vi.fn(),
 }));
@@ -11,7 +11,7 @@ vi.mock('../../common/http', () => ({
 import { DraftAssistantPanel } from '../index';
 
 describe('DraftAssistantPanel', () => {
-  it('renders proposed draft text from API response', async () => {
+  it('renders draft text from API response', async () => {
     (globalThis as any).localStorage = { getItem: () => '', setItem: () => {} };
     (globalThis as any).navigator = { clipboard: { writeText: async (_: string) => {} } };
     (globalThis as any).Office = {

--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -36,7 +36,6 @@ interface AnalyzeEnvelope {
   [k: string]: any;
 }
 interface DraftEnvelope {
-  proposed_text?: string;
   draft_text?: string;
   [k: string]: any;
 }
@@ -176,11 +175,11 @@ const DraftAssistantPanel: React.FC<PanelProps> = ({ initialAnalysis = null, ini
     try {
       const base = getBackend().replace(/\/+$/, '');
       const env = await postJSON<DraftEnvelope>(`${base}${DRAFT_PATH}`, {
-        cid: (analysis as any)?.cid,
-        clause: analysis?.text || clauseText,
+        clause_id: (analysis as any)?.cid,
+        text: analysis?.text || clauseText,
       });
-      const text = env?.proposed_text || env?.draft_text || '';
-      setDraft({ ...env, proposed_text: text });
+      const text = env?.draft_text || '';
+      setDraft({ ...env, draft_text: text });
       setStatus('ready');
       try { await insertIntoWord(text); } catch {}
     } catch (e: any) {
@@ -269,9 +268,9 @@ const DraftAssistantPanel: React.FC<PanelProps> = ({ initialAnalysis = null, ini
           {status === 'loading' ? 'Generating…' : 'Get AI Draft'}
         </button>
 
-        {draft?.proposed_text && (
+        {draft?.draft_text && (
           <button
-            onClick={() => insertIntoWord(draft.proposed_text || '')}
+            onClick={() => insertIntoWord(draft.draft_text || '')}
             style={{ background: '#28a745', color: 'white', padding: '8px 12px', border: 'none', borderRadius: 4 }}
           >
             Insert result into Word
@@ -311,11 +310,11 @@ const DraftAssistantPanel: React.FC<PanelProps> = ({ initialAnalysis = null, ini
             </div>
           )}
 
-          {draft?.proposed_text && (
+          {draft?.draft_text && (
             <div style={{ marginTop: 20 }}>
               <h3>Suggested Draft</h3>
               <pre style={{ background: '#f5f5f5', padding: '1rem', borderRadius: 4, whiteSpace: 'pre-wrap' }}>
-                {draft.proposed_text}
+                {draft.draft_text}
               </pre>
             </div>
           )}

--- a/docs/api.d.ts
+++ b/docs/api.d.ts
@@ -349,7 +349,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/gpt-draft": {
+    "/api/gpt/draft": {
         parameters: {
             query?: never;
             header?: never;
@@ -360,7 +360,7 @@ export interface paths {
         put?: never;
         /**
          * Gpt Draft
-         * @description LLM draft endpoint with mock-friendly minimal payload support.
+         * @description Simplified LLM draft endpoint with strict validation.
          */
         post: operations["gpt_draft_api_gpt_draft_post"];
         delete?: never;
@@ -653,6 +653,11 @@ export interface components {
              */
             risk: string | null;
             /**
+             * Clause Type
+             * @default null
+             */
+            clause_type: string | null;
+            /**
              * Schema
              * @default null
              */
@@ -711,6 +716,26 @@ export interface components {
             /** Citations */
             citations: components["schemas"]["CitationInput"][];
         };
+        /** Context */
+        Context: {
+            /**
+             * Law
+             * @default UK
+             * @constant
+             */
+            law: "UK";
+            /**
+             * Language
+             * @default en-GB
+             * @constant
+             */
+            language: "en-GB";
+            /**
+             * Contracttype
+             * @default unknown
+             */
+            contractType: string;
+        };
         /** Coverage */
         Coverage: {
             /** Rules Total */
@@ -719,6 +744,80 @@ export interface components {
             rules_fired: number;
             /** Coverage */
             coverage: number;
+        };
+        /** DraftFinding */
+        DraftFinding: {
+            /** Id */
+            id: string;
+            /** Title */
+            title: string;
+            /** Text */
+            text: string;
+        };
+        /**
+         * DraftRequest
+         * @description Input model for ``/api/gpt/draft``.
+         */
+        DraftRequest: {
+            /**
+             * Mode
+             * @enum {string}
+             */
+            mode: "friendly" | "strict";
+            /** Clauseid */
+            clause_id?: string;
+            /** Text */
+            text: string;
+            context: components["schemas"]["Context"];
+            /** Findings */
+            findings?: components["schemas"]["DraftFinding"][];
+            /** @default null */
+            selection: components["schemas"]["Selection"] | null;
+            $defs: {
+                /** Context */
+                Context: {
+                    /**
+                     * Law
+                     * @default UK
+                     * @constant
+                     */
+                    law: "UK";
+                    /**
+                     * Language
+                     * @default en-GB
+                     * @constant
+                     */
+                    language: "en-GB";
+                    /**
+                     * Contracttype
+                     * @default unknown
+                     */
+                    contractType: string;
+                };
+                /** DraftFinding */
+                DraftFinding: {
+                    /** Id */
+                    id: string;
+                    /** Title */
+                    title: string;
+                    /** Text */
+                    text: string;
+                };
+                /** Selection */
+                Selection: {
+                    /** Start */
+                    start: number;
+                    /** End */
+                    end: number;
+                };
+            };
+        };
+        /** DraftResponse */
+        DraftResponse: {
+            /** Drafttext */
+            draft_text?: string;
+            /** Notes */
+            notes?: string[];
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -870,6 +969,13 @@ export interface components {
             /** F1 */
             f1: number;
         };
+        /** Selection */
+        Selection: {
+            /** Start */
+            start: number;
+            /** End */
+            end: number;
+        };
         /**
          * SummaryIn
          * @description Input model for ``/api/summary``.
@@ -900,24 +1006,6 @@ export interface components {
              * @default 10
              */
             limit: number;
-        };
-        /**
-         * DraftRequest
-         * @description Input model for ``/api/gpt-draft``.
-         */
-        DraftRequest: {
-            /** Text */
-            text: string;
-            /**
-             * Mode
-             * @default null
-             */
-            mode: string | null;
-            /**
-             * Cid
-             * @default null
-             */
-            cid: string | null;
         };
         /** Finding */
         Finding: {
@@ -3419,9 +3507,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": components["schemas"]["DraftRequest"];
             };
         };
         responses: {
@@ -3434,7 +3520,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["DraftResponse"];
                 };
             };
             /** @description Bad Request */
@@ -3859,9 +3945,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": components["schemas"]["DraftRequest"];
             };
         };
         responses: {
@@ -3874,7 +3958,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["DraftResponse"];
                 };
             };
             /** @description Bad Request */

--- a/docs/api_contracts.md
+++ b/docs/api_contracts.md
@@ -29,7 +29,7 @@ Content-Type: application/json
 
 # API contracts: /api/gpt-draft
 
-Frontend sends a flat JSON body. Aliases `text` and `clause` are accepted.
+Frontend sends a flat JSON body with `clause_id` and `text`.
 
 ## Request
 
@@ -38,6 +38,7 @@ POST /api/gpt-draft
 Content-Type: application/json
 
 {
+  "clause_id": "123",
   "text": "Hello"
 }
 ```
@@ -47,7 +48,7 @@ Content-Type: application/json
 ```json
 {
   "status": "ok",
-  "proposed_text": "...",
+  "draft_text": "...",
   "schema_version": "1.4"
 }
 ```

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,6 +1,6 @@
 | Узел | Кто инициирует | URL | Запрос (минимум) | Ответ (минимум) | Заголовки | Версия |
 | --- | --- | --- | --- | --- | --- | --- |
 | Analyze | Клиент | `POST /api/analyze` | [`{text, mode?, schema:"1.4"}`](api.d.ts#L625-L660) | [AnalyzeResponse](api.d.ts#L661-L671) | `Content-Type: application/json`<br>`X-Schema-Version: 1.4` | `1.4` |
-| Draft | Клиент | `POST /api/gpt-draft` | [`{clause_id, text, ...}`](api.d.ts#L905-L921) | [`{draft_text, ...}`](api.d.ts#L3436-L3438) | `Content-Type: application/json`<br>`X-Schema-Version: 1.4` | `1.4` |
+| Draft | Клиент | `POST /api/gpt-draft` | [`{clause_id, text, ...}`](api.d.ts#L761-L775) | [`{draft_text, ...}`](api.d.ts#L816-L820) | `Content-Type: application/json`<br>`X-Schema-Version: 1.4` | `1.4` |
 | QA Recheck | Клиент | `POST /api/qa-recheck` | [`{document_id, ...}`](api.d.ts#L792-L811) | [Findings[]](api.d.ts#L922-L941) | `Content-Type: application/json`<br>`X-Schema-Version: 1.4` | `1.4` |
 | OpenAPI | Клиент | `GET /openapi.json` | [—](api.d.ts#L1) | [JSON](api.d.ts#L1) | — | — |

--- a/tests/api/test_e2e_smoke.py
+++ b/tests/api/test_e2e_smoke.py
@@ -32,7 +32,7 @@ def test_e2e_smoke(api):
     assert r_summary.status_code == 200
 
     # GPT draft
-    payload = {'cid': cid, 'clause': 'Ping', 'mode': 'friendly'}
+    payload = {'clause_id': cid, 'text': 'Ping', 'mode': 'friendly'}
     r_draft = api.post('/api/gpt-draft', json=payload)
     assert r_draft.status_code == 200
-    assert r_draft.json().get('proposed_text', '').strip()
+    assert r_draft.json().get('draft_text', '').strip()

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -194,7 +194,7 @@ def test_summary_endpoint():
 def test_gpt_draft_endpoint():
     r_an = client.post("/api/analyze", json={"text": "sample"})
     cid = r_an.headers.get("x-cid")
-    r = client.post("/api/gpt-draft", json={"cid": cid, "clause": "sample"})
+    r = client.post("/api/gpt-draft", json={"clause_id": cid, "text": "sample"})
     assert r.status_code == 200
 
 

--- a/tests/api/test_llm_endpoints_integration.py
+++ b/tests/api/test_llm_endpoints_integration.py
@@ -33,6 +33,6 @@ def client():
 def test_endpoints_ok(client):
     r = client.post("/api/analyze", json={"text": "hi"})
     cid = r.headers.get("x-cid")
-    assert client.post("/api/gpt-draft", json={"cid": cid, "clause": "hi"}).status_code == 200
+    assert client.post("/api/gpt-draft", json={"clause_id": cid, "text": "hi"}).status_code == 200
     assert client.post("/api/suggest_edits", json={"text": "hi"}).status_code == 200
     assert client.post("/api/qa-recheck", json={"text": "hi"}).status_code == 200

--- a/tests/api/test_llm_mock_endpoints.py
+++ b/tests/api/test_llm_mock_endpoints.py
@@ -32,6 +32,6 @@ def test_llm_mock_endpoints():
 
 def test_llm_mock_invalid_gpt_draft_payload():
     client = _create_client()
-    resp = client.post("/api/gpt-draft", json={"cid": "only"})
+    resp = client.post("/api/gpt-draft", json={"clause_id": "only"})
     assert resp.status_code == 422
     assert isinstance(resp.json().get("detail"), list)

--- a/tests/integration/test_panel_selftest_like.py
+++ b/tests/integration/test_panel_selftest_like.py
@@ -33,7 +33,7 @@ def test_panel_selftest_like():
         r = client.post("/api/analyze", json={"text": "Hi"})
         assert r.status_code == 200
         cid = r.headers.get("x-cid")
-        assert client.post("/api/gpt-draft", json={"cid": cid, "clause": "Hi"}).status_code == 200
+        assert client.post("/api/gpt-draft", json={"clause_id": cid, "text": "Hi"}).status_code == 200
         assert client.post("/api/qa-recheck", json={"text": "hi", "rules": {}}).status_code == 200
         assert (
             client.post("/api/qa-recheck", json={"text": "hi", "rules": [{"R1": "on"}]})

--- a/tests/panel/test_cache_headers_v2.py
+++ b/tests/panel/test_cache_headers_v2.py
@@ -27,4 +27,4 @@ def test_analyze_cache_headers():
 def test_gpt_draft_cache_headers():
     r = client.post("/api/analyze", json={"text": "hello"})
     cid = r.headers.get("x-cid")
-    _check_etag_flow("/api/gpt-draft", {"cid": cid, "clause": "hello", "mode": "friendly"})
+    _check_etag_flow("/api/gpt-draft", {"clause_id": cid, "text": "hello", "mode": "friendly"})

--- a/tests/panel/test_gpt_draft_payload.py
+++ b/tests/panel/test_gpt_draft_payload.py
@@ -14,7 +14,7 @@ def test_gpt_draft_payload_and_response(extra):
         headers={"x-api-key": "k", "x-schema-version": "1.4"},
     )
     cid = r_an.headers.get("x-cid")
-    payload = {"cid": cid, "clause": "Ping", "mode": "friendly"}
+    payload = {"clause_id": cid, "text": "Ping", "mode": "friendly"}
     payload.update(extra)
     r = client.post(
         "/api/gpt-draft",
@@ -23,7 +23,7 @@ def test_gpt_draft_payload_and_response(extra):
     )
     assert r.status_code == 200
     data = r.json()
-    for k in ("cid", "clause", "mode"):
+    for k in ("clause_id", "text", "mode"):
         assert k in payload and isinstance(payload[k], str)
-    assert isinstance(data.get("proposed_text"), str)
-    assert data["proposed_text"].strip() != ""
+    assert isinstance(data.get("draft_text"), str)
+    assert data["draft_text"].strip() != ""

--- a/tests/panel/test_panel_flows.py
+++ b/tests/panel/test_panel_flows.py
@@ -51,11 +51,11 @@ def test_panel_end_to_end_flow():
 
     # Step 2: draft
     cid = r.headers.get("x-cid")
-    payload = {"cid": cid, "clause": "Ping", "mode": "friendly"}
+    payload = {"clause_id": cid, "text": "Ping", "mode": "friendly"}
     r = client.post("/api/gpt-draft", json=payload, headers=_headers())
     assert r.status_code == 200
     data = r.json()
-    assert data.get("proposed_text", "").strip() != ""
+    assert data.get("draft_text", "").strip() != ""
 
     # Step 3: suggest edits
     original = "bad clause"

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -27,7 +27,7 @@ def test_api_key_auth(monkeypatch):
     r = client.post("/api/analyze", json=payload)
     assert r.status_code == 401
     r = client.post(
-        "/api/gpt-draft", json={"cid": "x", "clause": "Ping", "mode": "friendly"}
+        "/api/gpt-draft", json={"clause_id": "x", "text": "Ping", "mode": "friendly"}
     )
     assert r.status_code == 401
     r = client.post("/api/suggest_edits", json=payload)
@@ -40,7 +40,7 @@ def test_api_key_auth(monkeypatch):
     assert (
         client.post(
             "/api/gpt-draft",
-            json={"cid": cid, "clause": "Ping", "mode": "friendly"},
+            json={"clause_id": cid, "text": "Ping", "mode": "friendly"},
             headers=headers,
         ).status_code
         == 200

--- a/tests/security/test_audit_log.py
+++ b/tests/security/test_audit_log.py
@@ -21,7 +21,7 @@ def test_audit_events_written(tmp_path):
     r1 = client.post("/api/analyze", json={"text": "Hello"})
     assert r1.status_code == 200
     cid = r1.headers.get("x-cid")
-    r2 = client.post("/api/gpt-draft", json={"cid": cid, "clause": "Draft clause"})
+    r2 = client.post("/api/gpt-draft", json={"clause_id": cid, "text": "Draft clause"})
     assert r2.status_code == 200
     r3 = client.post("/api/suggest_edits", json={"text": "Hello"})
     assert r3.status_code == 200

--- a/tests/security/test_privacy_redaction_b5.py
+++ b/tests/security/test_privacy_redaction_b5.py
@@ -11,13 +11,13 @@ def test_privacy_redaction_and_scrub():
     )
     r_an = client.post("/api/analyze", json={"text": text})
     cid = r_an.headers.get("x-cid")
-    r = client.post("/api/gpt-draft", json={"cid": cid, "clause": text, "mode": "friendly"})
+    r = client.post("/api/gpt-draft", json={"clause_id": cid, "text": text, "mode": "friendly"})
     assert r.status_code == 200
     data = r.json()
     sensitive = ["John Smith", "john@example.com", "+44 1234 567890", "AB123456C"]
     combined = " ".join(
         [
-            data.get("proposed_text", ""),
+            data.get("draft_text", ""),
             data.get("rationale", ""),
             data.get("after_text", ""),
             data.get("diff", {}).get("value", ""),

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -43,7 +43,7 @@ def test_suggest_ok():
 def test_gpt_draft_ok():
     r_an = client.post("/api/analyze", json={"text": "Hi"}, headers=_headers())
     cid = r_an.headers.get("x-cid")
-    payload = {"cid": cid, "clause": "Draft confidentiality clause"}
+    payload = {"clause_id": cid, "text": "Draft confidentiality clause"}
     r = client.post("/api/gpt-draft", json=payload, headers=_headers())
     assert r.status_code == 200
     r_alias = client.post("/api/draft", json=payload, headers=_headers())

--- a/word_addin_dev/app/__tests__/draft.spec.ts
+++ b/word_addin_dev/app/__tests__/draft.spec.ts
@@ -45,7 +45,7 @@ describe('get draft', () => {
     expect(calls.length).toBe(0);
   });
 
-  it('selection enables and sends request with clause', async () => {
+  it('selection enables and sends request with text', async () => {
     (globalThis as any).getSelectionText = vi.fn().mockResolvedValue('This is a sample clause with sufficient length.');
     const { wireUI, getClauseText, onSuggestEdit } = await import('../assets/taskpane.ts');
     wireUI();
@@ -56,7 +56,7 @@ describe('get draft', () => {
     const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt/draft'));
     expect(calls.length).toBe(1);
     const body = JSON.parse(calls[0][1].body);
-    expect(body).toMatchObject({ clause: 'This is a sample clause with sufficient length.' });
+    expect(body).toMatchObject({ text: 'This is a sample clause with sufficient length.' });
   });
 
   it('Word API failure warns and skips request', async () => {

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -286,8 +286,8 @@ export async function analyze(opts = {}) {
 export async function apiAnalyze(text) {
     return analyze({ text });
 }
-export async function apiGptDraft(cid, clause, mode = 'friendly') {
-    const { resp, json } = await postJSON('/api/gpt-draft', { cid, clause, mode });
+export async function apiGptDraft(clause_id, text, mode = 'friendly') {
+    const { resp, json } = await postJSON('/api/gpt-draft', { clause_id, text, mode });
     const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
     try {
         applyMetaToBadges(meta);

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -312,8 +312,8 @@ export async function apiAnalyze(text: string) {
   return analyze({ text });
 }
 
-export async function apiGptDraft(cid: string, clause: string, mode = 'friendly') {
-  const { resp, json } = await postJSON('/api/gpt-draft', { cid, clause, mode });
+export async function apiGptDraft(clause_id: string, text: string, mode = 'friendly') {
+  const { resp, json } = await postJSON('/api/gpt-draft', { clause_id, text, mode });
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -819,7 +819,8 @@ async function requestDraft(mode: 'friendly' | 'strict') {
 
   const payload = {
     mode,
-    clause,
+    clause_id: lastCid || undefined,
+    text: clause,
     context: {
       law: 'UK',
       language: 'en-GB',
@@ -853,7 +854,7 @@ async function requestDraft(mode: 'friendly' | 'strict') {
   }
 
   const json = await res.json();
-  const proposed = (json?.proposed_text ?? json?.text ?? '').toString();
+  const proposed = (json?.draft_text || '').toString();
   const dst = $(Q.proposed);
   const w: any = window as any;
   w.__last = w.__last || {};


### PR DESCRIPTION
## Summary
- rename draft request fields to `clause_id` and `text`
- consume `draft_text` in draft handling and types
- regenerate OpenAPI TS types and update docs

## Testing
- `npm --prefix word_addin_dev test -- app/__tests__/draft.spec.ts` *(fails: expected false to be true)*
- `pytest tests/panel/test_gpt_draft_payload.py tests/panel/test_cache_headers_v2.py -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*


------
https://chatgpt.com/codex/tasks/task_e_68c724f776888325bbeeaee7c1f52cb4