### PR TITLE
Implement deterministic L1/L2 merge policy

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -49,6 +49,7 @@ from contract_review_app.core.lx_types import LxFeatureSet, LxSegment
 from contract_review_app.config import CH_ENABLED, CH_API_KEY
 from contract_review_app.utils.logging import logger as cai_logger
 from contract_review_app.legal_rules import constraints
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
 from contract_review_app.legal_rules.constraints import InternalFinding
 
 
@@ -2189,7 +2190,7 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
             )
             seen_ids.add(str(rule_id))
 
-        return merged
+        return apply_merge_policy(merged)
 
     # resolve citations for each finding after final list is determined
     def _add_citations(lst: List[Dict[str, Any]]):

--- a/contract_review_app/legal_rules/aggregate.py
+++ b/contract_review_app/legal_rules/aggregate.py
@@ -1,0 +1,165 @@
+"""Utilities for deterministic aggregation of rule findings."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Tuple
+
+__all__ = ["apply_merge_policy"]
+
+# Priority order for channels when conflicts share the same span.
+_CHANNEL_PRIORITY = {
+    "law": 0,
+    "policy": 1,
+    "substantive": 2,
+    "drafting": 3,
+    "grammar": 4,
+}
+_DEFAULT_CHANNEL_RANK = len(_CHANNEL_PRIORITY)
+
+# Severity ranking (higher numbers mean higher severity).
+_SEVERITY_PRIORITY = {
+    "critical": 4,
+    "severe": 4,
+    "blocker": 4,
+    "major": 3,
+    "high": 3,
+    "medium": 2,
+    "moderate": 2,
+    "minor": 1,
+    "low": 1,
+    "info": 0,
+    "informational": 0,
+}
+
+_MAX_POSITION = 10 ** 12
+
+
+def apply_merge_policy(findings: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return a deterministically ordered list with conflicts resolved.
+
+    Conflicts are defined as findings that share the same span (start/end
+    coordinates). Only the highest-priority finding for each span is kept.  The
+    priority order is: channel, severity, length, rule_id.  The output list is
+    always sorted deterministically so identical inputs yield identical outputs.
+    """
+
+    items = [f for f in findings if isinstance(f, dict)]
+    if not items:
+        return []
+
+    buckets: Dict[Tuple[Any, ...], List[Dict[str, Any]]] = {}
+    for idx, finding in enumerate(items):
+        key = _bucket_key(finding, idx)
+        buckets.setdefault(key, []).append(finding)
+
+    resolved: List[Dict[str, Any]] = []
+    for key, bucket in buckets.items():
+        if key[0] == "span":
+            best = min(bucket, key=_priority_tuple)
+            resolved.append(best)
+        else:
+            resolved.extend(sorted(bucket, key=_priority_tuple))
+
+    resolved.sort(key=_final_sort_key)
+    return list(resolved)
+
+
+def _bucket_key(finding: Dict[str, Any], idx: int) -> Tuple[Any, ...]:
+    start = _coerce_int(finding.get("start"))
+    end = _coerce_int(finding.get("end"))
+    if start is not None and end is not None:
+        return ("span", start, end)
+
+    anchors = finding.get("anchors")
+    if isinstance(anchors, list) and anchors:
+        anchor = anchors[0]
+        if isinstance(anchor, dict):
+            span = anchor.get("span")
+            if (
+                isinstance(span, (list, tuple))
+                and len(span) == 2
+            ):
+                a_start = _coerce_int(span[0])
+                a_end = _coerce_int(span[1])
+                if a_start is not None and a_end is not None:
+                    return ("span", a_start, a_end)
+    return ("idx", idx)
+
+
+def _priority_tuple(finding: Dict[str, Any]) -> Tuple[Any, ...]:
+    return (
+        _channel_rank(finding),
+        -_severity_rank(finding),
+        -_span_length(finding),
+        str(finding.get("rule_id") or ""),
+    )
+
+
+def _final_sort_key(finding: Dict[str, Any]) -> Tuple[Any, ...]:
+    start = _coerce_int(finding.get("start"))
+    end = _coerce_int(finding.get("end"))
+    if start is None:
+        start = _MAX_POSITION
+    if end is None:
+        end = _MAX_POSITION
+    return (
+        start,
+        end,
+        _channel_rank(finding),
+        -_severity_rank(finding),
+        -_span_length(finding),
+        str(finding.get("rule_id") or ""),
+    )
+
+
+def _channel_rank(finding: Dict[str, Any]) -> int:
+    channel = _infer_channel(finding)
+    return _CHANNEL_PRIORITY.get(channel.lower(), _DEFAULT_CHANNEL_RANK)
+
+
+def _infer_channel(finding: Dict[str, Any]) -> str:
+    channel = finding.get("channel")
+    if isinstance(channel, str) and channel.strip():
+        return channel.strip()
+
+    source = finding.get("source")
+    if isinstance(source, str) and source.strip():
+        if source.strip().lower() == "constraints":
+            return "Law"
+
+    rule_id = finding.get("rule_id")
+    if isinstance(rule_id, str) and rule_id.upper().startswith("L2"):
+        return "Law"
+
+    return ""
+
+
+def _severity_rank(finding: Dict[str, Any]) -> int:
+    severity = finding.get("severity") or finding.get("severity_level")
+    if not isinstance(severity, str):
+        severity = str(severity or "")
+    severity_norm = severity.strip().lower()
+    return _SEVERITY_PRIORITY.get(severity_norm, 0)
+
+
+def _span_length(finding: Dict[str, Any]) -> int:
+    start = _coerce_int(finding.get("start"))
+    end = _coerce_int(finding.get("end"))
+    if start is not None and end is not None:
+        length = end - start
+        if length >= 0:
+            return length
+    snippet = finding.get("snippet") or finding.get("message") or ""
+    return len(str(snippet))
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):  # bool is subclass of int; filter out explicitly
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if value is None:
+        return None
+    try:
+        return int(str(value))
+    except Exception:
+        return None

--- a/tests/lx/test_merge_policy.py
+++ b/tests/lx/test_merge_policy.py
@@ -1,0 +1,83 @@
+import itertools
+
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
+
+
+def _finding(
+    channel: str,
+    severity: str = "medium",
+    start: int = 0,
+    end: int = 10,
+    rule_id: str = "R-001",
+    snippet: str | None = None,
+) -> dict:
+    return {
+        "channel": channel,
+        "severity": severity,
+        "start": start,
+        "end": end,
+        "rule_id": rule_id,
+        "snippet": snippet if snippet is not None else "x" * max(end - start, 1),
+    }
+
+
+def test_channel_priority_beats_other_attributes():
+    law_finding = _finding("Law", severity="medium", rule_id="LAW")
+    policy_finding = _finding("Policy", severity="critical", rule_id="POL")
+
+    merged = apply_merge_policy([policy_finding, law_finding])
+
+    assert len(merged) == 1
+    assert merged[0]["rule_id"] == "LAW"
+
+
+def test_severity_breaks_ties_within_channel():
+    low = _finding("Policy", severity="medium", rule_id="POL-LOW")
+    high = _finding("Policy", severity="critical", rule_id="POL-HIGH")
+
+    merged = apply_merge_policy([low, high])
+
+    assert len(merged) == 1
+    assert merged[0]["rule_id"] == "POL-HIGH"
+
+
+def test_snippet_length_breaks_severity_ties():
+    shorter = _finding("Policy", severity="medium", snippet="short", rule_id="S1")
+    longer = _finding("Policy", severity="medium", snippet="longer text", rule_id="L1")
+
+    merged = apply_merge_policy([shorter, longer])
+
+    assert len(merged) == 1
+    assert merged[0]["rule_id"] == "L1"
+
+
+def test_rule_id_breaks_all_other_ties():
+    first = _finding("Policy", severity="medium", rule_id="A")
+    second = _finding("Policy", severity="medium", rule_id="B")
+
+    merged = apply_merge_policy([second, first])
+
+    assert len(merged) == 1
+    assert merged[0]["rule_id"] == "A"
+
+
+def test_overlapping_spans_preserve_best_per_span():
+    dominant = _finding("Law", severity="medium", start=0, end=10, rule_id="LAW")
+    weaker = _finding("Policy", severity="medium", start=0, end=10, rule_id="POL")
+    other = _finding("Substantive", severity="medium", start=5, end=15, rule_id="SUB")
+
+    merged = apply_merge_policy([weaker, other, dominant])
+
+    assert [f["rule_id"] for f in merged] == ["LAW", "SUB"]
+
+
+def test_merge_policy_is_deterministic():
+    base = [
+        _finding("Policy", severity="medium", start=0, end=10, rule_id="P1"),
+        _finding("Law", severity="medium", start=0, end=10, rule_id="L1"),
+        _finding("Grammar", severity="low", start=20, end=30, rule_id="G1"),
+    ]
+
+    expected = apply_merge_policy(base)
+    for perm in itertools.permutations(base):
+        assert apply_merge_policy(list(perm)) == expected


### PR DESCRIPTION
## Summary
- add `apply_merge_policy` helper to enforce deterministic tie-breaking across channels, severity, span length and rule id
- integrate the merge policy into the API's L1/L2 findings merger so conflicts resolve consistently before citations
- cover the new behaviour with dedicated `tests/lx/test_merge_policy.py`

## Testing
- pytest tests/lx/test_merge_policy.py

------
https://chatgpt.com/codex/tasks/task_e_68cecf6e71708325ba8d73fc5bfcab1b