### PR TITLE
Fix docId recheck to refresh last analyzed text

### DIFF
--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1067,14 +1067,11 @@ async function doQARecheck() {
     ensureHeaders();
 
     const docId = (window as any).__docId;
-    let payload: any;
-    if (docId) {
-      payload = { document_id: docId, rules: {} };
-    } else {
-      const text = await getWholeDocText();
-      (window as any).__lastAnalyzed = text;
-      payload = { text, rules: {} };
-    }
+    const text = await getWholeDocText();
+    (window as any).__lastAnalyzed = text;
+    const payload: any = docId
+      ? { document_id: docId, rules: {} }
+      : { text, rules: {} };
     const { json } = await postJSON('/api/qa-recheck', payload);
       mustGetElementById<HTMLElement>("results").dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;


### PR DESCRIPTION
## Summary
- keep local `__lastAnalyzed` in sync when rechecking using a `document_id`

## Testing
- `npm test -- app/__tests__/analyze.flow.spec.ts app/__tests__/insertDraftText.spec.ts app/__tests__/qa.recheck.navigation.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c729716b8c83259b063a1d863dab46