### PR TITLE
Integrate L2 constraints into analyze pipeline

### DIFF
--- a/contract_review_app/legal_rules/constraints.py
+++ b/contract_review_app/legal_rules/constraints.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from dataclasses import dataclass
+import json
 import re
 from types import SimpleNamespace
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
@@ -36,6 +37,7 @@ __all__ = [
     "InternalFinding",
     "load_constraints",
     "eval_constraints",
+    "to_trace",
 ]
 
 
@@ -1622,3 +1624,34 @@ def eval_constraints(pg: ParamGraph, findings_in: List[InternalFinding]) -> List
             )
         )
     return findings
+
+
+def _model_to_dict(model: Any) -> Dict[str, Any]:
+    if hasattr(model, "model_dump_json"):
+        try:
+            return json.loads(model.model_dump_json(exclude_none=True))
+        except Exception:
+            pass
+    if hasattr(model, "model_dump"):
+        try:
+            data = model.model_dump(exclude_none=True)
+        except Exception:
+            data = model.model_dump()
+        if isinstance(data, dict):
+            return {k: v for k, v in data.items() if v is not None}
+    if isinstance(model, dict):
+        return {k: v for k, v in model.items() if v is not None}
+    return {}
+
+
+def to_trace(pg: ParamGraph, findings: Iterable[Any]) -> Dict[str, Any]:
+    """Serialize constraint evaluation artefacts for trace storage."""
+
+    payload = {
+        "param_graph": _model_to_dict(pg),
+        "findings": [],
+    }
+    for item in findings or []:
+        if isinstance(item, InternalFinding):
+            payload["findings"].append(_model_to_dict(item))
+    return payload

--- a/tests/server/test_analyze_l2_wire.py
+++ b/tests/server/test_analyze_l2_wire.py
@@ -1,0 +1,71 @@
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import TRACE
+
+
+TEXT = """
+This Agreement shall be governed by the laws of England and Wales.
+
+The parties submit to the exclusive jurisdiction of the courts of France.
+"""
+
+
+def _call_analyze(client: TestClient) -> tuple[dict, str]:
+    response = client.post("/api/analyze", json={"text": TEXT})
+    assert response.status_code == 200
+    return response.json(), response.headers.get("x-cid", "")
+
+
+def test_l2_constraints_toggle(monkeypatch):
+    from contract_review_app.api import app as app_module
+
+    monkeypatch.setattr(app_module, "FEATURE_LX_ENGINE", True, raising=False)
+    monkeypatch.setattr(app_module, "LX_L2_CONSTRAINTS", False, raising=False)
+
+    client = TestClient(app_module.app)
+    client.headers.update(
+        {"x-api-key": "test", "x-schema-version": app_module.SCHEMA_VERSION}
+    )
+
+    baseline_payload, baseline_cid = _call_analyze(client)
+    assert baseline_cid
+    baseline_findings = baseline_payload["analysis"]["findings"]
+    assert all(
+        not str(f.get("rule_id", "")).startswith("L2::") for f in baseline_findings
+    )
+
+    baseline_trace = TRACE.get(baseline_cid)
+    assert baseline_trace is not None
+    assert "constraints" not in (baseline_trace.get("body") or {})
+
+    app_module.an_cache._data.clear()
+    app_module.IDEMPOTENCY_CACHE._data.clear()
+    app_module.cid_index._data.clear()
+
+    monkeypatch.setattr(app_module, "LX_L2_CONSTRAINTS", True, raising=False)
+
+    enhanced_payload, enhanced_cid = _call_analyze(client)
+    assert enhanced_cid
+    enhanced_findings = enhanced_payload["analysis"]["findings"]
+
+    non_l2_baseline = [
+        f for f in baseline_findings if not str(f.get("rule_id", "")).startswith("L2::")
+    ]
+    non_l2_enhanced = [
+        f for f in enhanced_findings if not str(f.get("rule_id", "")).startswith("L2::")
+    ]
+    assert non_l2_enhanced == non_l2_baseline
+
+    l2_findings = [
+        f for f in enhanced_findings if str(f.get("rule_id", "")).startswith("L2::")
+    ]
+    assert l2_findings, "L2 findings should appear when the flag is enabled"
+    assert any(f.get("rule_id") == "L2::L2-010" for f in l2_findings)
+
+    trace_entry = TRACE.get(enhanced_cid)
+    assert trace_entry is not None
+    constraints_payload = (trace_entry.get("body") or {}).get("constraints")
+    assert constraints_payload is not None
+    assert isinstance(constraints_payload.get("param_graph"), dict)
+    trace_findings = constraints_payload.get("findings") or []
+    assert any(item.get("rule_id") == "L2::L2-010" for item in trace_findings)

--- a/tests/server/test_fields_propagation.py
+++ b/tests/server/test_fields_propagation.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
 
 client = TestClient(app)
+client.headers.update({"x-api-key": "test", "x-schema-version": SCHEMA_VERSION})
 
 TEXT = Path('tests/fixtures/quality_clause13.txt').read_text()
 

--- a/tests/server/test_fields_propagation_ipr.py
+++ b/tests/server/test_fields_propagation_ipr.py
@@ -1,7 +1,9 @@
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
 
 client = TestClient(app)
+client.headers.update({"x-api-key": "test", "x-schema-version": SCHEMA_VERSION})
 
 def test_ipr_fields_propagation_minimal():
     body = {"text": "Title to the Agreement Documentation shall vest in Company."}

--- a/tests/server/test_fields_propagation_quality.py
+++ b/tests/server/test_fields_propagation_quality.py
@@ -1,7 +1,9 @@
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
 
 client = TestClient(app)
+client.headers.update({"x-api-key": "test", "x-schema-version": SCHEMA_VERSION})
 
 TEXT = "Contractor shall produce an inspection and test plan (ITP). The ITP will list inspections only."
 

--- a/tests/server/test_fields_propagation_title.py
+++ b/tests/server/test_fields_propagation_title.py
@@ -1,7 +1,9 @@
 from fastapi.testclient import TestClient
 from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
 
 client = TestClient(app)
+client.headers.update({"x-api-key": "test", "x-schema-version": SCHEMA_VERSION})
 
 def test_title_fields_propagation_minimal():
     body = {"text": "Title shall vest in Company upon manufacture or identification to this Agreement."}


### PR DESCRIPTION
## Summary
- gate L2 evaluation in /api/analyze behind a new LX_L2_CONSTRAINTS flag, merge constraint findings, and emit constraint traces
- add trace serialization helpers for ParamGraph constraint runs and adjust analysis normalization to prefer top-level findings
- extend server tests to set required headers and cover the L2 toggle behaviour and trace payload

## Testing
- pytest tests/server

------
https://chatgpt.com/codex/tasks/task_e_68cecbc903688325ad3d8d43b45e584c