### PR TITLE
Send risk threshold with analyze requests

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.body.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/analyze.body.spec.ts
@@ -11,7 +11,7 @@ describe('analyze request body', () => {
     await analyze({ text: 'hi' });
     const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
     const body = JSON.parse(bodyStr);
-    expect(body).toMatchObject({ text: 'hi', mode: 'live', schema: '1.4' });
+    expect(body).toMatchObject({ text: 'hi', mode: 'live', schema: '1.4', risk: 'medium' });
     expect('payload' in body).toBe(false);
     expect(headers['x-schema-version']).toBe('1.4');
   });
@@ -23,7 +23,7 @@ describe('analyze request body', () => {
     await analyze({ schema: '1.4', mode: 'test', text: 'hi' });
     const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
     const body = JSON.parse(bodyStr);
-    expect(body).toMatchObject({ text: 'hi', mode: 'test', schema: '1.4' });
+    expect(body).toMatchObject({ text: 'hi', mode: 'test', schema: '1.4', risk: 'medium' });
     expect('payload' in body).toBe(false);
     expect(headers['x-schema-version']).toBe('1.4');
   });

--- a/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/api-client.ts
@@ -245,6 +245,7 @@ export async function analyze(opts: any = {}) {
   const body = {
     text:  opts?.text ?? opts?.content,
     mode:  opts?.mode ?? 'live',
+    risk:  opts?.risk ?? 'medium',
   };
   const { resp, json } = await postJSON('/api/analyze', body);
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1,6 +1,6 @@
 import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, analyze, apiQaRecheck } from "./api-client.ts";
 import domSchema from "../panel_dom.schema.json";
-import { normalizeText, severityRank, dedupeFindings } from "./dedupe.ts";
+import { normalizeText, dedupeFindings } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
 import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment, fallbackAnnotateWithContentControl } from "./annotate.ts";
 import { findAnchors } from "./anchors.ts";
@@ -208,10 +208,14 @@ function slot(id: string, role: string): HTMLElement {
   return mustGetElementById<HTMLElement>(id);
 }
 
-export function getRiskThreshold(): "low" | "medium" | "high" {
-  const sel = mustGetElementById<HTMLSelectElement>("selectRiskThreshold");
-  const v = sel.value.toLowerCase();
-  return (v === "low" || v === "medium" || v === "high") ? v : "medium";
+export function getRiskThreshold(): "low" | "medium" | "high" | "critical" {
+  try {
+    const sel = mustGetElementById<HTMLSelectElement>("selectRiskThreshold");
+    const v = sel.value.toLowerCase();
+    return (v === "low" || v === "medium" || v === "high" || v === "critical") ? v : "medium";
+  } catch {
+    return "medium";
+  }
 }
 
 export function isAddCommentsOnAnalyzeEnabled(): boolean {
@@ -237,12 +241,8 @@ function isDryRunAnnotateEnabled(): boolean {
   return !!cb.checked;
 }
 
-function filterByThreshold(list: AnalyzeFinding[], thr: "low" | "medium" | "high"): AnalyzeFinding[] {
-  const min = severityRank(thr);
-  return (list || [])
-    .filter(f => f && f.rule_id && f.snippet)
-    .map(f => ({ ...f, clause_type: f.clause_type || 'Unknown' }))
-    .filter(f => severityRank(f.severity) >= min);
+function filterByThreshold(list: AnalyzeFinding[], _thr: "low" | "medium" | "high" | "critical"): AnalyzeFinding[] {
+  return Array.isArray(list) ? list : [];
 }
 
 function buildLegalComment(f: AnalyzeFinding): string {
@@ -997,7 +997,7 @@ async function doAnalyze() {
 
       ensureHeaders();
 
-      const { resp, json } = await analyze({ text: base, mode: currentMode });
+      const { resp, json } = await analyze({ text: base, mode: currentMode, risk: getRiskThreshold() });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const respSchema = resp.headers.get('x-schema-version');
       if (respSchema) setSchemaVersion(respSchema);

--- a/word_addin_dev/app/__tests__/analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.flow.spec.ts
@@ -15,7 +15,7 @@ describe('analyze flow', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
-    expect(body).toMatchObject({ text: 'hello', mode: 'live', schema: '1.4' });
+    expect(body).toMatchObject({ text: 'hello', mode: 'live', schema: '1.4', risk: 'medium' });
     expect(opts.headers['x-schema-version']).toBe('1.4');
   });
 });

--- a/word_addin_dev/app/__tests__/analyze.payload.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.payload.spec.ts
@@ -11,7 +11,7 @@ describe('analyze payload wrapper', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
-    expect(body).toMatchObject({ mode: 'live', text: 'hello', schema: '1.4' });
+    expect(body).toMatchObject({ mode: 'live', text: 'hello', schema: '1.4', risk: 'medium' });
     expect('payload' in body).toBe(false);
     expect(opts.headers['x-schema-version']).toBe('1.4');
   });

--- a/word_addin_dev/app/__tests__/analyze.risk.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.risk.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+function makeElement(overrides: any = {}) {
+  return Object.assign({
+    style: { display: '', removeProperty: vi.fn() },
+    classList: { add: vi.fn(), remove: vi.fn(), toggle: vi.fn() },
+    appendChild: vi.fn(),
+    removeChild: vi.fn(),
+    dispatchEvent: vi.fn(),
+    addEventListener: vi.fn(),
+    setAttribute: vi.fn(),
+    removeAttribute: vi.fn(),
+    innerHTML: '',
+    textContent: '',
+    value: '',
+  }, overrides);
+}
+
+describe('risk forwarding to analyze', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).document;
+    delete (globalThis as any).window;
+    delete (globalThis as any).localStorage;
+    delete (globalThis as any).fetch;
+    delete (globalThis as any).CustomEvent;
+    delete (globalThis as any).Office;
+    delete (globalThis as any).__CAI_TESTING__;
+  });
+
+  it('includes selected critical risk in analyze request body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, headers: new Headers(), json: async () => ({}) });
+    (globalThis as any).fetch = fetchMock;
+    (globalThis as any).window = { addEventListener() {}, removeEventListener() {}, dispatchEvent() {}, location: { search: '' } } as any;
+    (globalThis as any).document = { addEventListener() {}, querySelectorAll() { return [] as any; } } as any;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    const { analyze } = await import('../assets/api-client.ts');
+    await analyze({ text: 'hello', risk: 'critical' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, opts] = fetchMock.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body).toMatchObject({ text: 'hello', mode: 'live', schema: '1.4', risk: 'critical' });
+  });
+
+  it('does not drop findings already filtered by the server', async () => {
+    const serverFindings = [
+      { rule_id: 'F1', snippet: 'alpha', severity: 'critical' },
+    ];
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).window = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      location: { search: '' },
+      __CAI_TESTING__: true,
+    } as any;
+    const apiClient = await import('../assets/api-client.ts');
+    const analyzeSpy = vi.spyOn(apiClient, 'analyze').mockResolvedValue({
+      resp: {
+        ok: true,
+        status: 200,
+        headers: new Headers([
+          ['x-schema-version', '1.4'],
+          ['x-cid', 'demo'],
+        ]),
+      },
+      json: { analysis: { findings: serverFindings }, recommendations: [] },
+      meta: {},
+    } as any);
+    const parseFindingsSpy = vi.spyOn(apiClient, 'parseFindings').mockImplementation(() => serverFindings);
+
+    const annotateMod = await import('../assets/annotate.ts');
+    const planAnnotationsSpy = vi.spyOn(annotateMod, 'planAnnotations').mockImplementation((items: any[]) => items.map(f => ({ ...f, raw: f.snippet })) as any);
+    vi.spyOn(annotateMod, 'annotateFindingsIntoWord').mockResolvedValue();
+
+    const notifierMod = await import('../assets/notifier');
+    vi.spyOn(notifierMod, 'notifyOk').mockImplementation(() => {});
+    vi.spyOn(notifierMod, 'notifyErr').mockImplementation(() => {});
+    vi.spyOn(notifierMod, 'notifyWarn').mockImplementation(() => {});
+
+    const storeMod = await import('../assets/store.ts');
+    vi.spyOn(storeMod, 'getApiKeyFromStore').mockReturnValue('k');
+    vi.spyOn(storeMod, 'getSchemaFromStore').mockReturnValue('1.4');
+    vi.spyOn(storeMod, 'getAddCommentsFlag').mockReturnValue(false);
+    vi.spyOn(storeMod, 'setAddCommentsFlag').mockImplementation(() => {});
+    vi.spyOn(storeMod, 'setSchemaVersion').mockImplementation(() => {});
+    vi.spyOn(storeMod, 'setApiKey').mockImplementation(() => {});
+
+    const elements = new Map<string, any>();
+    const ensureElement = (id: string, overrides: any = {}) => {
+      if (!elements.has(id)) {
+        elements.set(id, makeElement());
+      }
+      const el = elements.get(id);
+      Object.assign(el, overrides);
+      return el;
+    };
+
+    ensureElement('selectRiskThreshold', { value: 'critical' });
+    ensureElement('btnAnalyze', { disabled: false });
+    ensureElement('busyBar');
+    ensureElement('originalText', { value: 'contract text', dispatchEvent: vi.fn() });
+    ensureElement('hdrWarn');
+    ensureElement('results');
+    ensureElement('resultsBlock');
+    ensureElement('resClauseType');
+    ensureElement('findingsBlock');
+    ensureElement('recommendationsBlock');
+    ensureElement('recommendationsList');
+    ensureElement('resFindingsCount');
+    ensureElement('rawJson');
+    ensureElement('findingsList');
+    ensureElement('connBadge');
+
+    (globalThis as any).document = {
+      getElementById: (id: string) => ensureElement(id),
+      querySelector: () => null,
+      querySelectorAll: () => [] as any,
+      createElement: () => makeElement(),
+      createDocumentFragment: () => makeElement({ appendChild: vi.fn() }),
+      addEventListener: vi.fn(),
+      body: makeElement(),
+    } as any;
+
+    (globalThis as any).window = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      location: { search: '' },
+      __CAI_TESTING__: true,
+    } as any;
+
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    (globalThis as any).CustomEvent = class {
+      detail: any;
+      constructor(public type: string, init?: any) {
+        this.detail = init?.detail;
+      }
+    } as any;
+    (globalThis as any).Office = { onReady: (cb: any) => cb({}) } as any;
+
+    const taskpane = await import('../assets/taskpane.ts');
+    vi.spyOn(taskpane, 'renderAnalysisSummary').mockImplementation(() => {});
+
+    await taskpane.onAnalyze();
+
+    expect(analyzeSpy).toHaveBeenCalledWith(expect.objectContaining({ risk: 'critical' }));
+    expect(planAnnotationsSpy).toHaveBeenCalledTimes(1);
+    const planned = planAnnotationsSpy.mock.calls[0][0];
+    expect(planned).toHaveLength(serverFindings.length);
+    expect(planned.map((f: any) => f.rule_id)).toEqual(serverFindings.map(f => f.rule_id));
+    expect(parseFindingsSpy).toHaveBeenCalledWith({ analysis: { findings: serverFindings }, recommendations: [] });
+  });
+});

--- a/word_addin_dev/app/__tests__/riskThreshold.read.spec.ts
+++ b/word_addin_dev/app/__tests__/riskThreshold.read.spec.ts
@@ -13,6 +13,16 @@ describe('risk threshold read', () => {
     expect(mod.getRiskThreshold()).toBe('high');
   });
 
+  it('passes through critical risk option', async () => {
+    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).document = {
+      getElementById: (id: string) => id === 'selectRiskThreshold' ? { value: 'critical' } : null,
+    } as any;
+    const mod = await import('../assets/taskpane.ts');
+    expect(mod.getRiskThreshold()).toBe('critical');
+  });
+
   it('defaults to medium when missing', async () => {
     (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
     (globalThis as any).__CAI_TESTING__ = true;

--- a/word_addin_dev/app/assets/__tests__/analyze.body.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/analyze.body.spec.ts
@@ -11,7 +11,7 @@ describe('analyze request body', () => {
     await analyze({ text: 'hi' });
     const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
     const body = JSON.parse(bodyStr);
-    expect(body).toMatchObject({ text: 'hi', mode: 'live', schema: '1.4' });
+    expect(body).toMatchObject({ text: 'hi', mode: 'live', schema: '1.4', risk: 'medium' });
     expect('payload' in body).toBe(false);
     expect(headers['x-schema-version']).toBe('1.4');
   });
@@ -23,7 +23,7 @@ describe('analyze request body', () => {
     await analyze({ schema: '1.4', mode: 'test', text: 'hi' });
     const { headers, body: bodyStr } = fetchMock.mock.calls[0][1];
     const body = JSON.parse(bodyStr);
-    expect(body).toMatchObject({ text: 'hi', mode: 'test', schema: '1.4' });
+    expect(body).toMatchObject({ text: 'hi', mode: 'test', schema: '1.4', risk: 'medium' });
     expect('payload' in body).toBe(false);
     expect(headers['x-schema-version']).toBe('1.4');
   });

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -270,6 +270,7 @@ export async function analyze(opts: any = {}) {
   const body = {
     text:  opts?.text ?? opts?.content,
     mode:  opts?.mode ?? 'live',
+    risk:  opts?.risk ?? 'medium',
   };
   const { resp, json } = await postJSON('/api/analyze', body);
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Contract AI Panel (Dev Fixture)</title>
+  <link rel="stylesheet" href="./app/assets/taskpane.css" />
+  <script type="module" src="taskpane.bundle.js?b=__BUILD_TS__"></script>
+  <script nomodule>
+    document.body.innerHTML = '<div style="padding:12px;color:#f66">Your runtime is too old for ES modules. Please update your browser.</div>';
+  </script>
+</head>
+<body>
+  <div class="wrap">
+    <div class="row flex">
+      <button id="btnTest" class="btn-grey" type="button">Test</button>
+      <button id="btnAnalyze" class="btn" type="button">Analyze</button>
+      <span id="busyBar" class="js-busy-indicator" style="display:none"></span>
+    </div>
+    <div class="row">
+      <label for="selectRiskThreshold">Risk threshold</label>
+      <select id="selectRiskThreshold">
+        <option value="low">Low</option>
+        <option value="medium" selected>Medium</option>
+        <option value="high">High</option>
+        <option value="critical">Critical</option>
+      </select>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- include the selected risk threshold in /api/analyze requests for both panel bundles
- accept the `critical` risk option, remove client-side filtering, and update HTML/test fixtures accordingly
- adjust analyze payload tests and add a dedicated risk forwarding spec to cover the new behavior

## Testing
- npm ci
- npm run test -s *(fails: numerous existing Vitest suites depend on full panel DOM, Office mocks, and bundle shape; see run for details)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0dee0c6c832597b876552eb6b24d