### PR TITLE
feat(panel): gate comments API and handle NotImplemented in safeInsertComment

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -439,7 +439,12 @@ export async function applyOpsTracked(
           }
         }
         const comment = `${COMMENT_PREFIX} ${op.rationale || op.source || 'AI edit'}`;
-        const ok = await safeInsertComment(target, comment);
+        let ok = false;
+        try {
+          ok = await safeInsertComment(target, comment);
+        } catch (e) {
+          console.warn('[applyOpsTracked] safeInsertComment failed', e);
+        }
         if (!ok) { /* noop */ }
 
       } else {
@@ -1183,7 +1188,12 @@ async function onAcceptAll() {
       const range = ctx.document.getSelection();
       (ctx.document as any).trackRevisions = true;
       range.insertText(proposed, Word.InsertLocation.replace);
-      const ok = await safeInsertComment(range, `${COMMENT_PREFIX} ${link}`);
+      let ok = false;
+      try {
+        ok = await safeInsertComment(range, `${COMMENT_PREFIX} ${link}`);
+      } catch (e) {
+        console.warn('[onAcceptAll] safeInsertComment failed', e);
+      }
       if (!ok) { /* noop */ }
       await ctx.sync();
     });

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -439,7 +439,12 @@ export async function applyOpsTracked(
           }
         }
         const comment = `${COMMENT_PREFIX} ${op.rationale || op.source || 'AI edit'}`;
-        const ok = await safeInsertComment(target, comment);
+        let ok = false;
+        try {
+          ok = await safeInsertComment(target, comment);
+        } catch (e) {
+          console.warn('[applyOpsTracked] safeInsertComment failed', e);
+        }
         if (!ok) { /* noop */ }
 
       } else {
@@ -1176,7 +1181,12 @@ async function onAcceptAll() {
       const range = ctx.document.getSelection();
       (ctx.document as any).trackRevisions = true;
       range.insertText(proposed, Word.InsertLocation.replace);
-      const ok = await safeInsertComment(range, `${COMMENT_PREFIX} ${link}`);
+      let ok = false;
+      try {
+        ok = await safeInsertComment(range, `${COMMENT_PREFIX} ${link}`);
+      } catch (e) {
+        console.warn('[onAcceptAll] safeInsertComment failed', e);
+      }
       if (!ok) { /* noop */ }
       await ctx.sync();
     });


### PR DESCRIPTION
## Summary
- guard `safeInsertComment` failures in `applyOpsTracked`
- handle `safeInsertComment` errors in `onAcceptAll`

## Testing
- `pnpm --dir word_addin_dev test` *(fails: ERR, 14 failed)*
- `pnpm --dir contract_review_app test` *(fails: No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_68c82ca645308325a53e2837b5e631e4