### PR TITLE
Add LX engine feature flag and trace hook

### DIFF
--- a/contract_review_app/analysis/lx_features.py
+++ b/contract_review_app/analysis/lx_features.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Sequence
+
+
+def extract_l0_features(text: str, segments: Sequence[Any] | Iterable[Any] | None) -> list[Any]:
+    """Placeholder implementation for LX engine feature extraction."""
+
+    return []

--- a/tests/codex/test_app_analyze_hook.py
+++ b/tests/codex/test_app_analyze_hook.py
@@ -1,4 +1,10 @@
-import json, subprocess, sys
+import json
+import subprocess
+import sys
+
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.models import SCHEMA_VERSION
 
 
 def _run_doctor(tmp_path, monkeypatch):
@@ -31,3 +37,37 @@ def test_app_has_analyze_hook(monkeypatch):
 def test_doctor_reports_analyze_hook(tmp_path, monkeypatch):
     data = _run_doctor(tmp_path, monkeypatch)
     assert data["api"]["has__analyze_document"] is True
+
+
+def test_analyze_lx_engine_trace(monkeypatch):
+    import contract_review_app.api.app as app_module
+
+    monkeypatch.setenv("FEATURE_LX_ENGINE", "1")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key-123456789012345678901234")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("AZURE_KEY_INVALID", "0")
+    monkeypatch.setattr(app_module, "FEATURE_LX_ENGINE", True, raising=False)
+
+    with TestClient(app_module.app) as client:
+        resp = client.post(
+            "/api/analyze",
+            json={"text": "Hello LX"},
+            headers={
+                "x-schema-version": SCHEMA_VERSION,
+                "x-api-key": "local-test-key-123",
+            },
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload.get("schema_version") == SCHEMA_VERSION
+        cid = resp.headers.get("x-cid")
+        assert cid
+
+        trace_resp = client.get(
+            f"/api/trace/{cid}",
+            headers={"x-schema-version": SCHEMA_VERSION},
+        )
+        assert trace_resp.status_code == 200
+        trace_body = trace_resp.json()
+        assert trace_body.get("l0_features", {}).get("status") == "enabled"
+        assert "count" in trace_body.get("l0_features", {})


### PR DESCRIPTION
## Summary
- introduce a FEATURE_LX_ENGINE flag to guard an optional LX extraction hook and trace logging
- extend TraceStore with an add helper and response merging so partial trace data is preserved
- add a smoke test for the LX feature flag and expose a /api/gpt-draft alias alongside a stub extractor module

## Testing
- pytest tests/codex/test_app_analyze_hook.py tests/api/test_analyze.py tests/api/test_analyze_minimal.py tests/api/test_openapi_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68cd8f84af648325bd829916e9b1a301