### PR TITLE
Add timeout parameter to dev add-in manifest

### DIFF
--- a/word_addin_dev/manifest.xml
+++ b/word_addin_dev/manifest.xml
@@ -27,7 +27,7 @@
 
   <DefaultSettings>
     <!-- dev panel served by serve_https_panel.py -->
-    <SourceLocation DefaultValue="https://127.0.0.1:9443/panel/taskpane.html?v=dev&amp;b=build-20250915-174338"/>
+    <SourceLocation DefaultValue="https://127.0.0.1:9443/panel/taskpane.html?timeout_analyze=30000" />
   </DefaultSettings>
 
   <Requirements>


### PR DESCRIPTION
## Summary
- update the development Word add-in manifest to include the timeout_analyze parameter in the task pane source URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac250a03c8325a0353e0097a591f5