### PR TITLE
chore: pin node 20 and harden PowerShell wrappers

### DIFF
--- a/RUN_DEV.ps1
+++ b/RUN_DEV.ps1
@@ -68,7 +68,7 @@ if (-not $panelArgs) { $panelArgs = @('') }
 Start-Process -FilePath $py -ArgumentList $panelArgs
 
 # 6) Відкрити self-test у браузері (для контролю зв’язку)
-Start-Process -FilePath "https://localhost:3000/panel_selftest.html?v=dev" -ArgumentList @('')
+Start-Process -FilePath "https://localhost:3000/panel_selftest.html?v=dev"
 
 # 7) Запустити Word — далі «Вставка → Мои надстройки → Общая папка → Contract AI — Draft Assistant»
-Start-Process -FilePath winword.exe -ArgumentList @('')
+Start-Process -FilePath winword.exe

--- a/RUN_DOCTOR.ps1
+++ b/RUN_DOCTOR.ps1
@@ -111,7 +111,7 @@ $md = "$OutPrefixFinal.md"
 $json = "$OutPrefixFinal.json"
 if (Test-Path $md) {
   Write-Ok "Звіт: $md"
-  try { Start-Process -FilePath $md -ArgumentList @('') } catch { Write-Warn "Не вдалося відкрити ${md}: $($_.Exception.Message)" }
+  try { Start-Process -FilePath $md } catch { Write-Warn "Не вдалося відкрити ${md}: $($_.Exception.Message)" }
 } else {
   Write-Warn "Markdown-звіт не знайдено."
 }

--- a/run_analysis.ps1
+++ b/run_analysis.ps1
@@ -14,7 +14,7 @@ if (Test-Path "$ROOT/.venv/Scripts/python.exe") {
 $code = $LASTEXITCODE
 if ($code -eq 0 -or $code -eq 2) {
     if (Test-Path "$OUT/analysis.html") {
-        Start-Process -FilePath "$OUT/analysis.html" -ArgumentList @('')
+        Start-Process -FilePath "$OUT/analysis.html"
     }
 }
 exit $code

--- a/word_addin_dev/RUN_DEV.ps1
+++ b/word_addin_dev/RUN_DEV.ps1
@@ -54,7 +54,7 @@ $okPanel = Wait-Ok 'https://127.0.0.1:3000/panel_selftest.html'
 if (-not $okApi)   { Write-Host '[ERR] Backend not ready' -ForegroundColor Red }
 if (-not $okPanel) { Write-Host '[ERR] Panel not ready'   -ForegroundColor Red }
 
-Start-Process -FilePath 'https://127.0.0.1:3000/panel_selftest.html?v=dev' -ArgumentList @('')
+Start-Process -FilePath 'https://127.0.0.1:3000/panel_selftest.html?v=dev'
 Write-Host '[OK] READY. Panel self-test opened.'
 Read-Host 'Press Enter to stop services'
 


### PR DESCRIPTION
## Summary
- remove empty -ArgumentList uses on fire-and-forget Start-Process calls

## Testing
- `node -v`
- `npm -v`
- `npm ci` *(fails: requires package-lock.json)*
- `npm run build` *(fails: missing script "build")*
- `python -m pre_commit run --files run_analysis.ps1 RUN_DEV.ps1 RUN_DOCTOR.ps1 word_addin_dev/RUN_DEV.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68c7282750bc8325b476135152c4ee7d