### PR TITLE
Add L0 feature type models and stub extractor

### DIFF
--- a/contract_review_app/analysis/lx_features.py
+++ b/contract_review_app/analysis/lx_features.py
@@ -1,0 +1,6 @@
+from contract_review_app.core.lx_types import LxDocFeatures
+
+
+def extract_l0_features(doc_text: str, segments) -> LxDocFeatures:
+    # заглушка: возврат пустой структуры
+    return LxDocFeatures(by_segment={})

--- a/contract_review_app/core/lx_types.py
+++ b/contract_review_app/core/lx_types.py
@@ -1,0 +1,26 @@
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class LxSegmentRef(BaseModel):
+    segment_id: int
+    start: int
+    end: int
+    level: str  # "section" | "clause" | "sentence"
+
+
+class LxFeatureSet(BaseModel):
+    labels: List[str] = []
+    parties: List[str] = []
+    company_numbers: List[str] = []
+    amounts: List[str] = []
+    durations: Dict[str, int] = {}
+    law_signals: List[str] = []
+    jurisdiction: Optional[str] = None
+    liability_caps: List[str] = []
+    carveouts: List[str] = []
+
+
+class LxDocFeatures(BaseModel):
+    by_segment: Dict[int, LxFeatureSet] = {}

--- a/tests/lx/test_l0_types.py
+++ b/tests/lx/test_l0_types.py
@@ -1,0 +1,35 @@
+from contract_review_app.core.lx_types import LxDocFeatures, LxFeatureSet
+
+
+def test_feature_set_defaults():
+    feature_set = LxFeatureSet()
+
+    assert feature_set.labels == []
+    assert feature_set.parties == []
+    assert feature_set.company_numbers == []
+    assert feature_set.amounts == []
+    assert feature_set.durations == {}
+    assert feature_set.law_signals == []
+    assert feature_set.jurisdiction is None
+    assert feature_set.liability_caps == []
+    assert feature_set.carveouts == []
+
+    serialized = feature_set.dict()
+    assert serialized["labels"] == []
+    assert serialized["parties"] == []
+    assert serialized["company_numbers"] == []
+    assert serialized["amounts"] == []
+    assert serialized["durations"] == {}
+    assert serialized["law_signals"] == []
+    assert serialized["jurisdiction"] is None
+    assert serialized["liability_caps"] == []
+    assert serialized["carveouts"] == []
+
+
+def test_doc_features_defaults():
+    doc_features = LxDocFeatures()
+
+    assert doc_features.by_segment == {}
+
+    serialized = doc_features.dict()
+    assert serialized["by_segment"] == {}


### PR DESCRIPTION
## Summary
- add Pydantic models describing L0 feature segments and document feature collections
- provide an L0 feature extraction stub returning empty features
- cover serialization defaults for the new models with unit tests

## Testing
- pytest tests/lx/test_l0_types.py

------
https://chatgpt.com/codex/tasks/task_e_68cd8f9074bc83259317b8d91de45667