### PR TITLE
refactor: drop payload wrapper

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1849,8 +1849,13 @@ def api_admin_purge(dry: int = 1):
     response_model=AnalyzeResponse,
 )
 def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello"})):
+    data = body
+    if isinstance(body, dict):
+        payload = body.get("payload")
+        if isinstance(payload, dict):
+            data = payload
     try:
-        req = AnalyzeRequest.model_validate(body.get("payload", body))
+        req = AnalyzeRequest.model_validate(data)
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors())
     clause_type = request.query_params.get("clause_type")

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.body.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.body.spec.ts
@@ -12,6 +12,7 @@ describe('analyze request body', () => {
     const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
     const body = JSON.parse(bodyStr);
     expect(body).toMatchObject({ text: 'hi', mode: 'live', schema: '1.4' });
+    expect('payload' in body).toBe(false);
     expect(headers['x-schema-version']).toBe('1.4');
   });
 
@@ -23,6 +24,7 @@ describe('analyze request body', () => {
     const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
     const body = JSON.parse(bodyStr);
     expect(body).toMatchObject({ text: 'hi', mode: 'test', schema: '1.4' });
+    expect('payload' in body).toBe(false);
     expect(headers['x-schema-version']).toBe('1.4');
   });
 });

--- a/word_addin_dev/app/__tests__/analyze.payload.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.payload.spec.ts
@@ -12,6 +12,7 @@ describe('analyze payload wrapper', () => {
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
     expect(body).toMatchObject({ mode: 'live', text: 'hello', schema: '1.4' });
+    expect('payload' in body).toBe(false);
     expect(opts.headers['x-schema-version']).toBe('1.4');
   });
 });

--- a/word_addin_dev/app/assets/__tests__/analyze.body.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/analyze.body.spec.ts
@@ -12,6 +12,7 @@ describe('analyze request body', () => {
     const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
     const body = JSON.parse(bodyStr);
     expect(body).toMatchObject({ text: 'hi', mode: 'live', schema: '1.4' });
+    expect('payload' in body).toBe(false);
     expect(headers['x-schema-version']).toBe('1.4');
   });
 
@@ -23,6 +24,7 @@ describe('analyze request body', () => {
     const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
     const body = JSON.parse(bodyStr);
     expect(body).toMatchObject({ text: 'hi', mode: 'test', schema: '1.4' });
+    expect('payload' in body).toBe(false);
     expect(headers['x-schema-version']).toBe('1.4');
   });
 });


### PR DESCRIPTION
## Summary
- avoid legacy payload wrapper on backend analyze endpoint
- harden API client tests against payload wrappers

## Testing
- `npx vitest run app/__tests__/analyze.payload.spec.ts app/assets/__tests__/analyze.body.spec.ts app/assets/__tests__/analyze.422.spec.ts`
- `npx vitest run /workspace/contract_ai/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.body.spec.ts /workspace/contract_ai/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.422.spec.ts` *(fails: No test files found)*
- `pytest tests/panel/test_analyze_body.py tests/api/test_analyze.py`
- `rg 'JSON\.stringify\(\s*\{\s*payload' -l --glob '!tests/**' --glob '!**/__tests__/**' --glob '!docs/**' --glob '!**/node_modules/**'`
- `rg '"payload":' -l --glob '!**/tests/**' --glob '!**/__tests__/**' --glob '!docs/**' --glob '!**/node_modules/**'`

------
https://chatgpt.com/codex/tasks/task_e_68c81ec201d0832595f73803508c400d