### PR TITLE
feat(panel): fallback to ContentControl when comments API not available

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -2,7 +2,7 @@ import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, A
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, severityRank, dedupeFindings } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
-import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment } from "./annotate.ts";
+import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment, fallbackAnnotateWithContentControl } from "./annotate.ts";
 import { findAnchors } from "./anchors.ts";
 import { safeBodySearch } from "./safeBodySearch.ts";
 import { insertDraftText } from "./insert.ts";
@@ -439,7 +439,10 @@ export async function applyOpsTracked(
           }
         }
         const comment = `${COMMENT_PREFIX} ${op.rationale || op.source || 'AI edit'}`;
-        try { await safeInsertComment(target, comment); } catch {}
+        const res = await safeInsertComment(target, comment);
+        if (!res.ok) {
+          await fallbackAnnotateWithContentControl(target, comment.replace(COMMENT_PREFIX, "").trim());
+        }
 
       } else {
         console.warn('[applyOpsTracked] match not found', { snippet, occIdx });
@@ -1182,7 +1185,10 @@ async function onAcceptAll() {
       const range = ctx.document.getSelection();
       (ctx.document as any).trackRevisions = true;
       range.insertText(proposed, Word.InsertLocation.replace);
-      try { await safeInsertComment(range, `${COMMENT_PREFIX} ${link}`); } catch {}
+      const res = await safeInsertComment(range, `${COMMENT_PREFIX} ${link}`);
+      if (!res.ok) {
+        await fallbackAnnotateWithContentControl(range, link);
+      }
       await ctx.sync();
     });
 

--- a/word_addin_dev/app/__tests__/applyOpsTracked.long.spec.ts
+++ b/word_addin_dev/app/__tests__/applyOpsTracked.long.spec.ts
@@ -11,7 +11,7 @@ vi.mock('../assets/pending.ts', async () => {
 
 vi.mock('../assets/annotate.ts', async () => {
   const actual = await vi.importActual('../assets/annotate.ts')
-  return { ...actual, COMMENT_PREFIX: '[CAI]', safeInsertComment: vi.fn() }
+  return { ...actual, COMMENT_PREFIX: '[CAI]', safeInsertComment: vi.fn(), fallbackAnnotateWithContentControl: vi.fn() }
 })
 
 const innerRange: any = {}

--- a/word_addin_dev/app/assets/__tests__/fallbackAnnotateWithContentControl.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/fallbackAnnotateWithContentControl.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fallbackAnnotateWithContentControl } from '../annotate.ts';
+
+;(globalThis as any).Word = { InsertLocation: { end: 'end' } } as any;
+
+describe('fallbackAnnotateWithContentControl', () => {
+  it('skips when content control already exists', async () => {
+    const range: any = {
+      context: { sync: vi.fn().mockResolvedValue(undefined) },
+      load: vi.fn(),
+      parentContentControl: { tag: 'cai-note' }
+    };
+    const res = await fallbackAnnotateWithContentControl(range, 'hi');
+    expect(res.ok).toBe(false);
+    expect(range.load).toHaveBeenCalledWith('parentContentControl');
+  });
+
+  it('inserts new content control when missing', async () => {
+    const cc: any = { insertText: vi.fn() };
+    const range: any = {
+      context: { sync: vi.fn().mockResolvedValue(undefined) },
+      load: vi.fn(),
+      insertContentControl: vi.fn(() => cc)
+    };
+    const res = await fallbackAnnotateWithContentControl(range, 'note');
+    expect(res.ok).toBe(true);
+    expect(range.insertContentControl).toHaveBeenCalled();
+    expect(cc.tag).toBe('cai-note');
+    expect(cc.title).toBe('ContractAI Note');
+    expect(cc.insertText).toHaveBeenCalledWith('CAI: note', Word.InsertLocation.end);
+  });
+});

--- a/word_addin_dev/app/assets/__tests__/safeInsertComment.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/safeInsertComment.spec.ts
@@ -21,8 +21,9 @@ describe('safeInsertComment', () => {
     vi.stubGlobal('logRichError', logRichError);
     vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await expect(safeInsertComment(range, 'oops')).rejects.toThrow('fail');
+    const res = await safeInsertComment(range, 'oops');
 
+    expect(res.ok).toBe(false);
     expect(notifyWarn).toHaveBeenCalledWith('Failed to insert comment');
     expect(logRichError).toHaveBeenCalled();
   });

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -8,7 +8,7 @@ export interface CommentItem {
   message: string;
 }
 
-export async function safeInsertComment(range: Word.Range, text: string) {
+export async function safeInsertComment(range: Word.Range, text: string): Promise<{ ok: boolean; err?: any }> {
   const context: any = (range as any).context;
   let lastErr: any = null;
   try {
@@ -16,13 +16,13 @@ export async function safeInsertComment(range: Word.Range, text: string) {
     if (anyDoc?.comments?.add) {
       anyDoc.comments.add(range, text);
       await context?.sync?.();
-      return;
+      return { ok: true };
     }
   } catch (e) { lastErr = e; }
   try {
     range.insertComment(text);
     await context?.sync?.();
-    return;
+    return { ok: true };
   } catch (e) { lastErr = e; }
   try {
     await context?.sync?.();
@@ -30,14 +30,40 @@ export async function safeInsertComment(range: Word.Range, text: string) {
     if (anyDoc?.comments?.add) {
       anyDoc.comments.add(range, text);
       await context?.sync?.();
-      return;
+      return { ok: true };
     }
   } catch (e) { lastErr = e; }
   const g: any = globalThis as any;
   console.warn("safeInsertComment failed", lastErr);
   g.logRichError?.(lastErr, "insertComment");
   g.notifyWarn?.("Failed to insert comment");
-  throw lastErr;
+  return { ok: false, err: lastErr };
+}
+
+export async function fallbackAnnotateWithContentControl(range: Word.Range, text: string): Promise<{ ok: boolean }> {
+  const ctx: any = (range as any).context;
+  try {
+    range.load?.("parentContentControl");
+    await ctx?.sync?.();
+  } catch {}
+  try {
+    const parent: any = (range as any).parentContentControl;
+    if (parent && parent.tag === "cai-note") {
+      return { ok: false };
+    }
+  } catch {}
+  try {
+    const cc: any = range.insertContentControl();
+    cc.tag = "cai-note";
+    cc.title = "ContractAI Note";
+    try { cc.color = "yellow" as any; } catch {}
+    cc.insertText(`CAI: ${text}`, Word.InsertLocation.end);
+    await ctx?.sync?.();
+    return { ok: true };
+  } catch (e) {
+    console.warn("fallbackAnnotateWithContentControl failed", e);
+    return { ok: false };
+  }
 }
 
 /**
@@ -54,21 +80,21 @@ export async function insertComments(ctx: any, items: CommentItem[]): Promise<nu
   for (const it of items) {
     let r = it.range;
     const msg = it.message;
-    try {
-      await safeInsertComment(r, msg);
-      inserted++;
-    } catch (e: any) {
-      if (String(e).includes("0xA7210002")) {
-        try {
-          r = r.expandTo ? r.expandTo(ctx.document.body) : r;
-          await safeInsertComment(r, msg);
-          inserted++;
-        } catch (e2) {
-          console.warn("annotate retry failed", e2);
-        }
-      } else {
-        console.warn("annotate error", e);
+    let res = await safeInsertComment(r, msg);
+    if (!res.ok && res.err && String(res.err).includes("0xA7210002")) {
+      try {
+        r = r.expandTo ? r.expandTo(ctx.document.body) : r;
+        res = await safeInsertComment(r, msg);
+      } catch (e2) {
+        res = { ok: false, err: e2 };
+        console.warn("annotate retry failed", e2);
       }
+    }
+    if (res.ok) {
+      inserted++;
+    } else {
+      const fb = await fallbackAnnotateWithContentControl(r, msg.replace(COMMENT_PREFIX, "").trim());
+      if (fb.ok) inserted++;
     }
   }
   return inserted;
@@ -198,13 +224,21 @@ export async function annotateFindingsIntoWord(findings: AnalyzeFinding[]): Prom
           console.warn("[annotate] overlapping range", { rid: op.rule_id, start, end });
           continue;
         }
+        let ok = false;
         if (isDryRunAnnotateEnabled()) {
-          try { target.select(); } catch {}
+          try { target.select(); ok = true; } catch {}
         } else if (op.msg) {
-          await safeInsertComment(target, op.msg);
+          const res = await safeInsertComment(target, op.msg);
+          if (res.ok) ok = true;
+          else {
+            const fb = await fallbackAnnotateWithContentControl(target, op.msg.replace(COMMENT_PREFIX, "").trim());
+            ok = fb.ok;
+          }
         }
-        used.push({ start, end });
-        inserted++;
+        if (ok) {
+          used.push({ start, end });
+          inserted++;
+        }
       } else {
         console.warn("[annotate] no match for snippet", { rid: op.rule_id, snippet: op.raw.slice(0, 120) });
       }

--- a/word_addin_dev/app/src/panel/state.spec.ts
+++ b/word_addin_dev/app/src/panel/state.spec.ts
@@ -9,10 +9,12 @@ vi.mock('../assets/api-client.ts', () => ({
   postJSON: vi.fn(async () => ({ plainText: '', ops: [] }))
 }));
 const safeInsertMock = vi.fn()
-  .mockRejectedValueOnce(new Error('fail'))
-  .mockResolvedValue(undefined);
+  .mockResolvedValueOnce({ ok: false, err: new Error('fail') })
+  .mockResolvedValue({ ok: true });
 vi.mock('../assets/annotate.ts', () => ({
-  safeInsertComment: (...args: any[]) => safeInsertMock(...args)
+  safeInsertComment: (...args: any[]) => safeInsertMock(...args),
+  COMMENT_PREFIX: '[CAI]',
+  fallbackAnnotateWithContentControl: vi.fn()
 }));
 
 describe('navigation', () => {


### PR DESCRIPTION
## Summary
- add `fallbackAnnotateWithContentControl` to wrap ranges in `cai-note` content controls when comments fail
- call fallback when comment insertion isn't supported
- adjust tests and add coverage for content control fallback

## Testing
- `npm test` *(fails: missing DOM elements)*
- `npx vitest run app/assets/__tests__/fallbackAnnotateWithContentControl.spec.ts`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c82a812e188325872154779ef83907