### PR TITLE
Implement param graph extraction for universal parameters

### DIFF
--- a/contract_review_app/core/lx_types.py
+++ b/contract_review_app/core/lx_types.py
@@ -88,3 +88,7 @@ class ParamGraph(BaseModel):
     parties: List[Dict] = Field(default_factory=list)
     signatures: List[Dict] = Field(default_factory=list)
     sources: Dict[str, SourceRef] = Field(default_factory=dict)
+    annex_refs: List[str] = Field(default_factory=list)
+    order_of_precedence: Optional[bool] = None
+    undefined_terms: List[str] = Field(default_factory=list)
+    numbering_gaps: List[int] = Field(default_factory=list)

--- a/contract_review_app/legal_rules/constraints.py
+++ b/contract_review_app/legal_rules/constraints.py
@@ -1,3 +1,320 @@
 """Utilities for building the ParamGraph and evaluating legal constraints."""
 
-__all__ = []
+from __future__ import annotations
+
+from decimal import Decimal
+import re
+from types import SimpleNamespace
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from contract_review_app.analysis.extract_summary import (
+    _extract_cure_days,
+    _extract_cross_refs,
+    _extract_duration_from_text,
+    _extract_notice_days,
+    _extract_payment_term_days,
+    _detect_numbering_gaps,
+    _detect_order_of_precedence,
+    _detect_undefined_terms,
+)
+from contract_review_app.core.lx_types import (
+    Duration,
+    LxDocFeatures,
+    Money,
+    ParamGraph,
+    SourceRef,
+)
+from contract_review_app.legal_rules.cross_checks import _extract_survival_items
+
+__all__ = ["build_param_graph"]
+
+
+_ANNEX_RE = re.compile(r"\b(?P<prefix>annex|schedule)\s+(?P<label>[A-Z0-9]+)\b", re.IGNORECASE)
+_LAW_PATTERN = re.compile(r"governed\s+by\s+the\s+law", re.IGNORECASE)
+_JUR_PATTERN = re.compile(r"jurisdiction", re.IGNORECASE)
+_CAP_PATTERN = re.compile(r"liability|cap", re.IGNORECASE)
+_CURRENCY_PATTERN = re.compile(r"[$€£]|\bUSD\b|\bEUR\b|\bGBP\b", re.IGNORECASE)
+_SURVIVE_PATTERN = re.compile(r"\bsurviv", re.IGNORECASE)
+_NOTICE_PATTERN = re.compile(r"notice", re.IGNORECASE)
+_CURE_PATTERN = re.compile(r"\b(cure|remedy)\b", re.IGNORECASE)
+_PAYMENT_PATTERN = re.compile(r"\b(payment|invoice|fee|remit)\b", re.IGNORECASE)
+_GRACE_PATTERN = re.compile(r"grace\s+period", re.IGNORECASE)
+_CROSS_PATTERN = re.compile(r"\b(?:clause|section)\s+\d", re.IGNORECASE)
+
+
+def _iter_segments(segments: Iterable[Any]) -> Iterable[Any]:
+    for seg in segments or []:  # type: ignore[truthy-bool]
+        yield seg
+
+
+def _seg_attr(seg: Any, key: str, default: Any = None) -> Any:
+    if isinstance(seg, dict):
+        return seg.get(key, default)
+    return getattr(seg, key, default)
+
+
+def _combined_text(seg: Any) -> str:
+    text = str(_seg_attr(seg, "text", "") or "")
+    heading = _seg_attr(seg, "heading")
+    if heading:
+        return f"{heading}\n{text}" if text else str(heading)
+    return text
+
+
+def _clause_id(seg: Any) -> str:
+    number = _seg_attr(seg, "number")
+    if isinstance(number, str) and number:
+        return number
+    seg_id = _seg_attr(seg, "id")
+    return str(seg_id) if seg_id is not None else "?"
+
+
+def _seg_span(seg: Any) -> Optional[Tuple[int, int]]:
+    start = _seg_attr(seg, "start")
+    end = _seg_attr(seg, "end")
+    if isinstance(start, int) and isinstance(end, int):
+        return (start, end)
+    return None
+
+
+def _make_source(seg: Any, note: Optional[str] = None) -> SourceRef:
+    return SourceRef(clause_id=_clause_id(seg), span=_seg_span(seg), note=note)
+
+
+def _extract_grace_period(segments: Sequence[Any]) -> Optional[Duration]:
+    for seg in segments:
+        combined = _combined_text(seg)
+        if combined and _GRACE_PATTERN.search(combined):
+            lower = combined.lower()
+            idx = lower.find("grace period")
+            snippet = combined[idx:] if idx >= 0 else combined
+            duration = _extract_duration_from_text(snippet)
+            if duration:
+                return duration
+    return None
+
+
+def _extract_contract_term(l0: Optional[LxDocFeatures]) -> Optional[Duration]:
+    if not l0:
+        return None
+    for seg_id, features in (l0.by_segment or {}).items():
+        labels = getattr(features, "labels", [])
+        durations = getattr(features, "durations", {})
+        if "Term" not in labels:
+            continue
+        days = durations.get("days")
+        if isinstance(days, int) and days > 0:
+            return Duration(days=days, kind="calendar")
+    return None
+
+
+def _normalize_currency(value: Optional[str]) -> Optional[str]:
+    if not value or not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if cleaned in Money._symbol_map:
+        return Money._symbol_map[cleaned]
+    cleaned = cleaned.upper()
+    if len(cleaned) == 3:
+        return cleaned
+    return None
+
+
+def _annex_refs(full_text: str) -> List[str]:
+    refs = set()
+    for match in _ANNEX_RE.finditer(full_text or ""):
+        prefix = match.group("prefix") or "annex"
+        label = match.group("label") or ""
+        formatted = f"{prefix.title()} {label.upper()}" if label.isalpha() else f"{prefix.title()} {label}"
+        refs.add(formatted)
+    return sorted(refs)
+
+
+def _first_segment_matching(segments: Sequence[Any], pattern: re.Pattern[str]) -> Optional[Any]:
+    for seg in segments:
+        combined = _combined_text(seg)
+        if combined and pattern.search(combined):
+            return seg
+    return None
+
+
+def _full_text_from_segments(segments: Sequence[Any]) -> str:
+    parts: List[str] = []
+    for seg in segments:
+        combined = _combined_text(seg)
+        if combined:
+            parts.append(combined)
+    return "\n".join(parts)
+
+
+def _collect_survival_items(segments: Sequence[Any]) -> set[str]:
+    items: set[str] = set()
+    for seg in segments:
+        combined = _combined_text(seg)
+        if combined and _SURVIVE_PATTERN.search(combined):
+            items.update(_extract_survival_items(combined))
+    return items
+
+
+def build_param_graph(
+    snapshot: Any,
+    segments: Sequence[Any],
+    l0_features: Optional[LxDocFeatures],
+) -> ParamGraph:
+    segments_list = list(_iter_segments(segments))
+    full_text = _full_text_from_segments(segments_list)
+    parsed = SimpleNamespace(normalized_text=full_text, segments=segments_list)
+
+    payment_term = _extract_payment_term_days(parsed, segments_list)
+    notice_period = _extract_notice_days(parsed, segments_list)
+    cure_period = _extract_cure_days(parsed, segments_list)
+    cross_refs = _extract_cross_refs(parsed, segments_list)
+    order_of_precedence = _detect_order_of_precedence(parsed, segments_list)
+    undefined_terms = _detect_undefined_terms(parsed, segments_list)
+    numbering_gaps = _detect_numbering_gaps(parsed, segments_list)
+    grace_period = _extract_grace_period(segments_list)
+    contract_term = _extract_contract_term(l0_features)
+    survival_items = _collect_survival_items(segments_list)
+    annex_refs = _annex_refs(full_text)
+
+    parties = []
+    try:
+        for party in getattr(snapshot, "parties", []) or []:
+            if hasattr(party, "model_dump"):
+                parties.append(party.model_dump(exclude_none=True))
+            elif isinstance(party, dict):
+                parties.append({k: v for k, v in party.items() if v is not None})
+    except Exception:
+        parties = []
+
+    signatures = []
+    for sig in getattr(snapshot, "signatures", []) or []:
+        if isinstance(sig, dict):
+            signatures.append(sig)
+        else:
+            signatures.append({"raw": str(sig)})
+
+    law = getattr(snapshot, "governing_law", None)
+    juris = getattr(snapshot, "jurisdiction", None)
+
+    cap = None
+    liability = getattr(snapshot, "liability", None)
+    if liability and getattr(liability, "has_cap", False):
+        cap_value = getattr(liability, "cap_value", None)
+        cap_currency = getattr(liability, "cap_currency", None)
+        if cap_value is not None and cap_currency:
+            try:
+                amount = Decimal(str(cap_value))
+                currency = _normalize_currency(cap_currency)
+                if currency:
+                    cap = Money(amount=amount, currency=currency)
+            except Exception:
+                cap = None
+
+    contract_currency = _normalize_currency(getattr(snapshot, "currency", None))
+
+    pg = ParamGraph(
+        payment_term=payment_term,
+        contract_term=contract_term,
+        grace_period=grace_period,
+        governing_law=law,
+        jurisdiction=juris,
+        cap=cap,
+        contract_currency=contract_currency,
+        notice_period=notice_period,
+        cure_period=cure_period,
+        survival_items=survival_items,
+        cross_refs=cross_refs,
+        parties=parties,
+        signatures=signatures,
+        annex_refs=annex_refs,
+        order_of_precedence=order_of_precedence,
+        undefined_terms=undefined_terms,
+        numbering_gaps=numbering_gaps,
+    )
+
+    sources: Dict[str, SourceRef] = {}
+
+    seg_payment = _first_segment_matching(segments_list, _PAYMENT_PATTERN)
+    if payment_term and seg_payment:
+        sources["payment_term"] = _make_source(seg_payment)
+
+    seg_notice = _first_segment_matching(segments_list, _NOTICE_PATTERN)
+    if notice_period and seg_notice:
+        sources["notice_period"] = _make_source(seg_notice)
+
+    seg_cure = _first_segment_matching(segments_list, _CURE_PATTERN)
+    if cure_period and seg_cure:
+        sources["cure_period"] = _make_source(seg_cure)
+
+    seg_grace = _first_segment_matching(segments_list, _GRACE_PATTERN)
+    if grace_period and seg_grace:
+        sources["grace_period"] = _make_source(seg_grace)
+
+    seg_law = _first_segment_matching(segments_list, _LAW_PATTERN)
+    if law and seg_law:
+        sources["governing_law"] = _make_source(seg_law)
+
+    seg_jur = _first_segment_matching(segments_list, _JUR_PATTERN)
+    if juris and seg_jur:
+        sources["jurisdiction"] = _make_source(seg_jur)
+
+    seg_cap = _first_segment_matching(segments_list, _CAP_PATTERN)
+    if cap and seg_cap:
+        sources["cap"] = _make_source(seg_cap)
+
+    seg_currency = _first_segment_matching(segments_list, _CURRENCY_PATTERN)
+    if contract_currency and seg_currency:
+        sources["contract_currency"] = _make_source(seg_currency)
+
+    seg_survival = _first_segment_matching(segments_list, _SURVIVE_PATTERN)
+    if survival_items and seg_survival:
+        sources["survival_items"] = _make_source(seg_survival)
+
+    seg_cross = _first_segment_matching(segments_list, _CROSS_PATTERN)
+    if cross_refs and seg_cross:
+        sources["cross_refs"] = _make_source(seg_cross, note=f"{len(cross_refs)} cross-ref(s)")
+
+    seg_annex = _first_segment_matching(segments_list, _ANNEX_RE)
+    if annex_refs and seg_annex:
+        sources["annex_refs"] = _make_source(seg_annex)
+
+    if undefined_terms:
+        term = undefined_terms[0]
+        for seg in segments_list:
+            combined = _combined_text(seg)
+            if combined and term in combined:
+                sources["undefined_terms"] = _make_source(seg, note=term)
+                break
+
+    if numbering_gaps:
+        seg_numbering = None
+        for seg in segments_list:
+            if _seg_attr(seg, "number"):
+                seg_numbering = seg
+                break
+        if seg_numbering:
+            sources["numbering_gaps"] = _make_source(seg_numbering, note=", ".join(map(str, numbering_gaps)))
+
+    if parties:
+        seg_parties = None
+        for seg in segments_list:
+            combined = _combined_text(seg)
+            if combined and "between" in combined.lower():
+                seg_parties = seg
+                break
+        if seg_parties:
+            sources["parties"] = _make_source(seg_parties)
+
+    if signatures:
+        seg_sign = None
+        for seg in segments_list:
+            combined = _combined_text(seg)
+            if combined and "signed" in combined.lower():
+                seg_sign = seg
+                break
+        if seg_sign:
+            sources["signatures"] = _make_source(seg_sign)
+
+    pg.sources = sources
+    return pg

--- a/tests/lx/test_pg_extract.py
+++ b/tests/lx/test_pg_extract.py
@@ -1,0 +1,130 @@
+from decimal import Decimal
+
+from contract_review_app.analysis.extract_summary import extract_document_snapshot
+from contract_review_app.analysis.lx_features import extract_l0_features
+from contract_review_app.analysis.parser import parse_text
+from contract_review_app.core.lx_types import Duration, ParamGraph
+from contract_review_app.legal_rules.constraints import build_param_graph
+
+
+CONTRACT_TEXT = """
+This Services Agreement (the "Agreement") is made between Acme Corp (the "Seller") and Beta LLC (the "Buyer").
+
+1. PAYMENT TERMS
+Payment shall be made net 30 days from the date of invoice. Late payments incur interest after a grace period of five (5) days.
+
+2. TERM AND TERMINATION
+2.1 Term. The Agreement shall remain in force for sixty (60) days from the Effective Date.
+2.2 Termination for Convenience. Either party may terminate this Agreement for convenience upon thirty (30) days' prior written notice.
+2.3 Cure. The breaching party shall cure any breach within fifteen (15) business days after notice.
+The following provisions shall survive termination: confidentiality and limitation of liability.
+
+4. MISCELLANEOUS
+See Clause 2.1 for details about the Term. Annex A describes the deliverables. The parties acknowledge the "Service Credits" shall apply when service levels are missed.
+
+GOVERNING LAW
+This Agreement shall be governed by the laws of England and Wales, and the parties submit to the exclusive jurisdiction of the courts of Scotland.
+
+LIABILITY
+The aggregate liability of either party shall be capped at £500,000.
+
+SIGNED by John Doe on 1 January 2024
+"""
+
+
+REORDERED_TEXT = """
+This Services Agreement (the "Agreement") is made between Acme Corp (the "Seller") and Beta LLC (the "Buyer").
+
+4. MISCELLANEOUS
+See Clause 2.1 for details about the Term. Annex A describes the deliverables. The parties acknowledge the "Service Credits" shall apply when service levels are missed.
+
+2. TERM AND TERMINATION
+2.1 Term. The Agreement shall remain in force for sixty (60) days from the Effective Date.
+2.2 Termination for Convenience. Either party may terminate this Agreement for convenience upon thirty (30) days' prior written notice.
+2.3 Cure. The breaching party shall cure any breach within fifteen (15) business days after notice.
+The following provisions shall survive termination: confidentiality and limitation of liability.
+
+1. PAYMENT TERMS
+Payment shall be made net 30 days from the date of invoice. Late payments incur interest after a grace period of five (5) days.
+
+GOVERNING LAW
+This Agreement shall be governed by the laws of England and Wales, and the parties submit to the exclusive jurisdiction of the courts of Scotland.
+
+LIABILITY
+The aggregate liability of either party shall be capped at £500,000.
+
+SIGNED by John Doe on 1 January 2024
+"""
+
+
+def _build_pg(text: str) -> ParamGraph:
+    parsed = parse_text(text)
+    snapshot = extract_document_snapshot(text)
+    features = extract_l0_features(text, parsed.segments)
+    return build_param_graph(snapshot, parsed.segments, features)
+
+
+def test_param_graph_extracts_core_parameters():
+    pg = _build_pg(CONTRACT_TEXT)
+
+    assert isinstance(pg.payment_term, Duration)
+    assert pg.payment_term.days == 30
+    assert pg.payment_term.kind == "calendar"
+
+    assert isinstance(pg.notice_period, Duration)
+    assert pg.notice_period.days == 30
+
+    assert isinstance(pg.cure_period, Duration)
+    assert pg.cure_period.days == 21
+    assert pg.cure_period.kind == "business"
+
+    assert isinstance(pg.grace_period, Duration)
+    assert pg.grace_period.days == 5
+
+    assert isinstance(pg.contract_term, Duration)
+    assert pg.contract_term.days == 60
+
+    assert pg.governing_law == "England and Wales"
+    assert "Scotland" in (pg.jurisdiction or "")
+
+    assert pg.cap is not None
+    assert pg.cap.amount == Decimal("500000")
+    assert pg.cap.currency == "GBP"
+
+    assert pg.contract_currency == "GBP"
+
+    assert sorted(pg.survival_items) == ["confidentiality", "limitation of liability"]
+
+    assert ("4", "2.1") in pg.cross_refs
+    assert pg.annex_refs == ["Annex A"]
+    assert pg.order_of_precedence is False
+
+    assert "Service Credits" in pg.undefined_terms
+    assert pg.numbering_gaps == [3]
+
+    assert len(pg.parties) == 2
+    party_names = sorted(p.get("name") for p in pg.parties)
+    assert party_names == ["Acme Corp", "Beta LLC"]
+
+    assert pg.signatures and "John Doe" in pg.signatures[0]["raw"]
+
+    assert {"payment_term", "notice_period", "cure_period", "cap"}.issubset(pg.sources.keys())
+    assert pg.sources["payment_term"].clause_id == "1"
+
+
+def test_param_graph_stable_under_reordering():
+    pg_original = _build_pg(CONTRACT_TEXT)
+    pg_reordered = _build_pg(REORDERED_TEXT)
+
+    assert pg_original.payment_term == pg_reordered.payment_term
+    assert pg_original.notice_period == pg_reordered.notice_period
+    assert pg_original.cure_period == pg_reordered.cure_period
+    assert pg_original.governing_law == pg_reordered.governing_law
+    assert pg_original.jurisdiction == pg_reordered.jurisdiction
+    assert pg_original.cap == pg_reordered.cap
+    assert pg_original.contract_currency == pg_reordered.contract_currency
+    assert pg_original.survival_items == pg_reordered.survival_items
+    assert pg_original.cross_refs == pg_reordered.cross_refs
+    assert pg_original.annex_refs == pg_reordered.annex_refs
+    assert pg_original.undefined_terms == pg_reordered.undefined_terms
+    assert pg_original.numbering_gaps == pg_reordered.numbering_gaps


### PR DESCRIPTION
## Summary
- add duration, cross-reference, and numbering helpers in the summary extractor to power param graph inputs
- build a comprehensive `build_param_graph` pipeline that normalizes currencies, days, survival items, and source references
- extend the ParamGraph model and add regression tests covering NDA-style samples and section reordering stability

## Testing
- `pytest tests/lx/test_pg_extract.py`
- `pytest tests/lx/test_pg_types.py`


------
https://chatgpt.com/codex/tasks/task_e_68cebf6580c88325b231e7cd65daf5aa