### PR TITLE
Add runtime server deps (FastAPI/Uvicorn/Cryptography/HTTPX) + smoke test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,8 @@ requests
 SQLAlchemy>=2.0,<3.0
 loguru>=0.7,<1.0
 sentry-sdk>=1.39,<2
+fastapi==0.115.*
+uvicorn[standard]==0.30.*
+python-dotenv>=1.0
+cryptography>=43
+httpx==0.27.*

--- a/tests/test_runtime_imports.py
+++ b/tests/test_runtime_imports.py
@@ -1,0 +1,2 @@
+def test_runtime_imports():
+    import fastapi, uvicorn, httpx, cryptography  # noqa: F401

--- a/tools/ContractAI-Start.ps1
+++ b/tools/ContractAI-Start.ps1
@@ -72,6 +72,7 @@ if($listen){
 } else {
   $args = @('-m','uvicorn','contract_review_app.api.app:app','--host',$hostip,'--port',$port,'--ssl-certfile',$crt,'--ssl-keyfile',$keyf)
   INF ("Start: {0} {1}" -f $py, ($args -join ' '))
+  .\.venv\Scripts\python.exe -m pip install -r requirements.txt | Out-Null
   $proc = Start-Process -FilePath $py -ArgumentList $args -WorkingDirectory $Root -PassThru
   OK  ("Uvicorn PID={0}" -f $proc.Id)
 


### PR DESCRIPTION
## Summary
- add FastAPI, Uvicorn, Cryptography, HTTPX, and python-dotenv runtime dependencies
- add a smoke test that verifies these runtime dependencies can be imported
- ensure the Windows launcher reinstalls runtime requirements before starting Uvicorn

## Testing
- pytest -q *(fails: existing contract_review_app tests expect additional API payload fields; pytest-watch still absent in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce64043fec8325b9f040ca03d5fc68