### PR TITLE
fix(panel): disable annotate/accept buttons without comments API

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/ui-gating.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/ui-gating.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+
+function stubEl(id: string) {
+  const listeners: Record<string, Function[]> = {};
+  return {
+    id,
+    disabled: true,
+    title: '',
+    value: '',
+    textContent: '',
+    style: {} as any,
+    classList: { remove() {}, add() {} },
+    addEventListener(type: string, fn: any) {
+      (listeners[type] ||= []).push(fn);
+    },
+    removeAttribute(name: string) {
+      if (name === 'disabled') this.disabled = false;
+    },
+    setAttribute() {},
+    dispatchEvent(ev: any) {
+      (listeners[ev.type] || []).forEach(fn => fn(ev));
+      return true;
+    },
+    click() {
+      if (this.disabled) return;
+      (listeners['click'] || []).forEach(fn => fn({ preventDefault() {} }));
+    },
+  } as any;
+}
+
+describe('UI gating without comments API', () => {
+  it('disables annotate/accept and prevents actions', async () => {
+    const elements: Record<string, any> = {};
+    const doc: any = {
+      readyState: 'complete',
+      getElementById(id: string) { return elements[id] || (elements[id] = stubEl(id)); },
+      querySelector(sel: string) { return this.getElementById(sel.replace('#', '')); },
+      createElement(tag: string) { return stubEl(tag); },
+      body: { innerHTML: '', appendChild() {} },
+      addEventListener() {},
+    };
+    (globalThis as any).document = doc;
+    (globalThis as any).window = { addEventListener() {}, dispatchEvent() {} } as any;
+    (globalThis as any).localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} } as any;
+    const wordRun = vi.fn();
+    (globalThis as any).Word = { run: wordRun } as any;
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false }, document: { addHandlerAsync() {} } }, onReady: () => {} } as any;
+    const fetchMock = vi.fn();
+    (globalThis as any).fetch = fetchMock;
+    const annotateMock = vi.fn();
+    (globalThis as any).annotateFindingsIntoWord = annotateMock;
+    const safeInsertMock = vi.fn();
+    (globalThis as any).safeInsertComment = safeInsertMock;
+    const notifyWarn = vi.fn();
+    vi.doMock('../notifier', () => ({ notifyOk: vi.fn(), notifyErr: vi.fn(), notifyWarn }));
+    (globalThis as any).__CAI_TESTING__ = true;
+    const mod = await import('../taskpane.ts');
+    (globalThis as any).__CAI_TESTING__ = false;
+    mod.wireUI();
+    const annotateBtn = elements['btnAnnotate'];
+    const acceptBtn = elements['btnAcceptAll'];
+    expect(annotateBtn.disabled).toBe(true);
+    expect(acceptBtn.disabled).toBe(true);
+    expect(notifyWarn).toHaveBeenCalledWith('Comments API not available in this Word build');
+    annotateBtn.click();
+    acceptBtn.click();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(annotateMock).not.toHaveBeenCalled();
+    expect(safeInsertMock).not.toHaveBeenCalled();
+    expect(wordRun).not.toHaveBeenCalled();
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/supports.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/supports.ts
@@ -3,16 +3,18 @@ export type FeatureSupport = {
   comments: boolean;
   search: boolean;
   contentControls: boolean;
+  commentsReason: string;
 };
 
 export function detectSupports(): FeatureSupport {
-  const req = !!(globalThis as any).Office?.context?.requirements?.isSetSupported?.('WordApi','1.4');
+  const req = !!(globalThis as any).Office?.context?.requirements?.isSetSupported?.('WordApi', '1.4');
   const w: any = (globalThis as any).Word || {};
   const rev = req && !!w?.Revision;
-  const com = req && !!w?.Comment;
   const srch = req && !!w?.SearchOptions;
   const cc = req && !!w?.ContentControl;
-  return { revisions: rev, comments: com, search: srch, contentControls: cc };
+  const com = req;
+  const reason = req ? 'WordApi 1.4' : 'WordApi < 1.4';
+  return { revisions: rev, comments: com, search: srch, contentControls: cc, commentsReason: reason };
 }
 
 export const supports = {

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1357,7 +1357,11 @@ export function wireUI() {
   updateAnchorBadge();
 
   if (!s.revisions) { disable('btnApplyTracked', 'revisions'); disable('btnAcceptAll', 'revisions'); disable('btnRejectAll', 'revisions'); }
-  if (!s.comments) { disable('btnAcceptAll', s.commentsReason); }
+  if (!s.comments) {
+    disable('btnAnnotate', 'comments');
+    disable('btnAcceptAll', s.commentsReason);
+    notifyWarn('Comments API not available in this Word build');
+  }
   if (!s.search) { disable('btnPrevIssue', 'search'); disable('btnNextIssue', 'search'); disable('btnQARecheck', 'search'); }
   if (!s.contentControls) { disable('btnAnnotate', 'contentControls'); }
   if (!s.revisions || !s.comments || !s.search || !s.contentControls) {

--- a/word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts
+++ b/word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts
@@ -31,7 +31,7 @@ describe('qa recheck navigation', () => {
 
   it('qa recheck replaces findings with api response', async () => {
     const qaResp = { analysis: { findings: [{ rule_id: 'r1', snippet: 'A', start: 0, end: 1 }] } };
-    const postJSON = vi.fn(async (_: string, body: any) => ({ json: qaResp }));
+    const postJSON = vi.fn(async () => ({ json: qaResp }));
     vi.doMock('../assets/api-client.ts', () => ({
       postJSON,
       applyMetaToBadges: () => {},

--- a/word_addin_dev/app/assets/__tests__/supports.test.ts
+++ b/word_addin_dev/app/assets/__tests__/supports.test.ts
@@ -16,10 +16,10 @@ describe('comments support detection', () => {
     delete (globalThis as any).Office;
   });
 
-  it('uses Word.Comment when requirement set is unsupported', () => {
+  it('requires WordApi 1.4 regardless of Word.Comment', () => {
     (globalThis as any).Word = { Comment: function() {} };
     (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false } } };
-    expect(detectSupports().comments).toBe(true);
+    expect(detectSupports().comments).toBe(false);
   });
 
   it('respects localStorage override', () => {

--- a/word_addin_dev/app/assets/__tests__/ui-gating.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/ui-gating.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+
+function stubEl(id: string) {
+  const listeners: Record<string, Function[]> = {};
+  return {
+    id,
+    disabled: true,
+    title: '',
+    value: '',
+    textContent: '',
+    style: {} as any,
+    classList: { remove() {}, add() {} },
+    addEventListener(type: string, fn: any) {
+      (listeners[type] ||= []).push(fn);
+    },
+    removeAttribute(name: string) {
+      if (name === 'disabled') this.disabled = false;
+    },
+    setAttribute() {},
+    dispatchEvent(ev: any) {
+      (listeners[ev.type] || []).forEach(fn => fn(ev));
+      return true;
+    },
+    click() {
+      if (this.disabled) return;
+      (listeners['click'] || []).forEach(fn => fn({ preventDefault() {} }));
+    },
+  } as any;
+}
+
+describe('UI gating without comments API', () => {
+  it('disables annotate/accept and prevents actions', async () => {
+    const elements: Record<string, any> = {};
+    const doc: any = {
+      readyState: 'complete',
+      getElementById(id: string) { return elements[id] || (elements[id] = stubEl(id)); },
+      querySelector(sel: string) { return this.getElementById(sel.replace('#', '')); },
+      createElement(tag: string) { return stubEl(tag); },
+      body: { innerHTML: '', appendChild() {} },
+      addEventListener() {},
+    };
+    (globalThis as any).document = doc;
+    (globalThis as any).window = { addEventListener() {}, dispatchEvent() {} } as any;
+    (globalThis as any).localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} } as any;
+    const wordRun = vi.fn();
+    (globalThis as any).Word = { run: wordRun } as any;
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false }, document: { addHandlerAsync() {} } }, onReady: () => {} } as any;
+    const fetchMock = vi.fn();
+    (globalThis as any).fetch = fetchMock;
+    const annotateMock = vi.fn();
+    (globalThis as any).annotateFindingsIntoWord = annotateMock;
+    const safeInsertMock = vi.fn();
+    (globalThis as any).safeInsertComment = safeInsertMock;
+    const notifyWarn = vi.fn();
+    vi.doMock('../notifier', () => ({ notifyOk: vi.fn(), notifyErr: vi.fn(), notifyWarn }));
+    (globalThis as any).__CAI_TESTING__ = true;
+    const mod = await import('../taskpane.ts');
+    (globalThis as any).__CAI_TESTING__ = false;
+    mod.wireUI();
+    const annotateBtn = elements['btnAnnotate'];
+    const acceptBtn = elements['btnAcceptAll'];
+    expect(annotateBtn.disabled).toBe(true);
+    expect(acceptBtn.disabled).toBe(true);
+    expect(notifyWarn).toHaveBeenCalledWith('Comments API not available in this Word build');
+    annotateBtn.click();
+    acceptBtn.click();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(annotateMock).not.toHaveBeenCalled();
+    expect(safeInsertMock).not.toHaveBeenCalled();
+    expect(wordRun).not.toHaveBeenCalled();
+  });
+});

--- a/word_addin_dev/app/assets/supports.ts
+++ b/word_addin_dev/app/assets/supports.ts
@@ -15,21 +15,8 @@ export function detectSupports(): FeatureSupport {
 
   const ls = (globalThis as any).localStorage;
   const override = ls?.getItem?.('cai.force.comments') === '1';
-  let comments = false;
-  let reason = 'unsupported';
-  if (override) {
-    comments = true;
-    reason = 'dev override';
-  } else if (w?.Comment) {
-    comments = true;
-    reason = 'Word.Comment available';
-  } else if (req) {
-    comments = true;
-    reason = 'WordApi 1.4';
-  } else {
-    comments = false;
-    reason = 'Word.Comment missing';
-  }
+  const comments = override || req;
+  const reason = override ? 'dev override' : req ? 'WordApi 1.4' : 'WordApi < 1.4';
 
   return { revisions: rev, comments, search: srch, contentControls: cc, commentsReason: reason };
 }

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1352,7 +1352,11 @@ export function wireUI() {
   updateAnchorBadge();
 
   if (!s.revisions) { disable('btnApplyTracked', 'revisions'); disable('btnAcceptAll', 'revisions'); disable('btnRejectAll', 'revisions'); }
-  if (!s.comments) { disable('btnAcceptAll', s.commentsReason); }
+  if (!s.comments) {
+    disable('btnAnnotate', 'comments');
+    disable('btnAcceptAll', s.commentsReason);
+    notifyWarn('Comments API not available in this Word build');
+  }
   if (!s.search) { disable('btnPrevIssue', 'search'); disable('btnNextIssue', 'search'); disable('btnQARecheck', 'search'); }
   if (!s.contentControls) { disable('btnAnnotate', 'contentControls'); }
   if (!s.revisions || !s.comments || !s.search || !s.contentControls) {


### PR DESCRIPTION
## Summary
- expose `supports.comments` based on WordApi 1.4
- disable Annotate/Accept buttons when Comments API missing and warn user
- add tests for UI gating

## Testing
- `pre-commit run --files contract_review_app/contract_review_app/static/panel/app/assets/supports.ts contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/ui-gating.spec.ts word_addin_dev/app/assets/supports.ts word_addin_dev/app/assets/taskpane.ts word_addin_dev/app/assets/__tests__/ui-gating.spec.ts word_addin_dev/app/assets/__tests__/supports.test.ts word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts`
- `npm test` *(fails: 14 failed tests)*
- `npx vitest run app/assets/__tests__/ui-gating.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c82a8ebdec8325ae221f28abbf3a8d