### PR TITLE
fix: remove document_id from QA recheck payload

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.js
@@ -274,16 +274,16 @@ export async function apiSummaryGet() {
     return req('/api/summary', { method: 'GET', key: 'summary' });
 }
 export async function apiQaRecheck(input, rules = {}) {
-    let payload;
+    let text;
     if (typeof input === 'string') {
-        payload = { text: input };
+        text = input;
     }
     else {
-        payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
+        text = (input.text || "");
         rules = input.rules ?? {};
     }
     const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-    const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
+    const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
     const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
     try {
         applyMetaToBadges(meta);

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -277,18 +277,18 @@ export async function apiSummaryGet() {
 
 
 export async function apiQaRecheck(
-  input: { document_id?: string; text?: string; rules?: any } | string,
+  input: { text?: string; rules?: any } | string,
   rules: any = {},
 ) {
-  let payload: any;
+  let text: string;
   if (typeof input === 'string') {
-    payload = { text: input };
+    text = input;
   } else {
-    payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
+    text = input.text || '';
     rules = input.rules ?? {};
   }
   const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-  const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
+  const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1068,16 +1068,9 @@ async function doQARecheck() {
     await clearHighlight();
     ensureHeaders();
 
-    const docId = (window as any).__docId;
-    let payload: any;
-    if (docId) {
-      payload = { document_id: docId, rules: {} };
-    } else {
-      const text = await getWholeDocText();
-      (window as any).__lastAnalyzed = text;
-      payload = { text, rules: {} };
-    }
-    const { json } = await postJSON('/api/qa-recheck', payload);
+    const text = await getWholeDocText();
+    (window as any).__lastAnalyzed = text;
+    const { json } = await postJSON('/api/qa-recheck', { text, rules: {} });
       mustGetElementById<HTMLElement>("results").dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;
     if (ok) {

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2,5 +2,5 @@
 | --- | --- | --- | --- | --- | --- | --- |
 | Analyze | Клиент | `POST /api/analyze` | [`{text, mode?, schema:"1.4"}`](api.d.ts#L625-L660) | [AnalyzeResponse](api.d.ts#L661-L671) | `Content-Type: application/json`<br>`X-Schema-Version: 1.4` | `1.4` |
 | Draft | Клиент | `POST /api/gpt-draft` | [`{clause_id, text, ...}`](api.d.ts#L761-L775) | [`{draft_text, ...}`](api.d.ts#L816-L820) | `Content-Type: application/json`<br>`X-Schema-Version: 1.4` | `1.4` |
-| QA Recheck | Клиент | `POST /api/qa-recheck` | [`{document_id, ...}`](api.d.ts#L792-L811) | [Findings[]](api.d.ts#L922-L941) | `Content-Type: application/json`<br>`X-Schema-Version: 1.4` | `1.4` |
+| QA Recheck | Клиент | `POST /api/qa-recheck` | [`{text, ...}`](api.d.ts#L891-L909) | [QARecheckOut](api.d.ts#L911-L921) | `Content-Type: application/json`<br>`X-Schema-Version: 1.4` | `1.4` |
 | OpenAPI | Клиент | `GET /openapi.json` | [—](api.d.ts#L1) | [JSON](api.d.ts#L1) | — | — |

--- a/word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts
+++ b/word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts
@@ -38,7 +38,6 @@ describe('qa recheck navigation', () => {
       parseFindings: (resp: any) => resp.analysis.findings,
       analyze: vi.fn(),
     }));
-    (window as any).__docId = 'doc1';
     const mod = await import('../assets/taskpane.ts');
     const resultsEl = document.getElementById('results')!;
     resultsEl.addEventListener('ca.qa', (e: any) => {
@@ -68,10 +67,10 @@ describe('qa recheck navigation', () => {
       li.scrollIntoView = () => {};
       fl.appendChild(li);
     });
-    await postJSON('/api/qa-recheck', { document_id: 'doc1', rules: {} });
+    await postJSON('/api/qa-recheck', { text: 'doc text', rules: {} });
     resultsEl.dispatchEvent(new CustomEvent('ca.qa', { detail: qaResp }));
 
-    expect(postJSON).toHaveBeenCalledWith('/api/qa-recheck', { document_id: 'doc1', rules: {} });
+    expect(postJSON).toHaveBeenCalledWith('/api/qa-recheck', { text: 'doc text', rules: {} });
 
     const items = (window as any).__findings;
     expect(items).toEqual(qaResp.analysis.findings);

--- a/word_addin_dev/app/assets/api-client.js
+++ b/word_addin_dev/app/assets/api-client.js
@@ -302,16 +302,16 @@ export async function apiSummaryGet() {
     return req('/api/summary', { method: 'GET', key: 'summary' });
 }
 export async function apiQaRecheck(input, rules = {}) {
-    let payload;
+    let text;
     if (typeof input === 'string') {
-        payload = { text: input };
+        text = input;
     }
     else {
-        payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
+        text = (input.text || "");
         rules = input.rules ?? {};
     }
     const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-    const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
+    const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
     const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
     try {
         applyMetaToBadges(meta);

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -302,18 +302,18 @@ export async function apiSummaryGet() {
 
 
 export async function apiQaRecheck(
-  input: { document_id?: string; text?: string; rules?: any } | string,
+  input: { text?: string; rules?: any } | string,
   rules: any = {},
 ) {
-  let payload: any;
+  let text: string;
   if (typeof input === 'string') {
-    payload = { text: input };
+    text = input;
   } else {
-    payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
+    text = input.text || '';
     rules = input.rules ?? {};
   }
   const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-  const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
+  const { resp, json } = await postJSON('/api/qa-recheck', { text, rules: dict });
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1066,13 +1066,9 @@ async function doQARecheck() {
     await clearHighlight();
     ensureHeaders();
 
-    const docId = (window as any).__docId;
     const text = await getWholeDocText();
     (window as any).__lastAnalyzed = text;
-    const payload: any = docId
-      ? { document_id: docId, rules: {} }
-      : { text, rules: {} };
-    const { json } = await postJSON('/api/qa-recheck', payload);
+    const { json } = await postJSON('/api/qa-recheck', { text, rules: {} });
       mustGetElementById<HTMLElement>("results").dispatchEvent(new CustomEvent("ca.qa", { detail: json }));
     const ok = !json?.error;
     if (ok) {


### PR DESCRIPTION
## Summary
- stop sending `document_id` in QA recheck requests
- update panel and word add-in clients, docs, and tests for text-based rechecks

## Testing
- `python tools/build_panel.py --run-tests` *(fails: Command '['npm', '--prefix', 'word_addin_dev', 'run', 'test']' returned non-zero exit status 1)*
- `pytest tests/panel/test_whole_doc_analyze_smoke.py` *(fails: CalledProcessError: Command '['node', '-e', '\nconst vm = require(\'vm\');\nconst fs = require(\'fs\');\nconst path = require(\'path\');\n\nconst bundlePath = path.resolve(process.cwd(), \\'word_addin_dev\\', \\'taskpane.bundle.js\\');\nlet code = fs.readFileSync(bundlePath, \\'utf-8\\');\ncode = code.replace(/bootstrap\\(\\);\\s*$/, \\''\\');\n\nlet analyzeCalled = 0;\nlet annotateCalled = 0;\nlet findingsLen = 0;\n\nconst btnAnalyze = {\n  handler: null,\n  addEventListener(ev, fn) { if (ev === \\'click\\') this.handler = fn; },\n  removeAttribute() {},\n  classList: { remove() {} },\n  click() { this.handler && this.handler({ preventDefault(){} }); }\n};\n\nconst elements = {\n  btnAnalyze,\n  results: { dispatchEvent() {} }\n};\n\nconst document = {\n  querySelector(sel) { return sel === \\'#btnAnalyze\\' ? btnAnalyze : null; },\n  getElementById(id) { return elements[id] || null; },\n  body: { dispatchEvent() {} }\n};\n\nconst sandbox = {\n  window: {},\n  document,\n  getWholeDocText: async () => \\'\\',\n  apiAnalyze: async () => ({ json: { analysis: { findings: [] } }, resp: {} }),\n  annotateFindingsIntoWord: async () => {},\n  notifyOk: () => {},\n  notifyErr: () => {},\n  notifyWarn: () => {},\n  applyMetaToBadges: () => {},\n  metaFromResponse: () => ({}),\n  console,\n  CustomEvent: function(type, init){ return { type, detail: (init && init.detail) || null }; },\n};\n\nvm.createContext(sandbox);\nvm.runInContext(code, sandbox);\n\nsandbox.getWholeDocText = async () => "Supplier shall provide an Inspection & Test Plan (ITP) with Hold and Witness points. No shipment without Company final inspection or a written waiver. All lifting equipment must have current LOLER/PUWER certificates and SWL marked.";\nsandbox.apiAnalyze = async () => {\n  analyzeCalled += 1;\n  return {\n    json: { analysis: { findings: [{"snippet": "Supplier shall provide an Inspection & Test Plan (ITP) with Hold and Witness points", "rule_id": "13.ITP.EXISTS", "severity": "high", "start": 0}, {"snippet": "No shipment without Company final inspection or a written waiver", "rule_id": "13.SHIP.BLOCK", "severity": "high", "start": 85}, {"snippet": "All lifting equipment must have current LOLER/PUWER certificates and SWL marked", "rule_id": "13.EQUIP.CERT.LOLER_PUWER", "severity": "high", "start": 151}] } },\n    resp: {},\n  };\n};\nsandbox.annotateFindingsIntoWord = async (findings) => {\n  if (Array.isArray(findings)) {\n    findingsLen = findings.length;\n    annotateCalled += 1;\n  }\n};\nsandbox.parseFindings = (resp) => {\n  const arr = resp?.analysis?.findings || resp?.findings || resp?.issues || [];\n  return Array.isArray(arr) ? arr.filter(Boolean) : [];\n};\n\nsandbox.wireUI();\nbtnAnalyze.click();\n\nsetTimeout(() => {\n  console.log(JSON.stringify({ analyze_called: analyzeCalled, annotate_called: annotateCalled, findings_len: findingsLen }));\n}, 0);\n']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c72be9a3948325a7dee8e38f6530f2