### PR TITLE
Adjust glob handling for segment-only patterns

### DIFF
--- a/tools/backup/scan_secrets.ps1
+++ b/tools/backup/scan_secrets.ps1
@@ -35,7 +35,12 @@ function Convert-PatternToRegex {
     $escaped = $escaped -replace '\\\*\\\*', '.*'
     $escaped = $escaped -replace '\\\*', '[^/]*'
     $escaped = $escaped -replace '\\\?', '[^/]'
-    return '^' + $escaped + '$'
+
+    if ($normalized.Contains('/')) {
+        return '^' + $escaped + '$'
+    }
+
+    return '(^|.*/)' + $escaped + '$'
 }
 
 $excludePatterns = @()


### PR DESCRIPTION
## Summary
- update the backup secret scan glob translation so patterns without slashes match any path segment

## Testing
- not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb01d2f980832587f9011787f9ae3a