### PR TITLE
chore: declare WordApi 1.4 requirement for add-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ UI panel surfaces this status so missing coverage is visible during checks.
 
 Фронтенд-тесты запускаются Vitest; Jest не используется.
 
+В манифесте указан Requirement WordApi 1.4. Для Office 2021 возможен фолбэк, см. Задача B.
+
 On Windows build and test with:
 
 ```bash

--- a/word_addin_dev/manifest.xml
+++ b/word_addin_dev/manifest.xml
@@ -33,6 +33,12 @@
     <SourceLocation DefaultValue="https://localhost:9443/panel/taskpane.html?v=dev&amp;b=build-20250911-102753"/>
   </DefaultSettings>
 
+  <Requirements>
+    <Sets DefaultMinVersion="1.1">
+      <Set Name="WordApi" MinVersion="1.4"/>
+    </Sets>
+  </Requirements>
+
   <Permissions>ReadWriteDocument</Permissions>
 
   <VersionOverrides xsi:type="ov:VersionOverridesV1_0">


### PR DESCRIPTION
## Summary
- declare WordApi 1.4 requirement in Word add-in manifest
- note Office 2021 fallback in README

## Testing
- `pytest contract_review_app/tests/api/test_gpt_draft_body.py::test_gpt_draft_accepts_text_aliases tests/dev/test_watch_setup.py::test_pytest_watch_installed -q` *(fails: 404 from /api/gpt-draft and missing pytest_watch)*

------
https://chatgpt.com/codex/tasks/task_e_68c82aa695b48325a5fc90953605b9a3