### PR TITLE
test: stabilize contract normalizers and fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import requests
 
@@ -5,6 +7,13 @@ try:
     import httpx
 except Exception:  # pragma: no cover
     httpx = None
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _stable_env():
+    os.environ.setdefault("FEATURE_COMPANIES_HOUSE", "0")
+    os.environ.setdefault("FEATURE_LLM_ANALYZE", "0")
+    os.environ.setdefault("PYTHONHASHSEED", "0")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/contract/normalizer.py
+++ b/tests/contract/normalizer.py
@@ -20,6 +20,13 @@ _DROP_PATHS: set[Tuple[str, ...]] = {
     ("meta", "timings_ms"),
     ("meta", "debug"),
     ("meta", "companies_meta"),
+    ("meta", "api_version"),
+    ("meta", "deployment"),
+    ("meta", "dep"),
+    ("meta", "provider"),
+    ("meta", "model"),
+    ("meta", "provider_meta"),
+    ("meta", "llm"),
 }
 
 _PARTY_KEYS = {"role", "name"}

--- a/tests/contract/test_contract_freeze.py
+++ b/tests/contract/test_contract_freeze.py
@@ -45,7 +45,8 @@ def _load_text(name: str) -> str:
 
 
 def _load_expected(name: str) -> dict:
-    return json.loads((EXPECTED_DIR / f"{name}.json").read_text())
+    data = json.loads((EXPECTED_DIR / f"{name}.json").read_text())
+    return normalize_for_diff(data)
 
 
 @pytest.mark.parametrize("fixture_name", TEST_CASES)


### PR DESCRIPTION
## Summary
- extend the contract response normalizer drop list so meta provider data no longer causes freeze diffs
- align the golden test normalizer with the contract helper, including sorting semantics and drop paths, and normalise expected freeze fixtures before comparison
- add a session fixture that freezes feature flags and guard golden docs loading when Git LFS blobs are unavailable while still emitting diff reports

## Testing
- pytest -q tests/contract/test_contract_freeze.py
- pytest -q tests/golden/test_golden_compare.py


------
https://chatgpt.com/codex/tasks/task_e_68cc25eb9eec8325bd8c789772e4566e