### PR TITLE
test: guard to ensure no raw comment insertion in bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "scripts": {
     "build:panel": "python tools/build_panel.py --run-tests",
-    "panel:dev:sync": "python tools/panel_dev_sync.py"
+    "panel:dev:sync": "python tools/panel_dev_sync.py",
+    "guard:no-raw-comments": "pwsh ./scripts/guard_no_raw_comments.ps1",
+    "test": "pwsh ./run_tests.ps1"
   },
   "devDependencies": {
     "ts-node": "^10.9.2"

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,3 +1,8 @@
+$ErrorActionPreference = "Stop"
+
+& "$PSScriptRoot/scripts/guard_no_raw_comments.ps1"
+if (!$?) { exit 1 }
+
 Get-ChildItem -Recurse -Filter '__pycache__' | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 pytest
 if ($LASTEXITCODE -eq 0) {

--- a/scripts/guard_no_raw_comments.ps1
+++ b/scripts/guard_no_raw_comments.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = "Stop"
+
+# Locate all bundle.js files excluding node_modules
+$root = Join-Path $PSScriptRoot ".."
+$bundles = Get-ChildItem -Path $root -Recurse -Filter "*bundle.js" -File |
+    Where-Object { $_.FullName -notmatch "node_modules" }
+
+foreach ($file in $bundles) {
+    if (Select-String -Path $file.FullName -Pattern '/\*' -Quiet) {
+        Write-Error "Raw comments detected in bundle $($file.FullName)"
+        exit 1
+    }
+}
+
+Write-Host "No raw comments found in bundles."


### PR DESCRIPTION
## Summary
- add PowerShell script to scan JS bundles for block comments
- run guard before tests and expose npm script hooks

## Testing
- `npm test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c82ae504448325b7d40063320c0e71