### PR TITLE
chore: include openapi types generator in lockfile

### DIFF
--- a/word_addin_dev/app/types/api.d.ts
+++ b/word_addin_dev/app/types/api.d.ts
@@ -5,5275 +5,4104 @@
 
 
 export interface paths {
-    "/api/llm/ping": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Llm Ping */
-        get: operations["llm_ping_api_llm_ping_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/analyze": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Api Analyze */
-        post: operations["api_analyze_api_analyze_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/analyze": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Analyze Alias */
-        post: operations["analyze_alias_analyze_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/llm/ping": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Llm Ping Alias */
-        get: operations["llm_ping_alias_llm_ping_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health
-         * @description Health endpoint with schema version and rule count.
-         */
-        get: operations["health_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/supports": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Supports */
-        get: operations["api_supports_api_supports_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/trace": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List Trace */
-        get: operations["list_trace_api_trace_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/trace/{cid}.html": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Trace Html */
-        get: operations["get_trace_html_api_trace__cid__html_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/trace/{cid}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Trace */
-        get: operations["get_trace_api_trace__cid__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/report/{cid}.html": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Report Html */
-        get: operations["api_report_html_api_report__cid__html_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/report/{cid}.pdf": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Report Pdf */
-        get: operations["api_report_pdf_api_report__cid__pdf_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Metrics */
-        get: operations["api_metrics_api_metrics_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/metrics.csv": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Metrics Csv */
-        get: operations["api_metrics_csv_api_metrics_csv_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/metrics.html": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Metrics Html */
-        get: operations["api_metrics_html_api_metrics_html_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/admin/purge": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Api Admin Purge */
-        post: operations["api_admin_purge_api_admin_purge_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/analyze/replay": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Analyze Replay */
-        get: operations["analyze_replay_api_analyze_replay_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Summary Get */
-        get: operations["api_summary_get_api_summary_get"];
-        put?: never;
-        /** Api Summary Post */
-        post: operations["api_summary_post_api_summary_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Summary Get Alias */
-        get: operations["summary_get_alias_summary_get"];
-        put?: never;
-        /** Summary Post Alias */
-        post: operations["summary_post_alias_summary_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/qa-recheck": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Api Qa Recheck */
-        post: operations["api_qa_recheck_api_qa_recheck_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/suggest_edits": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Api Suggest Edits */
-        post: operations["api_suggest_edits_api_suggest_edits_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gpt/draft": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Gpt Draft
-         * @description Simplified LLM draft endpoint with strict validation.
-         */
-        post: operations["gpt_draft_api_gpt_draft_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/panel/redlines": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Panel Redlines */
-        post: operations["panel_redlines_api_panel_redlines_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Health Alias */
-        get: operations["health_alias_api_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/suggest_edits": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Suggest Edits Alias */
-        post: operations["suggest_edits_alias_suggest_edits_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/draft": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Draft Alias */
-        post: operations["draft_alias_api_draft_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/calloff/validate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Api Calloff Validate */
-        post: operations["api_calloff_validate_api_calloff_validate_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/learning/log": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Api Learning Log */
-        post: operations["api_learning_log_api_learning_log_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/learning/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Api Learning Update */
-        post: operations["api_learning_update_api_learning_update_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/companies/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Companies Health */
-        get: operations["companies_health_api_companies_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/companies/search": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Companies Search Get */
-        get: operations["api_companies_search_get_api_companies_search_get"];
-        put?: never;
-        /** Api Companies Search */
-        post: operations["api_companies_search_api_companies_search_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/companies/{number}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Api Company Profile */
-        get: operations["api_company_profile_api_companies__number__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/dsar/access": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Dsar Access */
-        get: operations["dsar_access_api_dsar_access_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/dsar/erasure": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Dsar Erasure */
-        post: operations["dsar_erasure_api_dsar_erasure_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/dsar/export": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Dsar Export */
-        get: operations["dsar_export_api_dsar_export_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/citation/resolve": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Api Citation Resolve */
-        post: operations["api_citation_resolve_api_citation_resolve_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+  "/api/llm/ping": {
+    /** Llm Ping */
+    get: operations["llm_ping_api_llm_ping_get"];
+  };
+  "/api/analyze": {
+    /** Api Analyze */
+    post: operations["api_analyze_api_analyze_post"];
+  };
+  "/analyze": {
+    /** Analyze Alias */
+    post: operations["analyze_alias_analyze_post"];
+  };
+  "/llm/ping": {
+    /** Llm Ping Alias */
+    get: operations["llm_ping_alias_llm_ping_get"];
+  };
+  "/health": {
+    /**
+     * Health
+     * @description Health endpoint with schema version and rule count.
+     */
+    get: operations["health_health_get"];
+  };
+  "/api/supports": {
+    /** Api Supports */
+    get: operations["api_supports_api_supports_get"];
+  };
+  "/api/trace": {
+    /** List Trace */
+    get: operations["list_trace_api_trace_get"];
+  };
+  "/api/trace/{cid}.html": {
+    /** Get Trace Html */
+    get: operations["get_trace_html_api_trace__cid__html_get"];
+  };
+  "/api/trace/{cid}": {
+    /** Get Trace */
+    get: operations["get_trace_api_trace__cid__get"];
+  };
+  "/api/report/{cid}.html": {
+    /** Api Report Html */
+    get: operations["api_report_html_api_report__cid__html_get"];
+  };
+  "/api/report/{cid}.pdf": {
+    /** Api Report Pdf */
+    get: operations["api_report_pdf_api_report__cid__pdf_get"];
+  };
+  "/api/metrics": {
+    /** Api Metrics */
+    get: operations["api_metrics_api_metrics_get"];
+  };
+  "/api/metrics.csv": {
+    /** Api Metrics Csv */
+    get: operations["api_metrics_csv_api_metrics_csv_get"];
+  };
+  "/api/metrics.html": {
+    /** Api Metrics Html */
+    get: operations["api_metrics_html_api_metrics_html_get"];
+  };
+  "/api/admin/purge": {
+    /** Api Admin Purge */
+    post: operations["api_admin_purge_api_admin_purge_post"];
+  };
+  "/api/analyze/replay": {
+    /** Analyze Replay */
+    get: operations["analyze_replay_api_analyze_replay_get"];
+  };
+  "/api/summary": {
+    /** Api Summary Get */
+    get: operations["api_summary_get_api_summary_get"];
+    /** Api Summary Post */
+    post: operations["api_summary_post_api_summary_post"];
+  };
+  "/summary": {
+    /** Summary Get Alias */
+    get: operations["summary_get_alias_summary_get"];
+    /** Summary Post Alias */
+    post: operations["summary_post_alias_summary_post"];
+  };
+  "/api/qa-recheck": {
+    /** Api Qa Recheck */
+    post: operations["api_qa_recheck_api_qa_recheck_post"];
+  };
+  "/api/suggest_edits": {
+    /** Api Suggest Edits */
+    post: operations["api_suggest_edits_api_suggest_edits_post"];
+  };
+  "/api/gpt/draft": {
+    /**
+     * Gpt Draft
+     * @description Simplified LLM draft endpoint with strict validation.
+     */
+    post: operations["gpt_draft_api_gpt_draft_post"];
+  };
+  "/api/panel/redlines": {
+    /** Panel Redlines */
+    post: operations["panel_redlines_api_panel_redlines_post"];
+  };
+  "/api/health": {
+    /** Health Alias */
+    get: operations["health_alias_api_health_get"];
+  };
+  "/suggest_edits": {
+    /** Suggest Edits Alias */
+    post: operations["suggest_edits_alias_suggest_edits_post"];
+  };
+  "/api/draft": {
+    /** Draft Alias */
+    post: operations["draft_alias_api_draft_post"];
+  };
+  "/api/calloff/validate": {
+    /** Api Calloff Validate */
+    post: operations["api_calloff_validate_api_calloff_validate_post"];
+  };
+  "/api/learning/log": {
+    /** Api Learning Log */
+    post: operations["api_learning_log_api_learning_log_post"];
+  };
+  "/api/learning/update": {
+    /** Api Learning Update */
+    post: operations["api_learning_update_api_learning_update_post"];
+  };
+  "/api/companies/health": {
+    /** Companies Health */
+    get: operations["companies_health_api_companies_health_get"];
+  };
+  "/api/companies/search": {
+    /** Api Companies Search Get */
+    get: operations["api_companies_search_get_api_companies_search_get"];
+    /** Api Companies Search */
+    post: operations["api_companies_search_api_companies_search_post"];
+  };
+  "/api/companies/{number}": {
+    /** Api Company Profile */
+    get: operations["api_company_profile_api_companies__number__get"];
+  };
+  "/api/dsar/access": {
+    /** Dsar Access */
+    get: operations["dsar_access_api_dsar_access_get"];
+  };
+  "/api/dsar/erasure": {
+    /** Dsar Erasure */
+    post: operations["dsar_erasure_api_dsar_erasure_post"];
+  };
+  "/api/dsar/export": {
+    /** Dsar Export */
+    get: operations["dsar_export_api_dsar_export_get"];
+  };
+  "/api/citation/resolve": {
+    /** Api Citation Resolve */
+    post: operations["api_citation_resolve_api_citation_resolve_post"];
+  };
 }
+
 export type webhooks = Record<string, never>;
+
 export interface components {
-    schemas: {
-        /** Acceptance */
-        Acceptance: {
-            /** Applied */
-            applied: number;
-            /** Rejected */
-            rejected: number;
-            /** Acceptance Rate */
-            acceptance_rate: number;
-        };
-        /**
-         * AnalyzeRequest
-         * @description Public request DTO for ``/api/analyze``.
-         *
-         *     Accepts ``text`` as a required field while allowing legacy aliases
-         *     ``clause`` and ``body`` for backward compatibility. The aliases are
-         *     folded into ``text`` during validation so downstream logic only needs to
-         *     handle a single attribute.
-         * @example {
-         *       "language": "en-GB",
-         *       "text": "Hello"
-         *     }
-         */
-        AnalyzeRequest: {
-            /** Text */
-            text: string;
-            /**
-             * Language
-             * @default en-GB
-             */
-            language: string;
-            /**
-             * Mode
-             * @default null
-             */
-            mode: string | null;
-            /**
-             * Risk
-             * @default null
-             */
-            risk: string | null;
-            /**
-             * Clause Type
-             * @default null
-             */
-            clause_type: string | null;
-            /**
-             * Schema
-             * @default null
-             */
-            schema: string | null;
-        };
-        /** AnalyzeResponse */
-        AnalyzeResponse: {
-            /** Status */
-            status: string;
-            /** Analysis */
-            analysis: {
-                [key: string]: unknown;
-            };
-        } & {
-            [key: string]: unknown;
-        };
-        /** CitationInput */
-        CitationInput: {
-            /** Instrument */
-            instrument: string;
-            /** Section */
-            section: string;
-        };
-        /**
-         * CitationResolveRequest
-         * @description Request model for ``/api/citation/resolve``.
-         *
-         *     Exactly one of ``findings`` or ``citations`` must be provided.  Both
-         *     fields are optional to allow Pydantic to perform the exclusive-or check
-         *     below.
-         * @example {
-         *       "citations": [
-         *         {
-         *           "instrument": "Act",
-         *           "section": "1"
-         *         }
-         *       ]
-         *     }
-         * @example {
-         *       "findings": [
-         *         {
-         *           "code": "X",
-         *           "message": "m"
-         *         }
-         *       ]
-         *     }
-         */
-        CitationResolveRequest: {
-            /** Findings */
-            findings?: components["schemas"]["QaFindingInput"][] | null;
-            /** Citations */
-            citations?: components["schemas"]["CitationInput"][] | null;
-        };
-        /** CitationResolveResponse */
-        CitationResolveResponse: {
-            /** Citations */
-            citations: components["schemas"]["CitationInput"][];
-        };
+  schemas: {
+    /** Acceptance */
+    Acceptance: {
+      /** Applied */
+      applied: number;
+      /** Rejected */
+      rejected: number;
+      /** Acceptance Rate */
+      acceptance_rate: number;
+    };
+    /**
+     * AnalyzeRequest
+     * @description Public request DTO for ``/api/analyze``.
+     *
+     * Accepts ``text`` as a required field while allowing legacy aliases
+     * ``clause`` and ``body`` for backward compatibility. The aliases are
+     * folded into ``text`` during validation so downstream logic only needs to
+     * handle a single attribute.
+     * @example {
+     *   "language": "en-GB",
+     *   "text": "Hello"
+     * }
+     */
+    AnalyzeRequest: {
+      /** Text */
+      text: string;
+      /**
+       * Language
+       * @default en-GB
+       */
+      language?: string;
+      /**
+       * Mode
+       * @default null
+       */
+      mode?: string | null;
+      /**
+       * Risk
+       * @default null
+       */
+      risk?: string | null;
+      /**
+       * Clause Type
+       * @default null
+       */
+      clause_type?: string | null;
+      /**
+       * Schema
+       * @default null
+       */
+      schema?: string | null;
+    };
+    /** AnalyzeResponse */
+    AnalyzeResponse: {
+      /** Status */
+      status: string;
+      /** Analysis */
+      analysis: {
+        [key: string]: unknown;
+      };
+      [key: string]: unknown;
+    };
+    /** CitationInput */
+    CitationInput: {
+      /** Instrument */
+      instrument: string;
+      /** Section */
+      section: string;
+    };
+    /**
+     * CitationResolveRequest
+     * @description Request model for ``/api/citation/resolve``.
+     *
+     * Exactly one of ``findings`` or ``citations`` must be provided.  Both
+     * fields are optional to allow Pydantic to perform the exclusive-or check
+     * below.
+     */
+    CitationResolveRequest: {
+      /** Findings */
+      findings?: components["schemas"]["QaFindingInput"][] | null;
+      /** Citations */
+      citations?: components["schemas"]["CitationInput"][] | null;
+    };
+    /** CitationResolveResponse */
+    CitationResolveResponse: {
+      /** Citations */
+      citations: components["schemas"]["CitationInput"][];
+    };
+    /** Context */
+    Context: {
+      /**
+       * Law
+       * @default UK
+       * @constant
+       */
+      law?: "UK";
+      /**
+       * Language
+       * @default en-GB
+       * @constant
+       */
+      language?: "en-GB";
+      /**
+       * Contracttype
+       * @default unknown
+       */
+      contractType?: string;
+    };
+    /** Coverage */
+    Coverage: {
+      /** Rules Total */
+      rules_total: number;
+      /** Rules Fired */
+      rules_fired: number;
+      /** Coverage */
+      coverage: number;
+    };
+    /** DraftFinding */
+    DraftFinding: {
+      /** Id */
+      id: string;
+      /** Title */
+      title: string;
+      /** Text */
+      text: string;
+    };
+    /**
+     * DraftRequest
+     * @description Input model for ``/api/gpt/draft``.
+     */
+    DraftRequest: {
+      /**
+       * Mode
+       * @enum {string}
+       */
+      mode: "friendly" | "strict";
+      /** Clause */
+      clause: string;
+      context: components["schemas"]["Context"];
+      /** Findings */
+      findings?: components["schemas"]["DraftFinding"][];
+      /** @default null */
+      selection?: components["schemas"]["Selection"] | null;
+      $defs: {
         /** Context */
         Context: {
-            /**
-             * Law
-             * @default UK
-             * @constant
-             */
-            law: "UK";
-            /**
-             * Language
-             * @default en-GB
-             * @constant
-             */
-            language: "en-GB";
-            /**
-             * Contracttype
-             * @default unknown
-             */
-            contractType: string;
-        };
-        /** Coverage */
-        Coverage: {
-            /** Rules Total */
-            rules_total: number;
-            /** Rules Fired */
-            rules_fired: number;
-            /** Coverage */
-            coverage: number;
+          /**
+           * Law
+           * @default UK
+           * @constant
+           */
+          law?: "UK";
+          /**
+           * Language
+           * @default en-GB
+           * @constant
+           */
+          language?: "en-GB";
+          /**
+           * Contracttype
+           * @default unknown
+           */
+          contractType?: string;
         };
         /** DraftFinding */
         DraftFinding: {
-            /** Id */
-            id: string;
-            /** Title */
-            title: string;
-            /** Text */
-            text: string;
-        };
-        /**
-         * DraftRequest
-         * @description Input model for ``/api/gpt/draft``.
-         */
-        DraftRequest: {
-            /**
-             * Mode
-             * @enum {string}
-             */
-            mode: "friendly" | "strict";
-            /** Clause */
-            clause: string;
-            context: components["schemas"]["Context"];
-            /** Findings */
-            findings?: components["schemas"]["DraftFinding"][];
-            /** @default null */
-            selection: components["schemas"]["Selection"] | null;
-            $defs: {
-                /** Context */
-                Context: {
-                    /**
-                     * Law
-                     * @default UK
-                     * @constant
-                     */
-                    law: "UK";
-                    /**
-                     * Language
-                     * @default en-GB
-                     * @constant
-                     */
-                    language: "en-GB";
-                    /**
-                     * Contracttype
-                     * @default unknown
-                     */
-                    contractType: string;
-                };
-                /** DraftFinding */
-                DraftFinding: {
-                    /** Id */
-                    id: string;
-                    /** Title */
-                    title: string;
-                    /** Text */
-                    text: string;
-                };
-                /** Selection */
-                Selection: {
-                    /** Start */
-                    start: number;
-                    /** End */
-                    end: number;
-                };
-            };
-        };
-        /** DraftResponse */
-        DraftResponse: {
-            /** Draft */
-            draft: string;
-            /** Notes */
-            notes?: string[];
-        };
-        /** HTTPValidationError */
-        HTTPValidationError: {
-            /** Detail */
-            detail?: components["schemas"]["ValidationError"][];
-        };
-        /** LearningUpdateIn */
-        LearningUpdateIn: {
-            /**
-             * Force
-             * @default false
-             */
-            force: boolean | null;
-        };
-        /** MetricsResponse */
-        MetricsResponse: {
-            /**
-             * Schema Version
-             * @default 1.4
-             */
-            schema_version: string;
-            /**
-             * Snapshot At
-             * Format: date-time
-             */
-            snapshot_at: string;
-            metrics: components["schemas"]["QualityMetrics"];
-        };
-        /** Perf */
-        Perf: {
-            /** Docs */
-            docs: number;
-            /** Avg Ms Per Page */
-            avg_ms_per_page: number;
-        };
-        /** ProblemDetail */
-        ProblemDetail: {
-            /**
-             * Type
-             * @default /errors/general
-             */
-            type: string;
-            /** Title */
-            title: string;
-            /** Status */
-            status: number;
-            /**
-             * Detail
-             * @default null
-             */
-            detail: string | null;
-            /**
-             * Instance
-             * @default null
-             */
-            instance: string | null;
-            /**
-             * Code
-             * @default null
-             */
-            code: string | null;
-            /**
-             * Extra
-             * @default null
-             */
-            extra: {
-                [key: string]: unknown;
-            } | null;
-        };
-        /**
-         * QARecheckIn
-         * @description Input model for ``/api/qa-recheck``.
-         *
-         *     ``rules`` accepts either a mapping of rule flags or a list of small
-         *     dictionaries which will be merged into a single mapping for backward
-         *     compatibility with legacy clients.
-         */
-        QARecheckIn: {
-            /** Text */
-            text: string;
-            /** Rules */
-            rules?: {
-                [key: string]: unknown;
-            };
-            /**
-             * Language
-             * @default en-GB
-             */
-            language: string;
-        };
-        /** QARecheckOut */
-        QARecheckOut: {
-            /** Status */
-            status: string;
-            /** Qa */
-            qa: unknown[];
-            /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
-        };
-        /** QaFindingInput */
-        QaFindingInput: {
-            /** Code */
-            code?: string | null;
-            /** Message */
-            message?: string | null;
-            /** Rule */
-            rule?: string | null;
-        };
-        /** QualityMetrics */
-        QualityMetrics: {
-            /** Rules */
-            rules: components["schemas"]["RuleMetric"][];
-            coverage: components["schemas"]["Coverage"];
-            acceptance: components["schemas"]["Acceptance"];
-            perf: components["schemas"]["Perf"];
-        };
-        /** RedlinesIn */
-        RedlinesIn: {
-            /** Before Text */
-            before_text: string;
-            /** After Text */
-            after_text: string;
-        };
-        /** RedlinesOut */
-        RedlinesOut: {
-            /** Status */
-            status: string;
-            /** Diff Unified */
-            diff_unified: string;
-            /** Diff Html */
-            diff_html: string;
-        };
-        /** RuleMetric */
-        RuleMetric: {
-            /** Rule Id */
-            rule_id: string;
-            /** Tp */
-            tp: number;
-            /** Fp */
-            fp: number;
-            /** Fn */
-            fn: number;
-            /** Precision */
-            precision: number;
-            /** Recall */
-            recall: number;
-            /** F1 */
-            f1: number;
+          /** Id */
+          id: string;
+          /** Title */
+          title: string;
+          /** Text */
+          text: string;
         };
         /** Selection */
         Selection: {
-            /** Start */
-            start: number;
-            /** End */
-            end: number;
+          /** Start */
+          start: number;
+          /** End */
+          end: number;
         };
-        /**
-         * SummaryIn
-         * @description Input model for ``/api/summary``.
-         *
-         *     Exactly one of ``cid`` or ``hash`` must be provided.
-         */
-        SummaryIn: {
-            /** Cid */
-            cid?: string | null;
-            /** Hash */
-            hash?: string | null;
-        };
-        /** ValidationError */
-        ValidationError: {
-            /** Location */
-            loc: (string | number)[];
-            /** Message */
-            msg: string;
-            /** Error Type */
-            type: string;
-        };
-        /** _CompanySearchIn */
-        _CompanySearchIn: {
-            /** Query */
-            query: string;
-            /**
-             * Limit
-             * @default 10
-             */
-            limit: number;
-        };
-        /** Finding */
-        Finding: {
-            span: components["schemas"]["Span"];
-            /** Text */
-            text: string;
-            /**
-             * Lang
-             * @enum {string}
-             */
-            lang: "latin" | "cyrillic";
-            $defs: {
-                /** Span */
-                Span: {
-                    /** Start */
-                    start: number;
-                    /** End */
-                    end: number;
-                };
-            };
-        };
+      };
+    };
+    /** DraftResponse */
+    DraftResponse: {
+      /** Draft */
+      draft: string;
+      /** Notes */
+      notes?: string[];
+    };
+    /** HTTPValidationError */
+    HTTPValidationError: {
+      /** Detail */
+      detail?: components["schemas"]["ValidationError"][];
+    };
+    /** LearningUpdateIn */
+    LearningUpdateIn: {
+      /**
+       * Force
+       * @default false
+       */
+      force?: boolean | null;
+    };
+    /** MetricsResponse */
+    MetricsResponse: {
+      /**
+       * Schema Version
+       * @default 1.4
+       */
+      schema_version?: string;
+      /**
+       * Snapshot At
+       * Format: date-time
+       */
+      snapshot_at: string;
+      metrics: components["schemas"]["QualityMetrics"];
+    };
+    /** Perf */
+    Perf: {
+      /** Docs */
+      docs: number;
+      /** Avg Ms Per Page */
+      avg_ms_per_page: number;
+    };
+    /** ProblemDetail */
+    ProblemDetail: {
+      /**
+       * Type
+       * @default /errors/general
+       */
+      type?: string;
+      /** Title */
+      title: string;
+      /** Status */
+      status: number;
+      /**
+       * Detail
+       * @default null
+       */
+      detail?: string | null;
+      /**
+       * Instance
+       * @default null
+       */
+      instance?: string | null;
+      /**
+       * Code
+       * @default null
+       */
+      code?: string | null;
+      /**
+       * Extra
+       * @default null
+       */
+      extra?: {
+        [key: string]: unknown;
+      } | null;
+    };
+    /**
+     * QARecheckIn
+     * @description Input model for ``/api/qa-recheck``.
+     *
+     * ``rules`` accepts either a mapping of rule flags or a list of small
+     * dictionaries which will be merged into a single mapping for backward
+     * compatibility with legacy clients.
+     */
+    QARecheckIn: {
+      /** Text */
+      text: string;
+      /** Rules */
+      rules?: {
+        [key: string]: unknown;
+      };
+      /**
+       * Language
+       * @default en-GB
+       */
+      language?: string;
+    };
+    /** QARecheckOut */
+    QARecheckOut: {
+      /** Status */
+      status: string;
+      /** Qa */
+      qa: unknown[];
+      /** Meta */
+      meta?: {
+        [key: string]: unknown;
+      } | null;
+    };
+    /** QaFindingInput */
+    QaFindingInput: {
+      /** Code */
+      code?: string | null;
+      /** Message */
+      message?: string | null;
+      /** Rule */
+      rule?: string | null;
+    };
+    /** QualityMetrics */
+    QualityMetrics: {
+      /** Rules */
+      rules: components["schemas"]["RuleMetric"][];
+      coverage: components["schemas"]["Coverage"];
+      acceptance: components["schemas"]["Acceptance"];
+      perf: components["schemas"]["Perf"];
+    };
+    /** RedlinesIn */
+    RedlinesIn: {
+      /** Before Text */
+      before_text: string;
+      /** After Text */
+      after_text: string;
+    };
+    /** RedlinesOut */
+    RedlinesOut: {
+      /** Status */
+      status: string;
+      /** Diff Unified */
+      diff_unified: string;
+      /** Diff Html */
+      diff_html: string;
+    };
+    /** RuleMetric */
+    RuleMetric: {
+      /** Rule Id */
+      rule_id: string;
+      /** Tp */
+      tp: number;
+      /** Fp */
+      fp: number;
+      /** Fn */
+      fn: number;
+      /** Precision */
+      precision: number;
+      /** Recall */
+      recall: number;
+      /** F1 */
+      f1: number;
+    };
+    /** Selection */
+    Selection: {
+      /** Start */
+      start: number;
+      /** End */
+      end: number;
+    };
+    /**
+     * SummaryIn
+     * @description Input model for ``/api/summary``.
+     *
+     * Exactly one of ``cid`` or ``hash`` must be provided.
+     */
+    SummaryIn: {
+      /** Cid */
+      cid?: string | null;
+      /** Hash */
+      hash?: string | null;
+    };
+    /** ValidationError */
+    ValidationError: {
+      /** Location */
+      loc: (string | number)[];
+      /** Message */
+      msg: string;
+      /** Error Type */
+      type: string;
+    };
+    /** _CompanySearchIn */
+    _CompanySearchIn: {
+      /** Query */
+      query: string;
+      /**
+       * Limit
+       * @default 10
+       */
+      limit?: number;
+    };
+    /** Finding */
+    Finding: {
+      span: components["schemas"]["Span"];
+      /** Text */
+      text: string;
+      /**
+       * Lang
+       * @enum {string}
+       */
+      lang: "latin" | "cyrillic";
+      $defs: {
         /** Span */
         Span: {
-            /** Start */
-            start: number;
-            /** End */
-            end: number;
+          /** Start */
+          start: number;
+          /** End */
+          end: number;
         };
-        /** Segment */
-        Segment: {
-            span: components["schemas"]["Span"];
-            /**
-             * Lang
-             * @enum {string}
-             */
-            lang: "latin" | "cyrillic";
-            $defs: {
-                /** Span */
-                Span: {
-                    /** Start */
-                    start: number;
-                    /** End */
-                    end: number;
-                };
-            };
-        };
-        /** SearchHit */
-        SearchHit: {
-            /** Doc Id */
-            doc_id: string;
-            /** Score */
-            score: number;
-            span: components["schemas"]["Span"];
-            /**
-             * Snippet
-             * @default null
-             */
-            snippet: string | null;
-            /**
-             * Title
-             * @default null
-             */
-            title: string | null;
-            /**
-             * Text
-             * @default null
-             */
-            text: string | null;
-            /**
-             * Meta
-             * @default null
-             */
-            meta: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Bm25 Score
-             * @default null
-             */
-            bm25_score: number | null;
-            /**
-             * Cosine Sim
-             * @default null
-             */
-            cosine_sim: number | null;
-            /**
-             * Rank Fusion
-             * @default null
-             */
-            rank_fusion: number | null;
-            $defs: {
-                /** Span */
-                Span: {
-                    /** Start */
-                    start: number;
-                    /** End */
-                    end: number;
-                };
-            };
-        };
+      };
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: {
-        /** @example 1.4 */
-        XSchemaVersion: string;
-        /** @example 12 */
-        XLatencyMs: number;
-        /** @example e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 */
-        XCid: string;
+    /** Span */
+    Span: {
+      /** Start */
+      start: number;
+      /** End */
+      end: number;
     };
-    pathItems: never;
+    /** Segment */
+    Segment: {
+      span: components["schemas"]["Span"];
+      /**
+       * Lang
+       * @enum {string}
+       */
+      lang: "latin" | "cyrillic";
+      $defs: {
+        /** Span */
+        Span: {
+          /** Start */
+          start: number;
+          /** End */
+          end: number;
+        };
+      };
+    };
+    /** SearchHit */
+    SearchHit: {
+      /** Doc Id */
+      doc_id: string;
+      /** Score */
+      score: number;
+      span: components["schemas"]["Span"];
+      /**
+       * Snippet
+       * @default null
+       */
+      snippet?: string | null;
+      /**
+       * Title
+       * @default null
+       */
+      title?: string | null;
+      /**
+       * Text
+       * @default null
+       */
+      text?: string | null;
+      /**
+       * Meta
+       * @default null
+       */
+      meta?: {
+        [key: string]: unknown;
+      } | null;
+      /**
+       * Bm25 Score
+       * @default null
+       */
+      bm25_score?: number | null;
+      /**
+       * Cosine Sim
+       * @default null
+       */
+      cosine_sim?: number | null;
+      /**
+       * Rank Fusion
+       * @default null
+       */
+      rank_fusion?: number | null;
+      $defs: {
+        /** Span */
+        Span: {
+          /** Start */
+          start: number;
+          /** End */
+          end: number;
+        };
+      };
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: {
+    /** @example 1.4 */
+    XSchemaVersion: string;
+    /** @example 12 */
+    XLatencyMs: number;
+    /** @example e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 */
+    XCid: string;
+  };
+  pathItems: never;
 }
+
 export type $defs = Record<string, never>;
+
+export type external = Record<string, never>;
+
 export interface operations {
-    llm_ping_api_llm_ping_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+
+  /** Llm Ping */
+  llm_ping_api_llm_ping_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_analyze_api_analyze_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+  };
+  /** Api Analyze */
+  api_analyze_api_analyze_post: {
+    requestBody: {
+      content: {
+        /**
+         * @example {
+         *   "text": "Hello"
+         * }
+         */
+        "application/json": {
+          [key: string]: unknown;
         };
-        requestBody: {
-            content: {
-                /** @example {
-                 *       "text": "Hello"
-                 *     } */
-                "application/json": {
-                    [key: string]: unknown;
-                };
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AnalyzeResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+      };
     };
-    analyze_alias_analyze_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AnalyzeRequest"];
-            };
+        content: {
+          "application/json": components["schemas"]["AnalyzeResponse"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    llm_ping_alias_llm_ping_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Analyze Alias */
+  analyze_alias_analyze_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AnalyzeRequest"];
+      };
     };
-    health_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_supports_api_supports_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+  };
+  /** Llm Ping Alias */
+  llm_ping_alias_llm_ping_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    list_trace_api_trace_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+  };
+  /**
+   * Health
+   * @description Health endpoint with schema version and rule count.
+   */
+  health_health_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    get_trace_html_api_trace__cid__html_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cid: string;
-            };
-            cookie?: never;
+  };
+  /** Api Supports */
+  api_supports_api_supports_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    get_trace_api_trace__cid__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cid: string;
-            };
-            cookie?: never;
+  };
+  /** List Trace */
+  list_trace_api_trace_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_report_html_api_report__cid__html_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cid: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Get Trace Html */
+  get_trace_html_api_trace__cid__html_get: {
+    parameters: {
+      path: {
+        cid: string;
+      };
     };
-    api_report_pdf_api_report__cid__pdf_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cid: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_metrics_api_metrics_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MetricsResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Get Trace */
+  get_trace_api_trace__cid__get: {
+    parameters: {
+      path: {
+        cid: string;
+      };
     };
-    api_metrics_csv_api_metrics_csv_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_metrics_html_api_metrics_html_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Api Report Html */
+  api_report_html_api_report__cid__html_get: {
+    parameters: {
+      path: {
+        cid: string;
+      };
     };
-    api_admin_purge_api_admin_purge_post: {
-        parameters: {
-            query?: {
-                dry?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    analyze_replay_api_analyze_replay_get: {
-        parameters: {
-            query?: {
-                cid?: string | null;
-                hash?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Api Report Pdf */
+  api_report_pdf_api_report__cid__pdf_get: {
+    parameters: {
+      path: {
+        cid: string;
+      };
     };
-    api_summary_get_api_summary_get: {
-        parameters: {
-            query?: {
-                mode?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_summary_post_api_summary_post: {
-        parameters: {
-            query?: {
-                mode?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+  };
+  /** Api Metrics */
+  api_metrics_api_metrics_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SummaryIn"];
-            };
+        content: {
+          "application/json": components["schemas"]["MetricsResponse"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    summary_get_alias_summary_get: {
-        parameters: {
-            query?: {
-                mode?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+  };
+  /** Api Metrics Csv */
+  api_metrics_csv_api_metrics_csv_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    summary_post_alias_summary_post: {
-        parameters: {
-            query?: {
-                mode?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+  };
+  /** Api Metrics Html */
+  api_metrics_html_api_metrics_html_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SummaryIn"];
-            };
+        content: {
+          "application/json": unknown;
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_qa_recheck_api_qa_recheck_post: {
-        parameters: {
-            query?: {
-                profile?: string;
-            };
-            header?: {
-                "x-cid"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["QARecheckIn"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["QARecheckOut"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Api Admin Purge */
+  api_admin_purge_api_admin_purge_post: {
+    parameters: {
+      query?: {
+        dry?: number;
+      };
     };
-    api_suggest_edits_api_suggest_edits_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "x-cid"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    gpt_draft_api_gpt_draft_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DraftRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DraftResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Analyze Replay */
+  analyze_replay_api_analyze_replay_get: {
+    parameters: {
+      query?: {
+        cid?: string | null;
+        hash?: string | null;
+      };
     };
-    panel_redlines_api_panel_redlines_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RedlinesIn"];
-            };
+        content: {
+          "application/json": unknown;
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RedlinesOut"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    health_alias_api_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Api Summary Get */
+  api_summary_get_api_summary_get: {
+    parameters: {
+      query?: {
+        mode?: string | null;
+      };
     };
-    suggest_edits_alias_suggest_edits_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "x-cid"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    draft_alias_api_draft_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DraftRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DraftResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Api Summary Post */
+  api_summary_post_api_summary_post: {
+    parameters: {
+      query?: {
+        mode?: string | null;
+      };
     };
-    api_calloff_validate_api_calloff_validate_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "x-cid"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SummaryIn"];
+      };
     };
-    api_learning_log_api_learning_log_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody: {
-            content: {
-                "application/json": unknown;
-            };
+        content: {
+          "application/json": unknown;
         };
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_learning_update_api_learning_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LearningUpdateIn"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Summary Get Alias */
+  summary_get_alias_summary_get: {
+    parameters: {
+      query?: {
+        mode?: string | null;
+      };
     };
-    companies_health_api_companies_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_companies_search_get_api_companies_search_get: {
-        parameters: {
-            query: {
-                q: string;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Summary Post Alias */
+  summary_post_alias_summary_post: {
+    parameters: {
+      query?: {
+        mode?: string | null;
+      };
     };
-    api_companies_search_api_companies_search_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["_CompanySearchIn"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SummaryIn"];
+      };
     };
-    api_company_profile_api_companies__number__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                number: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": unknown;
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    dsar_access_api_dsar_access_get: {
-        parameters: {
-            query: {
-                identifier: string;
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Api Qa Recheck */
+  api_qa_recheck_api_qa_recheck_post: {
+    parameters: {
+      query?: {
+        profile?: string;
+      };
+      header?: {
+        "x-cid"?: string | null;
+      };
     };
-    dsar_erasure_api_dsar_erasure_post: {
-        parameters: {
-            query: {
-                identifier: string;
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["QARecheckIn"];
+      };
     };
-    dsar_export_api_dsar_export_get: {
-        parameters: {
-            query: {
-                identifier: string;
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["QARecheckOut"];
         };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
     };
-    api_citation_resolve_api_citation_resolve_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "x-cid"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CitationResolveRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CitationResolveResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Unprocessable Entity */
-            422: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Too Many Requests */
-            429: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-            /** @description Gateway Timeout */
-            504: {
-                headers: {
-                    "x-schema-version": components["headers"]["XSchemaVersion"];
-                    "x-latency-ms": components["headers"]["XLatencyMs"];
-                    "x-cid": components["headers"]["XCid"];
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProblemDetail"];
-                };
-            };
-        };
+  };
+  /** Api Suggest Edits */
+  api_suggest_edits_api_suggest_edits_post: {
+    parameters: {
+      header?: {
+        "x-cid"?: string | null;
+      };
     };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /**
+   * Gpt Draft
+   * @description Simplified LLM draft endpoint with strict validation.
+   */
+  gpt_draft_api_gpt_draft_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DraftRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["DraftResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Panel Redlines */
+  panel_redlines_api_panel_redlines_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["RedlinesIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["RedlinesOut"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Health Alias */
+  health_alias_api_health_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Suggest Edits Alias */
+  suggest_edits_alias_suggest_edits_post: {
+    parameters: {
+      header?: {
+        "x-cid"?: string | null;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Draft Alias */
+  draft_alias_api_draft_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["DraftRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["DraftResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Api Calloff Validate */
+  api_calloff_validate_api_calloff_validate_post: {
+    parameters: {
+      header?: {
+        "x-cid"?: string | null;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Api Learning Log */
+  api_learning_log_api_learning_log_post: {
+    requestBody: {
+      content: {
+        "application/json": unknown;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        content: never;
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Api Learning Update */
+  api_learning_update_api_learning_update_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LearningUpdateIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Companies Health */
+  companies_health_api_companies_health_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Api Companies Search Get */
+  api_companies_search_get_api_companies_search_get: {
+    parameters: {
+      query: {
+        q: string;
+        limit?: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Api Companies Search */
+  api_companies_search_api_companies_search_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["_CompanySearchIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Api Company Profile */
+  api_company_profile_api_companies__number__get: {
+    parameters: {
+      path: {
+        number: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Dsar Access */
+  dsar_access_api_dsar_access_get: {
+    parameters: {
+      query: {
+        identifier: string;
+        token: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Dsar Erasure */
+  dsar_erasure_api_dsar_erasure_post: {
+    parameters: {
+      query: {
+        identifier: string;
+        token: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Dsar Export */
+  dsar_export_api_dsar_export_get: {
+    parameters: {
+      query: {
+        identifier: string;
+        token: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
+  /** Api Citation Resolve */
+  api_citation_resolve_api_citation_resolve_post: {
+    parameters: {
+      header?: {
+        "x-cid"?: string | null;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CitationResolveRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["CitationResolveResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Unprocessable Entity */
+      422: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+      /** @description Gateway Timeout */
+      504: {
+        headers: {
+          "x-schema-version": components["headers"]["XSchemaVersion"];
+          "x-latency-ms": components["headers"]["XLatencyMs"];
+          "x-cid": components["headers"]["XCid"];
+        };
+        content: {
+          "application/json": components["schemas"]["ProblemDetail"];
+        };
+      };
+    };
+  };
 }

--- a/word_addin_dev/package-lock.json
+++ b/word_addin_dev/package-lock.json
@@ -14,12 +14,14 @@
         "diff-match-patch": "^1.0.5",
         "eslint": "^8.57.0",
         "jsdom": "^24.0.0",
+        "openapi-typescript": "^6.7.0",
         "typescript": "^5.0.0",
         "vite": "^7.1.1",
         "vitest": "^0.34.6"
       },
       "engines": {
-        "node": ">=20 <23"
+        "node": ">=20 <21",
+        "npm": ">=10 <11"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -685,6 +687,16 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1548,6 +1560,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -3102,6 +3124,37 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-6.7.6.tgz",
+      "integrity": "sha512-c/hfooPx+RBIOPM09GSxABOZhYPblDoyaGhqBkD/59vtpN21jEuWKDlM0KYTvqJVlSYjKs0tBcIdeXKChlSPtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "fast-glob": "^3.3.2",
+        "js-yaml": "^4.1.0",
+        "supports-color": "^9.4.0",
+        "undici": "^5.28.4",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3888,6 +3941,19 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",
@@ -5263,6 +5329,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",


### PR DESCRIPTION
## Summary
- ensure `openapi-typescript` is pinned in `word_addin_dev/package-lock.json`
- regenerate `app/types/api.d.ts`

## Testing
- `pre-commit run --files word_addin_dev/package-lock.json word_addin_dev/app/types/api.d.ts word_addin_dev/package.json`
- `npm --prefix word_addin_dev test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c7297d0474832598f27538fa406c67