### PR TITLE
Optimize constraint evaluation caches

### DIFF
--- a/contract_review_app/analysis/extract_summary.py
+++ b/contract_review_app/analysis/extract_summary.py
@@ -61,6 +61,12 @@ _WARR_RE = re.compile(r"[^.]*warrant[^.]*", re.I)
 _CURRENCY_MAP = {"£": "GBP", "$": "USD", "€": "EUR"}
 
 
+_SUBJECT_SECTIONS = ("purpose", "scope", "services", "background", "recitals")
+_SUBJECT_PATTERNS: Tuple[Tuple[str, re.Pattern[str]], ...] = tuple(
+    (sec, re.compile(rf"^\s*{sec}\b[\s:]*\n(.{{0,400}})", re.I | re.M)) for sec in _SUBJECT_SECTIONS
+)
+
+
 def _iter_segments(segments: Iterable[Any]) -> Iterable[Tuple[int, str, Optional[str], Optional[int], Optional[int], Optional[str]]]:
     """Yield normalized segment information from dicts/objects."""
 
@@ -339,9 +345,7 @@ def _extract_cw(text: str, hints: List[str]) -> ConditionsVsWarranties:
 
 
 def _extract_subject(text: str) -> Optional[dict]:
-    sections = ["purpose", "scope", "services", "background", "recitals"]
-    for sec in sections:
-        pattern = re.compile(rf"^\s*{sec}\b[\s:]*\n(.{{0,400}})", re.I | re.M)
+    for sec, pattern in _SUBJECT_PATTERNS:
         m = pattern.search(text)
         if m:
             content = m.group(1).strip()


### PR DESCRIPTION
## Summary
- cache parsed constraint ASTs and identifier sets per rule id to avoid repeated parsing
- stop evaluating remaining constraints once an inconclusive result is encountered
- precompile subject section regex patterns at import time in extract_summary

## Testing
- pytest tests/perf/test_l2_perf.py

------
https://chatgpt.com/codex/tasks/task_e_68ced1a37c2883258bff94b16371d611