### PR TITLE
Add L2 constraints catalog and regression tests

### DIFF
--- a/tests/lx/test_pg_extract.py
+++ b/tests/lx/test_pg_extract.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from types import SimpleNamespace
 
 from contract_review_app.analysis.extract_summary import extract_document_snapshot
 from contract_review_app.analysis.lx_features import extract_l0_features
@@ -128,3 +129,35 @@ def test_param_graph_stable_under_reordering():
     assert pg_original.annex_refs == pg_reordered.annex_refs
     assert pg_original.undefined_terms == pg_reordered.undefined_terms
     assert pg_original.numbering_gaps == pg_reordered.numbering_gaps
+
+
+def test_param_graph_threads_doc_flags_from_snapshot():
+    snapshot = SimpleNamespace(
+        parties=[],
+        signatures=[],
+        liability=None,
+        governing_law=None,
+        jurisdiction=None,
+        currency=None,
+        doc_flags={"flag_a": True, "flag_b": False},
+    )
+
+    pg = build_param_graph(snapshot, [], None)
+
+    assert pg.doc_flags == {"flag_a": True, "flag_b": False}
+
+
+def test_param_graph_threads_doc_flags_from_debug():
+    snapshot = SimpleNamespace(
+        parties=[],
+        signatures=[],
+        liability=None,
+        governing_law=None,
+        jurisdiction=None,
+        currency=None,
+        debug={"doc_flags": {"flag_c": True}},
+    )
+
+    pg = build_param_graph(snapshot, [], None)
+
+    assert pg.doc_flags == {"flag_c": True}


### PR DESCRIPTION
## Summary
- implement the V1 catalog of 43 L2 constraints covering parties, durations, liability, confidentiality, regulatory, force majeure, data protection, references, and commercial anomalies
- extend the constraint evaluator with helper functions and utilities for company name normalisation, address checks, doc flag handling, and region matching
- add a dedicated ParamGraph doc_flags field and create regression tests for positive and negative scenarios across all constraints
- thread snapshot-level document flags into the ParamGraph builder and cover forwarding logic with unit tests

## Testing
- pytest tests/lx/test_pg_extract.py
- pytest tests/lx/test_l2_ruleset_v1.py

------
https://chatgpt.com/codex/tasks/task_e_68cecbf252e48325815a37d6ed2f5838