### PR TITLE
Add internal ParamGraph models and tests

### DIFF
--- a/contract_review_app/core/lx_types.py
+++ b/contract_review_app/core/lx_types.py
@@ -1,6 +1,9 @@
-from typing import Dict, List, Optional
+from decimal import Decimal
+from typing import ClassVar, Dict, List, Optional, Tuple
 
-from pydantic import BaseModel, Field
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class LxSegmentRef(BaseModel):
@@ -39,3 +42,49 @@ class LxFeatureSet(BaseModel):
 
 class LxDocFeatures(BaseModel):
     by_segment: Dict[int, LxFeatureSet] = Field(default_factory=dict)
+
+
+class SourceRef(BaseModel):
+    clause_id: Optional[str] = None
+    span: Optional[Tuple[int, int]] = None
+    note: Optional[str] = None
+
+
+class Money(BaseModel):
+    amount: Decimal
+    currency: str
+
+    _symbol_map: ClassVar[Dict[str, str]] = {"$": "USD", "£": "GBP", "€": "EUR"}
+
+    @field_validator("currency")
+    @classmethod
+    def normalize_currency(cls, value: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError("currency must be a string")
+        cleaned = value.strip()
+        normalized = cls._symbol_map.get(cleaned, cleaned).upper()
+        if len(normalized) != 3 or not normalized.isalpha():
+            raise ValueError("currency must be an ISO 4217 code")
+        return normalized
+
+
+class Duration(BaseModel):
+    days: int
+    kind: Literal["calendar", "business"] = "calendar"
+
+
+class ParamGraph(BaseModel):
+    payment_term: Optional[Duration] = None
+    contract_term: Optional[Duration] = None
+    grace_period: Optional[Duration] = None
+    governing_law: Optional[str] = None
+    jurisdiction: Optional[str] = None
+    cap: Optional[Money] = None
+    contract_currency: Optional[str] = None
+    notice_period: Optional[Duration] = None
+    cure_period: Optional[Duration] = None
+    survival_items: set[str] = Field(default_factory=set)
+    cross_refs: List[Tuple[str, str]] = Field(default_factory=list)
+    parties: List[Dict] = Field(default_factory=list)
+    signatures: List[Dict] = Field(default_factory=list)
+    sources: Dict[str, SourceRef] = Field(default_factory=dict)

--- a/contract_review_app/legal_rules/constraints.py
+++ b/contract_review_app/legal_rules/constraints.py
@@ -1,0 +1,3 @@
+"""Utilities for building the ParamGraph and evaluating legal constraints."""
+
+__all__ = []

--- a/tests/lx/test_pg_types.py
+++ b/tests/lx/test_pg_types.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+import json
+
+import pytest
+
+from contract_review_app.core.lx_types import Duration, Money, ParamGraph, SourceRef
+
+
+def test_money_currency_normalization():
+    assert Money(amount=Decimal("10"), currency="$").currency == "USD"
+    assert Money(amount="5", currency="gbp").currency == "GBP"
+    with pytest.raises(ValueError):
+        Money(amount=1, currency="bitcoin")
+
+
+def test_param_graph_json_serialization():
+    pg = ParamGraph(
+        payment_term=Duration(days=30),
+        cap=Money(amount=Decimal("1234.56"), currency="EUR"),
+        survival_items={"confidentiality"},
+        cross_refs=[("c1", "c2")],
+        parties=[{"name": "Acme", "role": "seller"}],
+        signatures=[{"name": "John Doe", "entity": "Acme"}],
+        sources={
+            "cap": SourceRef(clause_id="cl1", span=(0, 10)),
+        },
+    )
+
+    dumped = json.loads(pg.model_dump_json())
+    assert dumped["cap"]["amount"] == "1234.56"
+    assert dumped["cap"]["currency"] == "EUR"
+    assert sorted(dumped["survival_items"]) == ["confidentiality"]
+    assert dumped["cross_refs"] == [["c1", "c2"]]
+    assert dumped["sources"]["cap"]["clause_id"] == "cl1"


### PR DESCRIPTION
## Summary
- add SourceRef, Money, Duration, and ParamGraph internal models with ISO currency validation
- add placeholder module for future ParamGraph builders and constraint evaluation
- add tests covering currency normalization and JSON serialization for the new types

## Testing
- pytest tests/lx/test_pg_types.py

------
https://chatgpt.com/codex/tasks/task_e_68cebe8e52f883258731cee022b71bec