### PR TITLE
Add L1 rule dispatcher and integrate candidate filtering

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -21,7 +21,7 @@ import logging
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path, PurePosixPath
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from collections import OrderedDict
 import secrets
@@ -45,6 +45,7 @@ from contract_review_app.core.privacy import redact_pii, scrub_llm_output  # noq
 from contract_review_app.core.audit import audit
 from contract_review_app.security.secure_store import secure_write
 from contract_review_app.core.trace import TraceStore, compute_cid
+from contract_review_app.core.lx_types import LxFeatureSet, LxSegment
 from contract_review_app.config import CH_ENABLED, CH_API_KEY
 from contract_review_app.utils.logging import logger as cai_logger
 
@@ -2051,7 +2052,56 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
 
     seg_findings: List[Dict[str, Any]] = []
     clause_types_set: set[str] = set()
+    dispatch_segments: List[Dict[str, Any]] = []
+    candidate_rule_union: Set[str] = set()
+    dispatcher_mod = None
+    features_by_segment: Dict[int, LxFeatureSet] = {}
+    if FEATURE_LX_ENGINE and lx_features is not None:
+        try:
+            from contract_review_app.legal_rules import dispatcher as _dispatcher_mod
+        except Exception:
+            dispatcher_mod = None
+        else:
+            dispatcher_mod = _dispatcher_mod
+            features_by_segment = getattr(lx_features, "by_segment", {}) or {}
+
     for seg in parsed.segments:
+        seg_id = int(seg.get("id", 0) or 0)
+        if dispatcher_mod and seg_id in features_by_segment:
+            feats = features_by_segment.get(seg_id)
+            if feats is not None:
+                try:
+                    segment_obj = LxSegment(
+                        segment_id=seg_id,
+                        heading=str(seg.get("heading") or "") or None,
+                        text=str(seg.get("text") or ""),
+                        clause_type=str(seg.get("clause_type") or "") or None,
+                    )
+                    refs = dispatcher_mod.select_candidate_rules(segment_obj, feats)
+                except Exception:
+                    refs = []
+                if refs:
+                    candidate_ids = [ref.rule_id for ref in refs]
+                    candidate_rule_union.update(candidate_ids)
+                    if hasattr(feats, "model_dump"):
+                        feat_payload = feats.model_dump()
+                    else:  # pragma: no cover
+                        feat_payload = feats.dict()  # type: ignore[call-arg]
+                    dispatch_segments.append(
+                        {
+                            "segment_id": seg_id,
+                            "labels": list(feats.labels or []),
+                            "features": feat_payload,
+                            "candidates": [
+                                {
+                                    "rule_id": ref.rule_id,
+                                    "reasons": list(ref.reasons),
+                                }
+                                for ref in refs
+                            ],
+                        }
+                    )
+
         clause_type = seg.get("clause_type")
         if not clause_type:
             continue
@@ -2069,6 +2119,16 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
                 clause_type,
                 seg.get("text", ""),
                 int(seg.get("start", 0)),
+            )
+        except Exception:
+            pass
+
+    if dispatch_segments:
+        try:
+            TRACE.add(
+                request.state.cid,
+                "dispatch",
+                {"segments": dispatch_segments},
             )
         except Exception:
             pass
@@ -2109,12 +2169,19 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
         )
 
         _yaml_loader.load_rule_packs()
-        filtered_rules = _yaml_loader.filter_rules(
-            txt or "",
-            doc_type=snap.type,
-            clause_types=clause_types_set,
-            jurisdiction=snap.jurisdiction,
-        )
+        token = None
+        if candidate_rule_union:
+            token = _yaml_loader.CANDIDATES_VAR.set(set(candidate_rule_union))
+        try:
+            filtered_rules = _yaml_loader.filter_rules(
+                txt or "",
+                doc_type=snap.type,
+                clause_types=clause_types_set,
+                jurisdiction=snap.jurisdiction,
+            )
+        finally:
+            if token is not None:
+                _yaml_loader.CANDIDATES_VAR.reset(token)
         t3 = time.perf_counter()
         yaml_findings = _yaml_engine.analyze(
             txt or "", [r["rule"] for r in filtered_rules if not r.get("status")]

--- a/contract_review_app/core/lx_types.py
+++ b/contract_review_app/core/lx_types.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class LxSegmentRef(BaseModel):
@@ -10,17 +10,32 @@ class LxSegmentRef(BaseModel):
     level: str  # "section" | "clause" | "sentence"
 
 
+class LxSegment(BaseModel):
+    """Lightweight representation of a parsed segment for L1 dispatch."""
+
+    segment_id: int
+    text: str = ""
+    heading: Optional[str] = None
+    clause_type: Optional[str] = None
+
+    def combined_text(self) -> str:
+        heading = self.heading or ""
+        if heading:
+            return f"{heading}\n{self.text or ''}"
+        return self.text or ""
+
+
 class LxFeatureSet(BaseModel):
-    labels: List[str] = []
-    parties: List[str] = []
-    company_numbers: List[str] = []
-    amounts: List[str] = []
-    durations: Dict[str, int] = {}
-    law_signals: List[str] = []
+    labels: List[str] = Field(default_factory=list)
+    parties: List[str] = Field(default_factory=list)
+    company_numbers: List[str] = Field(default_factory=list)
+    amounts: List[str] = Field(default_factory=list)
+    durations: Dict[str, int] = Field(default_factory=dict)
+    law_signals: List[str] = Field(default_factory=list)
     jurisdiction: Optional[str] = None
-    liability_caps: List[str] = []
-    carveouts: List[str] = []
+    liability_caps: List[str] = Field(default_factory=list)
+    carveouts: List[str] = Field(default_factory=list)
 
 
 class LxDocFeatures(BaseModel):
-    by_segment: Dict[int, LxFeatureSet] = {}
+    by_segment: Dict[int, LxFeatureSet] = Field(default_factory=dict)

--- a/contract_review_app/legal_rules/dispatcher.py
+++ b/contract_review_app/legal_rules/dispatcher.py
@@ -1,0 +1,245 @@
+"""Lightweight L1 dispatcher narrowing candidate YAML rules per segment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import re
+from typing import Dict, Iterable, List, MutableMapping, Optional, Set, Tuple
+
+from contract_review_app.core.lx_types import LxFeatureSet, LxSegment
+
+from . import loader
+
+
+@dataclass(frozen=True)
+class RuleRef:
+    """Reference to a rule suggested for evaluation."""
+
+    rule_id: str
+    reasons: Tuple[str, ...] = ()
+
+
+def _normalize_token(token: str) -> str:
+    token = token.lower()
+    return re.sub(r"[^a-z0-9]+", "_", token).strip("_")
+
+
+def _tokenize(text: str) -> Set[str]:
+    if not text:
+        return set()
+    return set(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+@lru_cache(maxsize=1)
+def _rule_index() -> Tuple[
+    Tuple[Dict[str, str], ...],
+    Dict[str, Set[str]],
+    Dict[str, Set[str]],
+    Dict[str, Set[str]],
+]:
+    """Build cached indexes for rule metadata lookup."""
+
+    loader.load_rule_packs()
+    rules: List[Dict[str, str]] = []
+    token_index: Dict[str, Set[str]] = {}
+    clause_index: Dict[str, Set[str]] = {}
+    jurisdiction_index: Dict[str, Set[str]] = {}
+
+    for spec in loader.load_rules():
+        rule_id = str(spec.get("id") or spec.get("rule_id") or "").strip()
+        if not rule_id:
+            continue
+        clause_type = str(spec.get("clause_type") or "").strip().lower()
+        title = str(spec.get("title") or spec.get("Title") or "")
+        pack = str(spec.get("pack") or "")
+        requires_clause = spec.get("requires_clause") or []
+        jurisdiction = spec.get("jurisdiction") or []
+
+        fields = " ".join(
+            f
+            for f in [rule_id, title, clause_type, pack, " ".join(requires_clause)]
+            if f
+        )
+        tokens = _tokenize(fields)
+        for token in tokens:
+            token_index.setdefault(token, set()).add(rule_id)
+
+        if clause_type:
+            clause_index.setdefault(clause_type, set()).add(rule_id)
+        for req in requires_clause:
+            norm_req = _normalize_token(req)
+            if norm_req:
+                clause_index.setdefault(norm_req, set()).add(rule_id)
+
+        for juris in jurisdiction:
+            juris_token = juris.lower()
+            jurisdiction_index.setdefault(juris_token, set()).add(rule_id)
+
+        rules.append({"id": rule_id, "clause_type": clause_type, "title": title})
+
+    return tuple(rules), token_index, clause_index, jurisdiction_index
+
+
+_LABEL_TO_CLAUSES: Dict[str, Set[str]] = {
+    "payment": {"payment", "invoice", "billing", "setoff", "rebate", "tax"},
+    "term": {"term", "termination", "duration", "renewal"},
+    "liability": {"liability", "indemnity", "damages", "limitation"},
+    "confidentiality": {"confidentiality", "nda", "confidential"},
+    "indemnity": {"indemnity", "liability"},
+    "governinglaw": {"governing_law", "law"},
+    "jurisdiction": {"jurisdiction"},
+    "dispute": {"dispute", "litigation", "arbitration"},
+    "ip": {"intellectual_property", "ip", "ipr", "intellectual"},
+    "notices": {"notices", "notification", "notice"},
+    "taxes": {"tax", "taxes", "withholding", "vat"},
+    "setoff": {"setoff", "set_off", "payment"},
+    "interest": {"interest", "payment"},
+    "price": {"pricing", "payment", "price"},
+    "sla": {"sla", "service_level", "service_levels"},
+    "kpi": {"kpi", "service_level", "metrics"},
+    "acceptance": {"acceptance", "delivery", "inspection"},
+    "boilerplate": {"boilerplate", "general", "miscellaneous"},
+}
+
+_LABEL_KEYWORDS: Dict[str, Set[str]] = {
+    "payment": {"payment", "invoice", "pay", "interest", "setoff", "charge"},
+    "term": {"term", "notice", "duration", "renewal", "expire"},
+    "liability": {"liability", "damages", "cap", "limit", "limitation", "indemnity"},
+    "confidentiality": {"confidential", "nda", "non", "disclosure"},
+    "indemnity": {"indemnity", "defend", "hold", "harmless"},
+    "governinglaw": {"governing", "law", "laws", "england"},
+    "jurisdiction": {"jurisdiction", "courts", "forum"},
+    "dispute": {"dispute", "arbitration", "litigation", "mediati"},
+    "ip": {"intellectual", "property", "ip", "ipr", "licence", "license"},
+    "notices": {"notice", "notify", "address", "delivery"},
+    "taxes": {"tax", "vat", "withhold", "gross", "ddp"},
+    "setoff": {"setoff", "set", "off", "deduct"},
+    "interest": {"interest", "late", "payment"},
+    "price": {"price", "pricing", "rates", "charges", "fees"},
+    "sla": {"sla", "service", "level", "availability"},
+    "kpi": {"kpi", "performance", "target", "metric"},
+    "acceptance": {"acceptance", "accept", "inspection", "testing"},
+    "boilerplate": {"hereby", "thereof", "agreement", "entire"},
+}
+
+_TEXT_TOKEN_ALLOWLIST: Set[str] = {
+    "payment",
+    "invoice",
+    "interest",
+    "term",
+    "termination",
+    "notice",
+    "liability",
+    "indemnity",
+    "confidential",
+    "jurisdiction",
+    "law",
+    "governing",
+    "dispute",
+    "arbitration",
+    "tax",
+    "vat",
+    "price",
+    "charge",
+    "acceptance",
+    "inspection",
+    "ip",
+    "intellectual",
+    "sla",
+    "kpi",
+    "uk",
+    "england",
+    "wales",
+    "scotland",
+}
+
+
+def _collect_from_index(
+    index: MutableMapping[str, Set[str]],
+    keys: Iterable[str],
+    reason: str,
+    acc: MutableMapping[str, Set[str]],
+) -> None:
+    for key in keys:
+        if not key:
+            continue
+        vals = index.get(key)
+        if not vals:
+            continue
+        for rule_id in vals:
+            acc.setdefault(rule_id, set()).add(reason)
+
+
+def _features_from_segment(segment: LxSegment) -> Set[str]:
+    tokens = _tokenize(segment.combined_text())
+    return {t for t in tokens if t in _TEXT_TOKEN_ALLOWLIST}
+
+
+def select_candidate_rules(
+    segment: LxSegment,
+    feats: Optional[LxFeatureSet],
+) -> List[RuleRef]:
+    """Return rule references relevant to *segment* based on L0 features."""
+
+    if feats is None:
+        feats = LxFeatureSet()
+
+    (_, token_index, clause_index, jurisdiction_index) = _rule_index()
+
+    reasons: Dict[str, Set[str]] = {}
+
+    labels = { _normalize_token(lbl) for lbl in (feats.labels or []) }
+    clause_type = _normalize_token(segment.clause_type or "")
+    if clause_type:
+        labels.add(clause_type)
+
+    for label in sorted(labels):
+        clause_targets = _LABEL_TO_CLAUSES.get(label, set())
+        if clause_targets:
+            _collect_from_index(
+                clause_index,
+                (ct for ct in clause_targets),
+                f"label:{label}",
+                reasons,
+            )
+        keywords = _LABEL_KEYWORDS.get(label, set())
+        if keywords:
+            _collect_from_index(
+                token_index,
+                keywords,
+                f"keyword:{label}",
+                reasons,
+            )
+
+    if feats.durations:
+        _collect_from_index(token_index, {"day", "days", "payment", "term"}, "duration", reasons)
+
+    if feats.amounts:
+        _collect_from_index(token_index, {"amount", "fee", "charge", "price"}, "amount", reasons)
+
+    for signal in feats.law_signals or []:
+        tokens = _tokenize(signal)
+        _collect_from_index(token_index, tokens, "law", reasons)
+
+    if feats.jurisdiction:
+        juris_tokens = {feats.jurisdiction.lower()} | _tokenize(feats.jurisdiction)
+        _collect_from_index(jurisdiction_index, juris_tokens, "jurisdiction", reasons)
+        _collect_from_index(token_index, juris_tokens, "jurisdiction", reasons)
+
+    for token in _features_from_segment(segment):
+        _collect_from_index(token_index, {token}, f"text:{token}", reasons)
+
+    if not reasons:
+        if clause_type:
+            _collect_from_index(clause_index, {clause_type}, f"clause:{clause_type}", reasons)
+
+    if not reasons:
+        return []
+
+    rule_refs = [
+        RuleRef(rule_id=rid, reasons=tuple(sorted(reason_set)))
+        for rid, reason_set in reasons.items()
+    ]
+    rule_refs.sort(key=lambda ref: ref.rule_id)
+    return rule_refs

--- a/fixtures/lx/seg_liability_cap.txt
+++ b/fixtures/lx/seg_liability_cap.txt
@@ -1,0 +1,1 @@
+Limitation of Liability. Except for fraud, the total liability of either party shall not exceed the fees paid or payable in the preceding twelve months.

--- a/fixtures/lx/seg_payment_60d.txt
+++ b/fixtures/lx/seg_payment_60d.txt
@@ -1,0 +1,1 @@
+Payment Terms. Customer shall pay each undisputed invoice within sixty (60) days of receipt. Late payments accrue interest at 4% over the Bank of England base rate.

--- a/fixtures/lx/seg_term_45d.txt
+++ b/fixtures/lx/seg_term_45d.txt
@@ -1,0 +1,1 @@
+Term. This Agreement commences on the Effective Date and remains in force for an initial term of forty five (45) days, subject to automatic renewal upon mutual agreement.

--- a/tests/lx/test_l0_features.py
+++ b/tests/lx/test_l0_features.py
@@ -4,27 +4,27 @@ from contract_review_app.analysis.lx_features import extract_l0_features
 
 def _extract_labels(text: str):
     parsed = parse_text(text)
-    features = extract_l0_features(parsed)
-    segment = features.segments[1]
-    return features, segment
+    doc_features = extract_l0_features(text, parsed.segments)
+    segment = doc_features.by_segment[1]
+    return doc_features, segment
 
 
 def test_payment_duration_extraction():
     text = "Payment shall be made within sixty (60) days of receipt of invoice."
-    features, segment = _extract_labels(text)
+    doc_features, segment = _extract_labels(text)
 
     assert "Payment" in segment.labels
-    assert features.durations["days"] == 60
     assert segment.durations["days"] == 60
+    assert doc_features.by_segment[1].durations["days"] == 60
 
 
 def test_term_duration_extraction():
     text = "This Agreement shall remain in force for forty-five (45) days from execution."
-    features, segment = _extract_labels(text)
+    doc_features, segment = _extract_labels(text)
 
     assert "Term" in segment.labels
-    assert features.durations["days"] == 45
     assert segment.durations["days"] == 45
+    assert doc_features.by_segment[1].durations["days"] == 45
 
 
 def test_mixed_labels_are_detected():
@@ -33,12 +33,16 @@ def test_mixed_labels_are_detected():
         "The term shall remain in force for forty-five (45) days from execution."
     )
     parsed = parse_text(text)
-    features = extract_l0_features(parsed)
+    doc_features = extract_l0_features(text, parsed.segments)
 
-    first_segment = features.segments[1]
-    second_segment = features.segments[2]
+    first_segment = doc_features.by_segment[1]
+    second_segment = doc_features.by_segment[2]
 
     assert "Payment" in first_segment.labels
     assert "Term" in second_segment.labels
-    assert "Payment" in features.labels
-    assert "Term" in features.labels
+
+    all_labels = {
+        label for fs in doc_features.by_segment.values() for label in fs.labels
+    }
+    assert "Payment" in all_labels
+    assert "Term" in all_labels

--- a/tests/lx/test_l1_dispatcher.py
+++ b/tests/lx/test_l1_dispatcher.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from contract_review_app.core.lx_types import LxFeatureSet, LxSegment
+from contract_review_app.legal_rules import dispatcher
+
+FIXTURE_DIR = Path("fixtures/lx")
+
+
+def _read(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_payment_dispatch_includes_payment_rules():
+    text = _read("seg_payment_60d.txt")
+    segment = LxSegment(segment_id=1, heading="Payment Terms", text=text)
+    features = LxFeatureSet(
+        labels=["Payment", "Interest"],
+        durations={"days": 60},
+        law_signals=["Late Payment of Commercial Debts"],
+        jurisdiction="England",
+    )
+
+    refs = dispatcher.select_candidate_rules(segment, features)
+    ids = {ref.rule_id for ref in refs}
+
+    assert "P4.PAYMENT_TERMS_AND_INTEREST" in ids
+    assert "P3.LATE_INVOICE_TIMEBAR" in ids
+
+
+def test_term_dispatch_includes_notice_rules():
+    text = _read("seg_term_45d.txt")
+    segment = LxSegment(segment_id=2, heading="Term", text=text, clause_type="term")
+    features = LxFeatureSet(labels=["Term"], durations={"days": 45})
+
+    refs = dispatcher.select_candidate_rules(segment, features)
+    ids = {ref.rule_id for ref in refs}
+
+    assert "13.ITP.NOTICE" in ids
+
+
+def test_liability_dispatch_covers_caps():
+    text = _read("seg_liability_cap.txt")
+    segment = LxSegment(
+        segment_id=3,
+        heading="Limitation of Liability",
+        text=text,
+        clause_type="liability",
+    )
+    features = LxFeatureSet(labels=["Liability"], amounts=["100000"], liability_caps=["fees"])
+
+    refs = dispatcher.select_candidate_rules(segment, features)
+    ids = {ref.rule_id for ref in refs}
+
+    assert "ic.vicarious.liability.supervision_language" in ids
+    assert ids  # ensure we never return an empty set for liability segments

--- a/tests/lx/test_l1_props.py
+++ b/tests/lx/test_l1_props.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from contract_review_app.core.lx_types import LxFeatureSet, LxSegment
+from contract_review_app.legal_rules import dispatcher
+
+FIXTURE_DIR = Path("fixtures/lx")
+
+
+def _segment_and_features(name: str, labels: list[str]) -> tuple[LxSegment, LxFeatureSet]:
+    text = (FIXTURE_DIR / name).read_text(encoding="utf-8")
+    segment = LxSegment(segment_id=99, heading="Test", text=text)
+    features = LxFeatureSet(labels=labels)
+    return segment, features
+
+
+def _rule_ids(name: str, labels: list[str]) -> set[str]:
+    segment, features = _segment_and_features(name, labels)
+    refs = dispatcher.select_candidate_rules(segment, features)
+    return {ref.rule_id for ref in refs}
+
+
+def test_label_monotonicity_with_interest():
+    base_ids = _rule_ids("seg_payment_60d.txt", ["Payment"])
+    enriched_ids = _rule_ids("seg_payment_60d.txt", ["Payment", "Interest"])
+    assert base_ids <= enriched_ids
+
+
+def test_dispatch_is_deterministic():
+    segment, features = _segment_and_features("seg_liability_cap.txt", ["Liability"])
+    first = dispatcher.select_candidate_rules(segment, features)
+    second = dispatcher.select_candidate_rules(segment, features)
+    assert first == second

--- a/tests/panel/test_l1_end2end.py
+++ b/tests/panel/test_l1_end2end.py
@@ -1,0 +1,48 @@
+import importlib
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import contract_review_app.api.app as app_module
+
+
+def test_l1_end_to_end_dispatch(monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key-123456789012345678901234")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+
+    original_flag = "1" if getattr(app_module, "FEATURE_LX_ENGINE", False) else "0"
+
+    try:
+        monkeypatch.setenv("FEATURE_LX_ENGINE", "1")
+        reloaded = importlib.reload(app_module)
+
+        with TestClient(
+            reloaded.app,
+            headers={
+                "x-schema-version": reloaded.SCHEMA_VERSION,
+                "x-api-key": "local-test-key-123",
+            },
+        ) as client:
+            text = Path("fixtures/contracts/mixed_sample.txt").read_text(encoding="utf-8")
+            resp = client.post("/api/analyze?debug=coverage", json={"text": text})
+            assert resp.status_code == 200
+
+            payload = resp.json()
+            fired = [item["rule_id"] for item in payload.get("meta", {}).get("fired_rules", [])]
+            assert isinstance(fired, list)
+
+            cid = resp.headers.get("x-cid", "")
+            trace_entry = reloaded.TRACE.get(cid)
+            dispatch = ((trace_entry or {}).get("body") or {}).get("dispatch")
+            assert dispatch
+            segments = dispatch.get("segments", [])
+            assert segments
+            candidate_ids = {
+                cand["rule_id"]
+                for seg in segments
+                for cand in seg.get("candidates", [])
+            }
+            assert candidate_ids
+    finally:
+        monkeypatch.setenv("FEATURE_LX_ENGINE", original_flag)
+        importlib.reload(app_module)


### PR DESCRIPTION
## Summary
- add a cached L1 dispatcher that scores rules by labels, features, and segment text
- integrate dispatcher output into the analyze pipeline, constrain loader filtering via a context variable, and emit a dispatch trace
- supply fixtures and tests covering dispatcher behaviour, L0 feature extraction, and end-to-end trace capture

## Testing
- FEATURE_LX_ENGINE=1 pytest -q *(fails: existing test_gpt_draft_accepts_text_aliases requires relaxed DraftRequest schema)*
- pytest tests/lx -q
- pytest tests/panel/test_l1_end2end.py -vv


------
https://chatgpt.com/codex/tasks/task_e_68ce486b901c8325b1b0a905639a51e7