### PR TITLE
fix: include text with QA recheck request

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -273,9 +273,9 @@ export async function apiSummary(cid) {
 export async function apiSummaryGet() {
     return req('/api/summary', { method: 'GET', key: 'summary' });
 }
-export async function apiQaRecheck(text, rules = {}) {
+export async function apiQaRecheck(document_id, text, rules = {}) {
     const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-    const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
+    const { resp, json } = await postJSON('/api/qa-recheck', { document_id, text, rules: dict });
     const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
     try {
         applyMetaToBadges(meta);

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -275,8 +275,9 @@ export async function apiSummaryGet() {
   return req('/api/summary', { method: 'GET', key: 'summary' });
 }
 
-export async function apiQaRecheck(document_id: string) {
-  const { resp, json } = await postJSON('/api/qa-recheck', { document_id });
+export async function apiQaRecheck(document_id: string, text: string, rules: any = {}) {
+  const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
+  const { resp, json } = await postJSON('/api/qa-recheck', { document_id, text, rules: dict });
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1069,7 +1069,7 @@ async function doQARecheck() {
     const text = await getWholeDocText();
     (window as any).__lastAnalyzed = text;
     if (!lastCid) { notifyWarn('No document id'); return; }
-    const { json } = await apiQaRecheck(lastCid);
+    const { json } = await apiQaRecheck(lastCid, text);
       mustGetElementById<HTMLElement>("results").dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;
     if (ok) {

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -301,9 +301,9 @@ export async function apiSummary(cid) {
 export async function apiSummaryGet() {
     return req('/api/summary', { method: 'GET', key: 'summary' });
 }
-export async function apiQaRecheck(text, rules = {}) {
+export async function apiQaRecheck(document_id, text, rules = {}) {
     const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-    const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
+    const { resp, json } = await postJSON('/api/qa-recheck', { document_id, text, rules: dict });
     const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
     try {
         applyMetaToBadges(meta);

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -300,8 +300,9 @@ export async function apiSummaryGet() {
   return req('/api/summary', { method: 'GET', key: 'summary' });
 }
 
-export async function apiQaRecheck(document_id: string) {
-  const { resp, json } = await postJSON('/api/qa-recheck', { document_id });
+export async function apiQaRecheck(document_id: string, text: string, rules: any = {}) {
+  const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
+  const { resp, json } = await postJSON('/api/qa-recheck', { document_id, text, rules: dict });
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1063,7 +1063,7 @@ async function doQARecheck() {
     const text = await getWholeDocText();
     (window as any).__lastAnalyzed = text;
     if (!lastCid) { notifyWarn('No document id'); return; }
-    const { json } = await apiQaRecheck(lastCid);
+    const { json } = await apiQaRecheck(lastCid, text);
       mustGetElementById<HTMLElement>("results").dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;
     if (ok) {


### PR DESCRIPTION
## Summary
- send text with document ID when rechecking QA
- pass retrieved document text to QA recheck

## Testing
- `python tools/build_panel.py --run-tests` *(fails: FileNotFoundError: 'npm')*
- `pytest tests/panel/test_whole_doc_analyze_smoke.py` *(fails: FileNotFoundError: 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68c7281f18248325b8383a1e6e3367d6