### PR TITLE
Add contract response contract tests

### DIFF
--- a/tests/contract/fixtures/basic.txt
+++ b/tests/contract/fixtures/basic.txt
@@ -1,0 +1,1 @@
+This Agreement is made between Alpha Corp and Beta Ltd. The parties agree to keep all information confidential and comply with applicable law.

--- a/tests/contract/fixtures/expected/basic.json
+++ b/tests/contract/fixtures/expected/basic.json
@@ -1,0 +1,218 @@
+{
+  "analysis": {
+    "findings": [],
+    "status": "ok"
+  },
+  "clauses": [],
+  "document": {},
+  "findings": [],
+  "meta": {
+    "active_packs": [],
+    "document_type": "unknown",
+    "fired_rules": [],
+    "language": "en-GB",
+    "model": "mock-static",
+    "provider": "mock",
+    "rules_evaluated": 0,
+    "rules_fired_count": 0,
+    "rules_loaded_count": 0,
+    "text_bytes": 142,
+    "valid_config": true
+  },
+  "recommendations": [],
+  "results": {
+    "summary": {
+      "carveouts": {
+        "carveouts": [
+          "confidentiality"
+        ],
+        "has_carveouts": true,
+        "list": [
+          "confidentiality"
+        ]
+      },
+      "clause_type": "confidentiality",
+      "conditions_vs_warranties": {
+        "explicit_conditions": [],
+        "explicit_warranties": [],
+        "has_conditions": false,
+        "has_warranties": false
+      },
+      "currency": null,
+      "dates": {
+        "commencement": null,
+        "dated": null,
+        "effective": null
+      },
+      "debug": {
+        "doctype_top": [
+          {
+            "score": 0.0,
+            "type": "NDA"
+          },
+          {
+            "score": 0.0,
+            "type": "MSA (Services)"
+          },
+          {
+            "score": 0.0,
+            "type": "Supply of Goods"
+          },
+          {
+            "score": 0.0,
+            "type": "DPA"
+          },
+          {
+            "score": 0.0,
+            "type": "License (IP)"
+          }
+        ]
+      },
+      "doc_type": {
+        "candidates": [
+          {
+            "score": 0.0,
+            "type": "unknown"
+          }
+        ],
+        "confidence": 0.0,
+        "top": {
+          "score": 0.0,
+          "type": "unknown"
+        }
+      },
+      "exclusivity": null,
+      "governing_law": null,
+      "hints": [
+        "confidentiality"
+      ],
+      "jurisdiction": null,
+      "liability": {
+        "cap_currency": null,
+        "cap_value": null,
+        "has_cap": false,
+        "notes": null
+      },
+      "parties": [
+        {
+          "name": "Alpha Corp"
+        },
+        {
+          "name": "Beta Ltd"
+        }
+      ],
+      "rules_count": 176,
+      "signatures": [],
+      "term": {
+        "end": null,
+        "mode": "unknown",
+        "renew_notice": null,
+        "start": null
+      },
+      "type": "unknown",
+      "type_confidence": 0.0,
+      "type_source": null
+    }
+  },
+  "rules_coverage": {
+    "doc_type": {
+      "source": null,
+      "value": "unknown"
+    },
+    "rules": []
+  },
+  "schema_version": "1.4",
+  "status": "ok",
+  "summary": {
+    "carveouts": {
+      "carveouts": [
+        "confidentiality"
+      ],
+      "has_carveouts": true,
+      "list": [
+        "confidentiality"
+      ]
+    },
+    "clause_type": "confidentiality",
+    "conditions_vs_warranties": {
+      "explicit_conditions": [],
+      "explicit_warranties": [],
+      "has_conditions": false,
+      "has_warranties": false
+    },
+    "currency": null,
+    "dates": {
+      "commencement": null,
+      "dated": null,
+      "effective": null
+    },
+    "debug": {
+      "doctype_top": [
+        {
+          "score": 0.0,
+          "type": "NDA"
+        },
+        {
+          "score": 0.0,
+          "type": "MSA (Services)"
+        },
+        {
+          "score": 0.0,
+          "type": "Supply of Goods"
+        },
+        {
+          "score": 0.0,
+          "type": "DPA"
+        },
+        {
+          "score": 0.0,
+          "type": "License (IP)"
+        }
+      ]
+    },
+    "doc_type": {
+      "candidates": [
+        {
+          "score": 0.0,
+          "type": "unknown"
+        }
+      ],
+      "confidence": 0.0,
+      "top": {
+        "score": 0.0,
+        "type": "unknown"
+      }
+    },
+    "exclusivity": null,
+    "governing_law": null,
+    "hints": [
+      "confidentiality"
+    ],
+    "jurisdiction": null,
+    "liability": {
+      "cap_currency": null,
+      "cap_value": null,
+      "has_cap": false,
+      "notes": null
+    },
+    "parties": [
+      {
+        "name": "Alpha Corp"
+      },
+      {
+        "name": "Beta Ltd"
+      }
+    ],
+    "rules_count": 176,
+    "signatures": [],
+    "term": {
+      "end": null,
+      "mode": "unknown",
+      "renew_notice": null,
+      "start": null
+    },
+    "type": "unknown",
+    "type_confidence": 0.0,
+    "type_source": null
+  }
+}

--- a/tests/contract/fixtures/expected/governing_law.json
+++ b/tests/contract/fixtures/expected/governing_law.json
@@ -1,0 +1,204 @@
+{
+  "analysis": {
+    "findings": [],
+    "status": "ok"
+  },
+  "clauses": [],
+  "document": {},
+  "findings": [],
+  "meta": {
+    "active_packs": [],
+    "document_type": "Distribution",
+    "fired_rules": [],
+    "language": "en-GB",
+    "model": "mock-static",
+    "provider": "mock",
+    "rules_evaluated": 0,
+    "rules_fired_count": 0,
+    "rules_loaded_count": 0,
+    "text_bytes": 154,
+    "valid_config": true
+  },
+  "recommendations": [],
+  "results": {
+    "summary": {
+      "carveouts": {
+        "carveouts": [],
+        "has_carveouts": false,
+        "list": []
+      },
+      "clause_type": "governing_law",
+      "conditions_vs_warranties": {
+        "explicit_conditions": [],
+        "explicit_warranties": [],
+        "has_conditions": false,
+        "has_warranties": false
+      },
+      "currency": null,
+      "dates": {
+        "commencement": null,
+        "dated": null,
+        "effective": null
+      },
+      "debug": {
+        "doctype_top": [
+          {
+            "score": 1.0,
+            "type": "Distribution"
+          },
+          {
+            "score": 0.0,
+            "type": "NDA"
+          },
+          {
+            "score": 0.0,
+            "type": "MSA (Services)"
+          },
+          {
+            "score": 0.0,
+            "type": "Supply of Goods"
+          },
+          {
+            "score": 0.0,
+            "type": "DPA"
+          }
+        ]
+      },
+      "doc_type": {
+        "candidates": [
+          {
+            "score": 1.0,
+            "type": "Distribution"
+          }
+        ],
+        "confidence": 1.0,
+        "source": "keywords",
+        "top": {
+          "score": 1.0,
+          "type": "Distribution"
+        }
+      },
+      "exclusivity": true,
+      "governing_law": "England and Wales and the parties submit to the exclusive jurisdiction of the courts of England and Wales",
+      "hints": [
+        "exclusive",
+        "governed by the laws of England and Wales and the parties submit to the exclusive jurisdiction of the courts of England and Wales",
+        "jurisdiction of the courts of England and Wales.",
+        "exclusive jurisdiction"
+      ],
+      "jurisdiction": "England and Wales",
+      "liability": {
+        "cap_currency": null,
+        "cap_value": null,
+        "has_cap": false,
+        "notes": null
+      },
+      "parties": [],
+      "rules_count": 176,
+      "signatures": [],
+      "term": {
+        "end": null,
+        "mode": "unknown",
+        "renew_notice": null,
+        "start": null
+      },
+      "type": "Distribution",
+      "type_confidence": 1.0,
+      "type_source": "keywords"
+    }
+  },
+  "rules_coverage": {
+    "doc_type": {
+      "source": "keywords",
+      "value": "Distribution"
+    },
+    "rules": []
+  },
+  "schema_version": "1.4",
+  "status": "ok",
+  "summary": {
+    "carveouts": {
+      "carveouts": [],
+      "has_carveouts": false,
+      "list": []
+    },
+    "clause_type": "governing_law",
+    "conditions_vs_warranties": {
+      "explicit_conditions": [],
+      "explicit_warranties": [],
+      "has_conditions": false,
+      "has_warranties": false
+    },
+    "currency": null,
+    "dates": {
+      "commencement": null,
+      "dated": null,
+      "effective": null
+    },
+    "debug": {
+      "doctype_top": [
+        {
+          "score": 1.0,
+          "type": "Distribution"
+        },
+        {
+          "score": 0.0,
+          "type": "NDA"
+        },
+        {
+          "score": 0.0,
+          "type": "MSA (Services)"
+        },
+        {
+          "score": 0.0,
+          "type": "Supply of Goods"
+        },
+        {
+          "score": 0.0,
+          "type": "DPA"
+        }
+      ]
+    },
+    "doc_type": {
+      "candidates": [
+        {
+          "score": 1.0,
+          "type": "Distribution"
+        }
+      ],
+      "confidence": 1.0,
+      "source": "keywords",
+      "top": {
+        "score": 1.0,
+        "type": "Distribution"
+      }
+    },
+    "exclusivity": true,
+    "governing_law": "England and Wales and the parties submit to the exclusive jurisdiction of the courts of England and Wales",
+    "hints": [
+      "exclusive",
+      "governed by the laws of England and Wales and the parties submit to the exclusive jurisdiction of the courts of England and Wales",
+      "jurisdiction of the courts of England and Wales.",
+      "exclusive jurisdiction"
+    ],
+    "jurisdiction": "England and Wales",
+    "liability": {
+      "cap_currency": null,
+      "cap_value": null,
+      "has_cap": false,
+      "notes": null
+    },
+    "parties": [],
+    "rules_count": 176,
+    "signatures": [],
+    "term": {
+      "end": null,
+      "mode": "unknown",
+      "renew_notice": null,
+      "start": null
+    },
+    "type": "Distribution",
+    "type_confidence": 1.0,
+    "type_source": "keywords"
+  }
+}

--- a/tests/contract/fixtures/expected/payment_terms.json
+++ b/tests/contract/fixtures/expected/payment_terms.json
@@ -1,0 +1,192 @@
+{
+  "analysis": {
+    "findings": [],
+    "status": "ok"
+  },
+  "clauses": [],
+  "document": {},
+  "findings": [],
+  "meta": {
+    "active_packs": [],
+    "document_type": "unknown",
+    "fired_rules": [],
+    "language": "en-GB",
+    "model": "mock-static",
+    "provider": "mock",
+    "rules_evaluated": 0,
+    "rules_fired_count": 0,
+    "rules_loaded_count": 0,
+    "text_bytes": 148,
+    "valid_config": true
+  },
+  "recommendations": [],
+  "results": {
+    "summary": {
+      "carveouts": {
+        "carveouts": [],
+        "has_carveouts": false,
+        "list": []
+      },
+      "clause_type": "invoice",
+      "conditions_vs_warranties": {
+        "explicit_conditions": [],
+        "explicit_warranties": [],
+        "has_conditions": false,
+        "has_warranties": false
+      },
+      "currency": null,
+      "dates": {
+        "commencement": null,
+        "dated": null,
+        "effective": null
+      },
+      "debug": {
+        "doctype_top": [
+          {
+            "score": 0.0,
+            "type": "NDA"
+          },
+          {
+            "score": 0.0,
+            "type": "MSA (Services)"
+          },
+          {
+            "score": 0.0,
+            "type": "Supply of Goods"
+          },
+          {
+            "score": 0.0,
+            "type": "DPA"
+          },
+          {
+            "score": 0.0,
+            "type": "License (IP)"
+          }
+        ]
+      },
+      "doc_type": {
+        "candidates": [
+          {
+            "score": 0.0,
+            "type": "unknown"
+          }
+        ],
+        "confidence": 0.0,
+        "top": {
+          "score": 0.0,
+          "type": "unknown"
+        }
+      },
+      "exclusivity": null,
+      "governing_law": null,
+      "hints": [],
+      "jurisdiction": null,
+      "liability": {
+        "cap_currency": null,
+        "cap_value": null,
+        "has_cap": false,
+        "notes": null
+      },
+      "parties": [],
+      "rules_count": 176,
+      "signatures": [],
+      "term": {
+        "end": null,
+        "mode": "unknown",
+        "renew_notice": null,
+        "start": null
+      },
+      "type": "unknown",
+      "type_confidence": 0.0,
+      "type_source": null
+    }
+  },
+  "rules_coverage": {
+    "doc_type": {
+      "source": null,
+      "value": "unknown"
+    },
+    "rules": []
+  },
+  "schema_version": "1.4",
+  "status": "ok",
+  "summary": {
+    "carveouts": {
+      "carveouts": [],
+      "has_carveouts": false,
+      "list": []
+    },
+    "clause_type": "invoice",
+    "conditions_vs_warranties": {
+      "explicit_conditions": [],
+      "explicit_warranties": [],
+      "has_conditions": false,
+      "has_warranties": false
+    },
+    "currency": null,
+    "dates": {
+      "commencement": null,
+      "dated": null,
+      "effective": null
+    },
+    "debug": {
+      "doctype_top": [
+        {
+          "score": 0.0,
+          "type": "NDA"
+        },
+        {
+          "score": 0.0,
+          "type": "MSA (Services)"
+        },
+        {
+          "score": 0.0,
+          "type": "Supply of Goods"
+        },
+        {
+          "score": 0.0,
+          "type": "DPA"
+        },
+        {
+          "score": 0.0,
+          "type": "License (IP)"
+        }
+      ]
+    },
+    "doc_type": {
+      "candidates": [
+        {
+          "score": 0.0,
+          "type": "unknown"
+        }
+      ],
+      "confidence": 0.0,
+      "top": {
+        "score": 0.0,
+        "type": "unknown"
+      }
+    },
+    "exclusivity": null,
+    "governing_law": null,
+    "hints": [],
+    "jurisdiction": null,
+    "liability": {
+      "cap_currency": null,
+      "cap_value": null,
+      "has_cap": false,
+      "notes": null
+    },
+    "parties": [],
+    "rules_count": 176,
+    "signatures": [],
+    "term": {
+      "end": null,
+      "mode": "unknown",
+      "renew_notice": null,
+      "start": null
+    },
+    "type": "unknown",
+    "type_confidence": 0.0,
+    "type_source": null
+  }
+}

--- a/tests/contract/fixtures/governing_law.txt
+++ b/tests/contract/fixtures/governing_law.txt
@@ -1,0 +1,1 @@
+This Agreement shall be governed by the laws of England and Wales and the parties submit to the exclusive jurisdiction of the courts of England and Wales.

--- a/tests/contract/fixtures/payment_terms.txt
+++ b/tests/contract/fixtures/payment_terms.txt
@@ -1,0 +1,1 @@
+Supplier shall invoice Customer monthly in arrears. Customer shall pay all undisputed amounts within thirty (30) days of receipt of a valid invoice.

--- a/tests/contract/normalizer.py
+++ b/tests/contract/normalizer.py
@@ -1,0 +1,154 @@
+"""Deterministic normalisation helpers for contract API responses."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Iterable, Tuple
+
+_SEVERITY_ORDER = {
+    "critical": 4,
+    "major": 3,
+    "high": 3,
+    "medium": 2,
+    "minor": 1,
+    "low": 1,
+    "info": 0,
+}
+
+_DROP_PATHS: set[Tuple[str, ...]] = {
+    ("cid",),
+    ("meta", "pipeline_id"),
+    ("meta", "timings_ms"),
+    ("meta", "debug"),
+    ("meta", "companies_meta"),
+}
+
+_PARTY_KEYS = {"role", "name"}
+
+
+def normalize_for_diff(payload: Any) -> Any:
+    """Return a deep-copied payload with stable key ordering and list sorting."""
+
+    return _normalize(deepcopy(payload))
+
+
+def _normalize(node: Any, path: Tuple[str, ...] = ()) -> Any:
+    if isinstance(node, dict):
+        return _normalize_dict(node, path)
+    if isinstance(node, list):
+        return _normalize_list(node, path)
+    return node
+
+
+def _normalize_dict(data: dict[str, Any], path: Tuple[str, ...]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key in sorted(data.keys()):
+        next_path = path + (key,)
+        if next_path in _DROP_PATHS:
+            continue
+        value = _normalize(data[key], next_path)
+        if key == "parties" and path and path[-1] == "summary":
+            value = _sanitize_parties(value)
+        result[key] = value
+    return result
+
+
+def _sanitize_parties(value: Any) -> Any:
+    if not isinstance(value, list):
+        return value
+    trimmed: list[dict[str, Any]] = []
+    changed = False
+    for party in value:
+        if not isinstance(party, dict):
+            continue
+        minimal = {k: party[k] for k in _PARTY_KEYS if k in party and party[k] is not None}
+        if set(party.keys()) - _PARTY_KEYS:
+            changed = True
+        if minimal:
+            trimmed.append(minimal)
+    if changed:
+        return trimmed
+    return value
+
+
+def _normalize_list(items: Iterable[Any], path: Tuple[str, ...]) -> list[Any]:
+    normalized = [_normalize(item, path) for item in items]
+    if not path:
+        return normalized
+    key = path[-1]
+    if key == "findings":
+        normalized.sort(key=_finding_sort_key)
+    elif key == "clauses":
+        normalized.sort(key=_clause_sort_key)
+    elif path == ("meta", "active_packs"):
+        normalized = sorted(normalized)
+    elif path == ("meta", "fired_rules"):
+        normalized.sort(key=_fired_rule_key)
+    elif path == ("rules_coverage", "rules"):
+        normalized.sort(key=_coverage_rule_key)
+    elif key == "citations":
+        normalized.sort(key=_citation_sort_key)
+    return normalized
+
+
+def _finding_sort_key(item: Any) -> Tuple[Any, ...]:
+    if not isinstance(item, dict):
+        return ("", 0, 0, "", "")
+    clause = str(item.get("clause_id") or "")
+    start = _coerce_int(item.get("start"))
+    if start == 0 and isinstance(item.get("span"), dict):
+        start = _coerce_int(item["span"].get("start"))
+    severity = -_SEVERITY_ORDER.get(str(item.get("severity", "")).lower(), 0)
+    rule_id = str(item.get("rule_id") or "")
+    snippet_key = str(
+        item.get("normalized_snippet")
+        or item.get("snippet")
+        or item.get("text_hash")
+        or ""
+    )
+    return (clause, start, severity, rule_id, snippet_key)
+
+
+def _clause_sort_key(item: Any) -> Tuple[Any, ...]:
+    if not isinstance(item, dict):
+        return ("", 0)
+    clause_id = str(item.get("id") or item.get("clause_id") or "")
+    start = _coerce_int(item.get("start"))
+    if start == 0 and isinstance(item.get("span"), dict):
+        start = _coerce_int(item["span"].get("start"))
+    return (clause_id, start)
+
+
+def _fired_rule_key(item: Any) -> Tuple[str, str]:
+    if not isinstance(item, dict):
+        return ("", "")
+    name = str(item.get("name") or "")
+    rule_id = str(item.get("rule_id") or "")
+    pack = str(item.get("pack") or "")
+    return (name or rule_id, pack)
+
+
+def _coverage_rule_key(item: Any) -> Tuple[str, str]:
+    if not isinstance(item, dict):
+        return ("", "")
+    rid = str(item.get("rule_id") or "")
+    status = str(item.get("status") or "")
+    return (rid, status)
+
+
+def _citation_sort_key(item: Any) -> Tuple[str, str, str, str, str]:
+    if not isinstance(item, dict):
+        return ("", "", "", "", "")
+    return (
+        str(item.get("system") or ""),
+        str(item.get("instrument") or ""),
+        str(item.get("section") or ""),
+        str(item.get("title") or ""),
+        str(item.get("source") or ""),
+    )
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return 0

--- a/tests/contract/schema/analyze_response_v1_4.schema.json
+++ b/tests/contract/schema/analyze_response_v1_4.schema.json
@@ -1,0 +1,806 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contract-ai.tests/schema/analyze_response_v1_4.schema.json",
+  "title": "AnalyzeResponse v1.4",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "status",
+    "analysis",
+    "results",
+    "clauses",
+    "document",
+    "schema_version",
+    "meta",
+    "summary",
+    "cid",
+    "findings",
+    "recommendations",
+    "rules_coverage"
+  ],
+  "properties": {
+    "status": {
+      "type": "string"
+    },
+    "analysis": {
+      "$ref": "#/$defs/AnalysisBlock"
+    },
+    "results": {
+      "$ref": "#/$defs/ResultsBlock"
+    },
+    "clauses": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Finding"
+      }
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "schema_version": {
+      "const": "1.4",
+      "type": "string"
+    },
+    "meta": {
+      "$ref": "#/$defs/Meta"
+    },
+    "summary": {
+      "$ref": "#/$defs/DocumentSnapshot"
+    },
+    "cid": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Finding"
+      }
+    },
+    "recommendations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "rules_coverage": {
+      "$ref": "#/$defs/RulesCoverage"
+    }
+  },
+  "$defs": {
+    "AnalysisBlock": {
+      "type": "object",
+      "required": [
+        "findings",
+        "status"
+      ],
+      "properties": {
+        "findings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Finding"
+          }
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "Finding": {
+      "type": "object",
+      "required": [
+        "severity",
+        "start",
+        "end"
+      ],
+      "properties": {
+        "rule_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "clause_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "clause_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "critical",
+            "high",
+            "major",
+            "medium",
+            "minor",
+            "low",
+            "info"
+          ]
+        },
+        "start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "snippet": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "normalized_snippet": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "advice": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "law_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "citations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Citation"
+          }
+        },
+        "suggestion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "conflict_with": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ops": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "scope": {
+          "type": "object",
+          "properties": {
+            "unit": {
+              "type": "string"
+            },
+            "nth": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": true
+        },
+        "occurrences": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "matched_triggers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "trigger_positions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SpanRange"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "SpanRange": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "start",
+        "end"
+      ],
+      "additionalProperties": false
+    },
+    "Citation": {
+      "type": "object",
+      "properties": {
+        "system": {
+          "type": "string"
+        },
+        "instrument": {
+          "type": "string"
+        },
+        "section": {
+          "type": "string"
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "link": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "score": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "evidence": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "evidence_text": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "system",
+        "instrument",
+        "section"
+      ],
+      "additionalProperties": true
+    },
+    "DocumentSnapshot": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "type_confidence": {
+          "type": "number"
+        },
+        "type_source": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "doc_type": {
+          "type": "object",
+          "properties": {
+            "top": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "score": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": true
+            },
+            "confidence": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "candidates": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": true
+              }
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "top"
+          ],
+          "additionalProperties": true
+        },
+        "parties": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "dates": {
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "term": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string"
+            },
+            "start": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "end": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "renew_notice": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": true
+        },
+        "governing_law": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "jurisdiction": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signatures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "liability": {
+          "type": "object",
+          "properties": {
+            "has_cap": {
+              "type": "boolean"
+            },
+            "cap_value": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "cap_currency": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "notes": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "has_cap"
+          ],
+          "additionalProperties": true
+        },
+        "exclusivity": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "currency": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "carveouts": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "conditions_vs_warranties": {
+          "type": "object",
+          "properties": {
+            "has_conditions": {
+              "type": "boolean"
+            },
+            "has_warranties": {
+              "type": "boolean"
+            },
+            "explicit_conditions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explicit_warranties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "has_conditions",
+            "has_warranties"
+          ],
+          "additionalProperties": true
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules_count": {
+          "type": "integer"
+        },
+        "debug": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "type",
+        "type_confidence",
+        "parties",
+        "dates",
+        "term",
+        "liability",
+        "carveouts",
+        "conditions_vs_warranties",
+        "hints",
+        "rules_count"
+      ],
+      "additionalProperties": true
+    },
+    "Meta": {
+      "type": "object",
+      "required": [
+        "provider",
+        "model",
+        "valid_config",
+        "document_type",
+        "language",
+        "text_bytes",
+        "active_packs",
+        "rules_loaded_count",
+        "rules_fired_count",
+        "rules_evaluated",
+        "fired_rules",
+        "pipeline_id",
+        "timings_ms",
+        "debug"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "valid_config": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "language": {
+          "type": "string"
+        },
+        "text_bytes": {
+          "type": "integer"
+        },
+        "active_packs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules_loaded_count": {
+          "type": "integer"
+        },
+        "rules_fired_count": {
+          "type": "integer"
+        },
+        "rules_evaluated": {
+          "type": "integer"
+        },
+        "fired_rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FiredRule"
+          }
+        },
+        "pipeline_id": {
+          "type": "string"
+        },
+        "timings_ms": {
+          "type": "object",
+          "properties": {
+            "parse_ms": {
+              "type": "number"
+            },
+            "classify_ms": {
+              "type": "number"
+            },
+            "load_rules_ms": {
+              "type": "number"
+            },
+            "run_rules_ms": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": true
+        },
+        "debug": {
+          "type": "object",
+          "properties": {
+            "pipeline": {
+              "type": "string"
+            },
+            "packs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "rules_loaded": {
+              "type": "integer"
+            },
+            "rules_evaluated": {
+              "type": "integer"
+            },
+            "rules_triggered": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": true
+        },
+        "companies_meta": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "from_document": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "number": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": true
+              },
+              "matched": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": true
+              },
+              "verdict": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "FiredRule": {
+      "type": "object",
+      "properties": {
+        "rule_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pack": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "matched_triggers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "requires_clause_hit": {
+          "type": "boolean"
+        },
+        "positions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SpanRange"
+          }
+        }
+      },
+      "required": [
+        "rule_id",
+        "requires_clause_hit",
+        "positions"
+      ],
+      "additionalProperties": true
+    },
+    "RulesCoverage": {
+      "type": "object",
+      "required": [
+        "doc_type",
+        "rules"
+      ],
+      "properties": {
+        "doc_type": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "value"
+          ],
+          "additionalProperties": true
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rule_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "rule_id",
+              "status"
+            ],
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "ResultsBlock": {
+      "type": "object",
+      "required": [
+        "summary"
+      ],
+      "properties": {
+        "summary": {
+          "$ref": "#/$defs/DocumentSnapshot"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/tests/contract/test_contract_freeze.py
+++ b/tests/contract/test_contract_freeze.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+import os
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from jsonschema import Draft202012Validator
+
+from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
+
+from tests.contract.normalizer import normalize_for_diff
+
+SCHEMA_PATH = Path(__file__).resolve().parent / "schema" / "analyze_response_v1_4.schema.json"
+SCHEMA = json.loads(SCHEMA_PATH.read_text())
+VALIDATOR = Draft202012Validator(SCHEMA)
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+EXPECTED_DIR = FIXTURE_DIR / "expected"
+TEST_CASES = [
+    "basic",
+    "governing_law",
+    "payment_terms",
+]
+
+
+@pytest.fixture(scope="session")
+def analyze_client() -> TestClient:
+    os.environ.setdefault("AZURE_OPENAI_API_KEY", "test-key-123456789012345678901234")
+    os.environ.setdefault("FEATURE_COMPANIES_HOUSE", "0")
+    client = TestClient(app)
+    yield client
+    client.close()
+
+
+@pytest.fixture()
+def analyze_headers() -> dict[str, str]:
+    return {"x-api-key": "local-test-key-123", "x-schema-version": SCHEMA_VERSION}
+
+
+def _load_text(name: str) -> str:
+    return (FIXTURE_DIR / f"{name}.txt").read_text()
+
+
+def _load_expected(name: str) -> dict:
+    return json.loads((EXPECTED_DIR / f"{name}.json").read_text())
+
+
+@pytest.mark.parametrize("fixture_name", TEST_CASES)
+def test_analyze_contract_contract(analyze_client: TestClient, analyze_headers: dict[str, str], fixture_name: str) -> None:
+    response = analyze_client.post(
+        "/api/analyze",
+        json={"text": _load_text(fixture_name)},
+        headers=analyze_headers,
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    VALIDATOR.validate(payload)
+    normalized = normalize_for_diff(payload)
+    assert normalized == _load_expected(fixture_name)
+
+
+def _sample_payload() -> dict:
+    summary = {
+        "type": "Contract",
+        "type_confidence": 0.3,
+        "type_source": None,
+        "doc_type": {
+            "top": {"type": "Contract", "score": 0.3},
+            "confidence": 0.3,
+            "candidates": [{"type": "Contract", "score": 0.3}],
+        },
+        "parties": [
+            {
+                "name": "Alpha Corp",
+                "role": "Supplier",
+                "registry": {"number": "123", "status": "active"},
+            }
+        ],
+        "dates": {},
+        "term": {"mode": "unknown", "start": None, "end": None, "renew_notice": None},
+        "governing_law": None,
+        "jurisdiction": None,
+        "signatures": [],
+        "liability": {"has_cap": False, "cap_value": None, "cap_currency": None, "notes": None},
+        "exclusivity": None,
+        "currency": None,
+        "carveouts": {},
+        "conditions_vs_warranties": {
+            "has_conditions": False,
+            "has_warranties": False,
+            "explicit_conditions": [],
+            "explicit_warranties": [],
+        },
+        "hints": [],
+        "rules_count": 1,
+        "debug": {"doctype_top": []},
+    }
+    findings = [
+        {
+            "rule_id": "R-2",
+            "severity": "low",
+            "start": 5,
+            "end": 15,
+            "snippet": "Term",
+            "citations": [
+                {
+                    "system": "UK",
+                    "instrument": "Act",
+                    "section": "1",
+                    "title": "Example",
+                    "source": "statute",
+                },
+                {
+                    "system": "EU",
+                    "instrument": "Directive",
+                    "section": "2",
+                    "title": "Another",
+                    "source": "eu",
+                },
+            ],
+        },
+        {
+            "rule_id": "R-1",
+            "severity": "high",
+            "start": 20,
+            "end": 30,
+            "normalized_snippet": "payment",
+            "citations": [
+                {
+                    "system": "UK",
+                    "instrument": "Act",
+                    "section": "3",
+                    "title": "Supplement",
+                    "source": "statute",
+                }
+            ],
+        },
+    ]
+    meta = {
+        "provider": "mock",
+        "model": "static",
+        "valid_config": True,
+        "document_type": "Contract",
+        "language": "en-GB",
+        "text_bytes": 120,
+        "active_packs": ["beta", "alpha"],
+        "rules_loaded_count": 2,
+        "rules_fired_count": 2,
+        "rules_evaluated": 2,
+        "fired_rules": [
+            {
+                "rule_id": "R-2",
+                "name": "Rule two",
+                "pack": "pack-b",
+                "positions": [{"start": 5, "end": 15}],
+                "requires_clause_hit": False,
+            },
+            {
+                "rule_id": "R-1",
+                "pack": "pack-a",
+                "positions": [{"start": 20, "end": 30}],
+                "requires_clause_hit": True,
+            },
+        ],
+        "pipeline_id": "abc123",
+        "timings_ms": {"parse_ms": 1.2},
+        "debug": {"pipeline": "abc123", "packs": ["alpha"], "rules_loaded": 2, "rules_evaluated": 2, "rules_triggered": 2},
+    }
+    payload = {
+        "status": "ok",
+        "analysis": {"status": "ok", "findings": deepcopy(findings)},
+        "results": {"summary": deepcopy(summary)},
+        "clauses": deepcopy(findings),
+        "document": {},
+        "schema_version": "1.4",
+        "meta": meta,
+        "summary": deepcopy(summary),
+        "cid": "cid-1",
+        "findings": deepcopy(findings),
+        "recommendations": [],
+        "rules_coverage": {
+            "doc_type": {"value": "contract", "source": "heuristic"},
+            "rules": [
+                {"rule_id": "R-1", "status": "matched"},
+                {"rule_id": "R-2", "status": "missed"},
+            ],
+        },
+    }
+    return payload
+
+
+def test_normalizer_idempotent() -> None:
+    payload = _sample_payload()
+    first = normalize_for_diff(payload)
+    second = normalize_for_diff(first)
+    assert first == second
+    parties = first["summary"]["parties"]
+    assert parties == [{"name": "Alpha Corp", "role": "Supplier"}]
+
+
+def test_normalizer_permutation_invariance() -> None:
+    payload = _sample_payload()
+    permuted = _sample_payload()
+    permuted["findings"].reverse()
+    permuted["analysis"]["findings"].reverse()
+    permuted["clauses"].reverse()
+    permuted["meta"]["active_packs"].reverse()
+    permuted["meta"]["fired_rules"].reverse()
+    permuted["rules_coverage"]["rules"].reverse()
+    for finding in permuted["findings"]:
+        if "citations" in finding:
+            finding["citations"].reverse()
+    assert normalize_for_diff(payload) == normalize_for_diff(permuted)


### PR DESCRIPTION
## Summary
- add a deterministic AnalyzeResponse normalizer used by the contract tests
- lock in the AnalyzeResponse v1.4 JSON schema and plaintext fixtures
- cover the analyzer contract with schema validation, snapshot, and normalizer unit tests

## Testing
- pytest tests/contract -q

------
https://chatgpt.com/codex/tasks/task_e_68cc169f2dc48325b1f7e1105f950a32