### PR TITLE
Add PowerShell backup automation and manual workflow

### DIFF
--- a/.github/workflows/manual-backup.yml
+++ b/.github/workflows/manual-backup.yml
@@ -1,0 +1,53 @@
+name: Manual backup
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'Optional label to append to the backup archive name'
+        required: false
+        default: ''
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Scan for secrets
+        shell: pwsh
+        run: pwsh -File tools/backup/scan_secrets.ps1
+
+      - name: Create backup
+        shell: pwsh
+        run: |
+          $label = '${{ inputs.label }}'
+          if ([string]::IsNullOrWhiteSpace($label)) {
+            pwsh -File tools/backup/backup.ps1
+          } else {
+            pwsh -File tools/backup/backup.ps1 -Label $label
+          }
+
+      - name: Collect backup artifacts
+        shell: pwsh
+        run: |
+          $manifest = Get-ChildItem -Path "reports/backups" -Filter "backup_*.manifest.json" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $manifest) {
+            throw "Manifest file was not generated."
+          }
+          $zipPattern = "$($manifest.BaseName)*.zip"
+          $archive = Get-ChildItem -Path "_backups" -Filter $zipPattern | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $archive) {
+            throw "Backup archive matching $zipPattern was not found."
+          }
+          Add-Content -Path $env:GITHUB_ENV -Value "archive=$($archive.FullName)"
+          Add-Content -Path $env:GITHUB_ENV -Value "manifest=$($manifest.FullName)"
+
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repository-backup
+          path: |
+            ${{ env.archive }}
+            ${{ env.manifest }}

--- a/tools/backup/.backup-exclude.txt
+++ b/tools/backup/.backup-exclude.txt
@@ -1,0 +1,28 @@
+# секреты
+.env
+.env.*
+*.env
+*.env.*
+**/secrets/**
+dev/localhost.key
+**/private_key/**
+**/*.pfx
+**/*.pem
+**/*.key
+
+# мусор и кэш
+.venv/**
+venv/**
+**/__pycache__/**
+**/.pytest_cache/**
+**/.mypy_cache/**
+**/.DS_Store
+**/node_modules/**
+
+# внутренности git/ci
+.git/**
+.github/workflows/*-secrets*.yml
+
+# внутренние артефакты бэкапа
+_backups/**
+reports/backups/**

--- a/tools/backup/README.md
+++ b/tools/backup/README.md
@@ -1,0 +1,14 @@
+# Backup Utility
+
+Скрипты в этой папке создают безопасный архив текущего состояния репозитория без включения секретов.
+
+## Команды
+
+# Локальная проверка (сухой прогон)
+pwsh -File tools/backup/backup.ps1 -DryRun
+
+# Локальный бэкап
+pwsh -File tools/backup/backup.ps1 -Label "pre-change"
+
+# Запуск в GitHub Actions
+gh workflow run manual-backup.yml -f label=pre-change

--- a/tools/backup/backup.ps1
+++ b/tools/backup/backup.ps1
@@ -1,0 +1,171 @@
+[CmdletBinding()]
+param(
+    [string]$Label,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+$repoRoot = [System.IO.Path]::TrimEndingDirectorySeparator((Resolve-Path -Path (Join-Path $scriptDir '..\..')).Path)
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+
+Write-Host "Repository root: $repoRoot"
+if ($Label) {
+    Write-Host "Requested label: $Label"
+}
+if ($DryRun) {
+    Write-Host "Running in dry-run mode."
+}
+
+# Run secret scan before proceeding
+$scanScript = Join-Path $scriptDir 'scan_secrets.ps1'
+if (-not (Test-Path -LiteralPath $scanScript)) {
+    throw "Secret scan script not found at $scanScript"
+}
+
+& pwsh -NoLogo -NoProfile -File $scanScript
+$scanExitCode = $LASTEXITCODE
+if ($scanExitCode -eq 2) {
+    Write-Error "Secret patterns detected. Backup aborted."
+    exit 2
+} elseif ($scanExitCode -ne 0) {
+    Write-Error "Secret scan failed with exit code $scanExitCode."
+    exit $scanExitCode
+}
+
+$excludeFile = Join-Path $scriptDir '.backup-exclude.txt'
+if (-not (Test-Path -LiteralPath $excludeFile)) {
+    throw "Exclude file not found at $excludeFile"
+}
+
+function Convert-PatternToRegex {
+    param(
+        [string]$Pattern
+    )
+    $normalized = $Pattern.Trim()
+    $normalized = $normalized -replace '\\', '/'
+    $normalized = $normalized.TrimStart('/')
+    if ($normalized.Length -eq 0) {
+        return '^$'
+    }
+    $escaped = [regex]::Escape($normalized)
+    $escaped = $escaped -replace '\\\*\\\*', '.*'
+    $escaped = $escaped -replace '\\\*', '[^/]*'
+    $escaped = $escaped -replace '\\\?', '[^/]'
+    return '^' + $escaped + '$'
+}
+
+$excludePatterns = @()
+Get-Content -LiteralPath $excludeFile | ForEach-Object {
+    $line = $_.Trim()
+    if (-not $line -or $line.StartsWith('#')) { return }
+    $regexPattern = Convert-PatternToRegex -Pattern $line
+    $excludePatterns += [pscustomobject]@{
+        Pattern = $line
+        Regex   = [regex]::new($regexPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    }
+}
+
+$repoRootWithSep = [System.IO.Path]::TrimEndingDirectorySeparator($repoRoot)
+
+$allFiles = Get-ChildItem -Path $repoRoot -File -Recurse
+$included = @()
+$excluded = @()
+
+foreach ($file in $allFiles) {
+    $relative = $file.FullName.Substring($repoRootWithSep.Length)
+    $relative = $relative.TrimStart([char]'\', [char]'/' )
+    $relativeNormalized = $relative -replace '\\', '/'
+    $matchedPattern = $null
+    foreach ($entry in $excludePatterns) {
+        if ($entry.Regex.IsMatch($relativeNormalized)) {
+            $matchedPattern = $entry.Pattern
+            break
+        }
+    }
+    if ($matchedPattern) {
+        $excluded += [pscustomobject]@{
+            Path    = $relativeNormalized
+            Pattern = $matchedPattern
+        }
+        continue
+    }
+    $included += [pscustomobject]@{
+        Path     = $relativeNormalized
+        FullName = $file.FullName
+        Size     = $file.Length
+    }
+}
+
+Write-Host "Total files discovered: $($allFiles.Count)"
+Write-Host "Included files: $($included.Count)"
+Write-Host "Excluded files: $($excluded.Count)"
+
+if ($DryRun) {
+    Write-Host "--- Included ---"
+    foreach ($item in $included | Sort-Object Path) {
+        Write-Host "  $($item.Path)"
+    }
+    Write-Host "--- Excluded ---"
+    foreach ($item in $excluded | Sort-Object Path) {
+        Write-Host "  $($item.Path) (pattern: $($item.Pattern))"
+    }
+    Write-Host "Dry run complete. No archive or manifest created."
+    exit 0
+}
+
+if ($included.Count -eq 0) {
+    Write-Warning "No files to include in backup."
+    exit 0
+}
+
+$safeLabel = $null
+if ($Label) {
+    $safeLabel = ($Label -replace '[^A-Za-z0-9_\-]+', '_').Trim('_')
+}
+
+$archiveBaseName = "backup_$timestamp"
+if ($safeLabel) {
+    $archiveBaseName += "_" + $safeLabel
+}
+
+$backupDir = Join-Path $repoRoot '_backups'
+$archivePath = Join-Path $backupDir ($archiveBaseName + '.zip')
+New-Item -ItemType Directory -Path $backupDir -Force | Out-Null
+
+$includedPaths = $included | ForEach-Object { $_.Path }
+
+Push-Location -Path $repoRoot
+try {
+    Compress-Archive -Path $includedPaths -DestinationPath $archivePath -CompressionLevel Optimal -Force
+} finally {
+    Pop-Location
+}
+
+Write-Host "Archive created at: $archivePath"
+
+$manifestDir = Join-Path $repoRoot 'reports/backups'
+New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+$manifestPath = Join-Path $manifestDir ("backup_$timestamp.manifest.json")
+
+$manifestFiles = @()
+foreach ($item in $included | Sort-Object Path) {
+    $hash = Get-FileHash -LiteralPath $item.FullName -Algorithm SHA256
+    $manifestFiles += [ordered]@{
+        path   = $item.Path
+        size   = $item.Size
+        sha256 = $hash.Hash.ToLowerInvariant()
+    }
+}
+
+$manifest = [ordered]@{
+    timestamp = $timestamp
+    label     = $Label
+    archive   = (Join-Path '_backups' ($archiveBaseName + '.zip'))
+    files     = $manifestFiles
+}
+
+$manifest | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+
+Write-Host "Manifest written to: $manifestPath"

--- a/tools/backup/scan_secrets.ps1
+++ b/tools/backup/scan_secrets.ps1
@@ -1,0 +1,70 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+$repoRoot = [System.IO.Path]::TrimEndingDirectorySeparator((Resolve-Path -Path (Join-Path $scriptDir '..\..')).Path)
+
+Write-Host "Scanning repository for secret patterns..."
+
+$patterns = @(
+    'sk-[A-Za-z0-9_\-]{20,}',
+    'AZURE_OPENAI_API_KEY\s*[:=]\s*['"'][A-Za-z0-9_\-]{20,}['"']?',
+    'OPENAI_API_KEY\s*[:=]\s*['"'][A-Za-z0-9_\-]{20,}['"']?',
+    '-----BEGIN\s+(RSA|EC)\s+PRIVATE KEY-----',
+    'connection\s*string.*(password|pwd)\s*='
+)
+
+$allFiles = @()
+Push-Location -Path $repoRoot
+try {
+    $tracked = git ls-files 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to list tracked files via git."
+    }
+    $untracked = git ls-files --others --exclude-standard 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to list untracked files via git."
+    }
+    if ($tracked) { $allFiles += $tracked }
+    if ($untracked) { $allFiles += $untracked }
+} finally {
+    Pop-Location
+}
+
+$allFiles = $allFiles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object -Unique
+
+$findings = @()
+foreach ($relativePath in $allFiles) {
+    $fullPath = Join-Path $repoRoot $relativePath
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+        continue
+    }
+    try {
+        $matches = Select-String -Path $fullPath -Pattern $patterns -AllMatches -CaseSensitive:$false
+    } catch {
+        continue
+    }
+    if ($matches) {
+        foreach ($match in $matches) {
+            foreach ($m in $match.Matches) {
+                $findings += [pscustomobject]@{
+                    Path = $relativePath
+                    LineNumber = $match.LineNumber
+                    Value = $m.Value
+                }
+            }
+        }
+    }
+}
+
+if ($findings.Count -gt 0) {
+    Write-Host "Potential secret patterns detected:" -ForegroundColor Red
+    foreach ($finding in $findings) {
+        Write-Host "  $($finding.Path):$($finding.LineNumber): $($finding.Value)"
+    }
+    exit 2
+}
+
+Write-Host "No secret patterns detected."


### PR DESCRIPTION
## Summary
- add PowerShell scripts to scan for secrets and create timestamped backup archives with manifests
- track backup exclusions and usage documentation for local runs
- wire up a manually triggered GitHub Actions workflow to execute the backup and publish artifacts

## Testing
- `pwsh -File tools/backup/backup.ps1 -DryRun` *(fails in container: pwsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cad0d83b848325b694e517c127034b