### PR TITLE
Add Companies House widget rendering

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -18,6 +18,7 @@ import { supports, logSupportMatrix } from './supports.ts';
 import { registerUnloadHandlers, wasUnloaded, resetUnloadFlag, withBusy, pendingFetches } from './pending.ts';
 import { checkHealth } from './health.ts';
 import { runStartupSelftest } from './startup.selftest.ts';
+import { PartyRegistry, CompaniesMetaItem } from './types.ts';
 import DiffMatchPatch from 'diff-match-patch';
 
 declare const Violins: { initAudio: () => void };
@@ -119,6 +120,239 @@ function mustGetElementById<T extends HTMLElement>(id: string): T {
     throw new Error(`missing element #${id}`);
   }
   return el as T;
+}
+
+const CH_BLOCK_ID = 'companiesHouseBlock';
+const CH_COMPANY_BASE_URL = 'https://find-and-update.company-information.service.gov.uk/company/';
+
+const CH_VERDICT_STYLES: Record<CompaniesMetaItem['verdict'], { label: string; bg: string; color: string }> = {
+  match: { label: 'Match', bg: '#e6f4ea', color: '#1b5e20' },
+  mismatch: { label: 'Mismatch', bg: '#fdecea', color: '#b71c1c' },
+  ambiguous: { label: 'Ambiguous', bg: '#fff4e5', color: '#e65100' },
+  not_found: { label: 'Not found', bg: '#f5f5f5', color: '#424242' },
+  ok: { label: 'OK', bg: '#e3f2fd', color: '#0d47a1' },
+};
+
+function createVerdictBadge(verdict: CompaniesMetaItem['verdict']) {
+  const badge = document.createElement('span');
+  const style = CH_VERDICT_STYLES[verdict];
+  const label = style?.label || verdict.toUpperCase();
+  badge.textContent = label;
+  badge.style.display = 'inline-block';
+  badge.style.padding = '2px 6px';
+  badge.style.marginRight = '8px';
+  badge.style.borderRadius = '4px';
+  badge.style.fontSize = '12px';
+  badge.style.fontWeight = 'bold';
+  if (style) {
+    badge.style.backgroundColor = style.bg;
+    badge.style.color = style.color;
+  }
+  return badge;
+}
+
+function appendListItem(list: HTMLElement, label: string, value?: string | null) {
+  const text = value?.trim();
+  if (!text) return;
+  const li = document.createElement('li');
+  li.textContent = `${label}: ${text}`;
+  list.appendChild(li);
+}
+
+function appendSic(list: HTMLElement, label: string, sic?: string[] | null) {
+  if (!Array.isArray(sic) || !sic.length) return;
+  appendListItem(list, label, sic.join(', '));
+}
+
+function appendLinks(list: HTMLElement, label: string, links: { label: string; href: string }[]) {
+  const usable = links.filter(link => link.href);
+  if (!usable.length) return;
+  const li = document.createElement('li');
+  const span = document.createElement('span');
+  span.textContent = `${label}: `;
+  li.appendChild(span);
+  usable.forEach((link, idx) => {
+    if (idx > 0) {
+      const sep = document.createElement('span');
+      sep.textContent = ' | ';
+      li.appendChild(sep);
+    }
+    const a = document.createElement('a');
+    a.href = link.href;
+    a.textContent = link.label;
+    a.target = '_blank';
+    li.appendChild(a);
+  });
+  list.appendChild(li);
+}
+
+function normalizeValue(value?: string | null) {
+  return (value || '').trim();
+}
+
+function findMatchingMeta(
+  registry: PartyRegistry,
+  metaItems: CompaniesMetaItem[],
+  usedMeta: Set<CompaniesMetaItem>,
+): CompaniesMetaItem | undefined {
+  const normalizedNumber = normalizeValue(registry.number_or_duns).toLowerCase();
+  if (normalizedNumber) {
+    const numberMatch = metaItems.find(item => {
+      if (usedMeta.has(item)) return false;
+      const docNumber = normalizeValue(item.from_document?.number).toLowerCase();
+      const matchedNumber = normalizeValue(item.matched?.company_number).toLowerCase();
+      return docNumber === normalizedNumber || matchedNumber === normalizedNumber;
+    });
+    if (numberMatch) {
+      return numberMatch;
+    }
+  }
+
+  const normalizedName = normalizeValue(registry.name).toLowerCase();
+  if (normalizedName) {
+    return metaItems.find(item => {
+      if (usedMeta.has(item)) return false;
+      const docName = normalizeValue(item.from_document?.name).toLowerCase();
+      const matchedName = normalizeValue(item.matched?.company_name).toLowerCase();
+      return (docName && docName === normalizedName) || (matchedName && matchedName === normalizedName);
+    });
+  }
+
+  return undefined;
+}
+
+function ensureContainer(parent: HTMLElement) {
+  let container = document.getElementById(CH_BLOCK_ID) as HTMLElement | null;
+  if (!container) {
+    if (typeof (parent as any).appendChild !== 'function') {
+      return null;
+    }
+    container = document.createElement('div');
+    container.id = CH_BLOCK_ID;
+    parent.appendChild(container);
+  }
+  return container;
+}
+
+export function renderCompaniesHouse(
+  registries: PartyRegistry[] | undefined,
+  metaItems: CompaniesMetaItem[] | undefined,
+) {
+  const parties = Array.isArray(registries) ? registries.filter(Boolean) : [];
+  const companiesMeta = Array.isArray(metaItems) ? metaItems.filter(Boolean) : [];
+
+  const containerExisting = document.getElementById(CH_BLOCK_ID) as HTMLElement | null;
+  if (!parties.length && !companiesMeta.length) {
+    if (containerExisting) {
+      if (containerExisting.parentElement && typeof containerExisting.parentElement.removeChild === 'function') {
+        containerExisting.parentElement.removeChild(containerExisting);
+      } else if (typeof (containerExisting as any).remove === 'function') {
+        (containerExisting as any).remove();
+      }
+    }
+    return;
+  }
+
+  const parent = mustGetElementById<HTMLElement>('resultsBlock');
+  const container = ensureContainer(parent);
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Companies House';
+  container.appendChild(heading);
+
+  const usedMeta = new Set<CompaniesMetaItem>();
+  const entries: { registry?: PartyRegistry; meta?: CompaniesMetaItem }[] = [];
+
+  parties.forEach(registry => {
+    const match = findMatchingMeta(registry, companiesMeta, usedMeta);
+    if (match) {
+      usedMeta.add(match);
+    }
+    entries.push({ registry, meta: match });
+  });
+
+  companiesMeta.forEach(item => {
+    if (!usedMeta.has(item)) {
+      entries.push({ meta: item });
+    }
+  });
+
+  if (!entries.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No Companies House data available.';
+    container.appendChild(empty);
+    return;
+  }
+
+  entries.forEach(({ registry, meta }) => {
+    const entry = document.createElement('div');
+    container.appendChild(entry);
+
+    const header = document.createElement('div');
+    if (meta?.verdict) {
+      header.appendChild(createVerdictBadge(meta.verdict));
+    }
+    const title = document.createElement('strong');
+    title.textContent = normalizeValue(
+      registry?.name || meta?.from_document?.name || meta?.matched?.company_name || 'Company',
+    );
+    header.appendChild(title);
+    entry.appendChild(header);
+
+    const documentInfoExists =
+      registry?.number_or_duns ||
+      registry?.status ||
+      registry?.address ||
+      registry?.sic_codes?.length ||
+      registry?.incorp_date ||
+      meta?.from_document?.number;
+
+    if (documentInfoExists) {
+      const docTitle = document.createElement('div');
+      docTitle.textContent = 'Document';
+      entry.appendChild(docTitle);
+      const docList = document.createElement('ul');
+      appendListItem(docList, 'Number', registry?.number_or_duns || meta?.from_document?.number);
+      appendListItem(docList, 'Status', registry?.status);
+      appendListItem(docList, 'Address', registry?.address);
+      appendListItem(docList, 'Incorporated', registry?.incorp_date);
+      appendSic(docList, 'SIC', registry?.sic_codes);
+      entry.appendChild(docList);
+    }
+
+    if (meta) {
+      const chTitle = document.createElement('div');
+      chTitle.textContent = 'Companies House';
+      entry.appendChild(chTitle);
+      const chList = document.createElement('ul');
+      const companyNumber = meta.matched?.company_number || meta.from_document?.number;
+      appendListItem(chList, 'Company number', companyNumber);
+      appendListItem(chList, 'Status', meta.matched?.company_status);
+      appendListItem(chList, 'Address', meta.matched?.address_snippet);
+      appendSic(chList, 'SIC', meta.matched?.sic_codes);
+
+      const linkItems: { label: string; href: string }[] = [];
+      if (companyNumber) {
+        linkItems.push({ label: 'Profile', href: `${CH_COMPANY_BASE_URL}${companyNumber}` });
+      }
+      if (meta.matched?.links?.self) {
+        linkItems.push({ label: 'Self', href: meta.matched.links.self });
+      }
+      if (meta.matched?.links?.officers) {
+        linkItems.push({ label: 'Officers', href: meta.matched.links.officers });
+      }
+      if (meta.matched?.links?.filing_history) {
+        linkItems.push({ label: 'Filings', href: meta.matched.links.filing_history });
+      }
+      appendLinks(chList, 'Links', linkItems);
+
+      entry.appendChild(chList);
+    }
+  });
 }
 
 function updateStatusChip(schema?: string | null, cid?: string | null) {
@@ -552,6 +786,15 @@ export function renderAnalysisSummary(json: any) {
   const findings = Array.isArray(json?.findings) ? json.findings : [];
   const recs = Array.isArray(json?.recommendations) ? json.recommendations : [];
 
+  const registries: PartyRegistry[] = Array.isArray(json?.summary?.parties)
+    ? json.summary.parties
+        .map((p: any) => p?.registry)
+        .filter((reg: any): reg is PartyRegistry => Boolean(reg))
+    : [];
+  const companiesMeta: CompaniesMetaItem[] = Array.isArray(json?.meta?.companies_meta)
+    ? json.meta.companies_meta.filter((item: any): item is CompaniesMetaItem => Boolean(item))
+    : [];
+
   const thr = getRiskThreshold();
   const visibleFindings = filterByThreshold(findings, thr);
   const visible = visibleFindings.length;
@@ -626,6 +869,8 @@ export function renderAnalysisSummary(json: any) {
   // Показать блок результатов (если был скрыт стилями)
   const rb = mustGetElementById<HTMLElement>("resultsBlock");
   rb.style.removeProperty("display");
+
+  renderCompaniesHouse(registries, companiesMeta);
 }
 
 function renderResults(res: any) {

--- a/contract_review_app/contract_review_app/static/panel/app/assets/types.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/types.ts
@@ -1,0 +1,28 @@
+export interface PartyRegistry {
+  name: string
+  number_or_duns?: string
+  status?: string
+  address?: string
+  incorp_date?: string
+  sic_codes?: string[]
+}
+
+export interface CompaniesMetaItem {
+  verdict: 'match' | 'mismatch' | 'ambiguous' | 'not_found' | 'ok'
+  from_document: {
+    name?: string
+    number?: string
+  }
+  matched?: {
+    company_name?: string
+    company_number?: string
+    company_status?: string
+    address_snippet?: string
+    sic_codes?: string[]
+    links?: {
+      self?: string
+      officers?: string
+      filing_history?: string
+    }
+  }
+}

--- a/word_addin_dev/app/__tests__/render.ch.spec.ts
+++ b/word_addin_dev/app/__tests__/render.ch.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest'
+
+function createElementFactory(elements: Record<string, any>) {
+  return function createElement(tag: string) {
+    const el: any = {
+      tagName: tag.toUpperCase(),
+      children: [] as any[],
+      style: {},
+      appendChild(child: any) {
+        if (child === undefined || child === null) {
+          return child
+        }
+        this.children.push(child)
+        if (typeof child === 'object') {
+          child.parentElement = this
+        }
+        return child
+      },
+      removeChild(child: any) {
+        this.children = this.children.filter((node: any) => node !== child)
+        if (child && typeof child === 'object') {
+          child.parentElement = null
+        }
+        return child
+      },
+      setAttribute(name: string, value: any) {
+        ;(this as any)[name] = value
+      },
+    }
+
+    let textContent = ''
+    Object.defineProperty(el, 'textContent', {
+      get() {
+        return textContent
+      },
+      set(val) {
+        textContent = String(val ?? '')
+      },
+    })
+
+    Object.defineProperty(el, 'innerHTML', {
+      get() {
+        return textContent
+      },
+      set(_val) {
+        textContent = ''
+        el.children = []
+      },
+    })
+
+    Object.defineProperty(el, 'id', {
+      get() {
+        return (this as any)._id
+      },
+      set(val) {
+        ;(this as any)._id = val
+        if (val) {
+          elements[val] = el
+        }
+      },
+    })
+
+    return el
+  }
+}
+
+function collectText(node: any): string {
+  if (!node) return ''
+  let text = node.textContent || ''
+  if (Array.isArray(node.children) && node.children.length) {
+    for (const child of node.children) {
+      text += collectText(child)
+    }
+  }
+  return text
+}
+
+function findAnchor(node: any): any {
+  if (!node) return undefined
+  if (node.tagName === 'A') return node
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      const found = findAnchor(child)
+      if (found) return found
+    }
+  }
+  return undefined
+}
+
+describe('Companies House rendering', () => {
+  it('renders Companies House block with verdict and links', async () => {
+    const elements: Record<string, any> = {
+      clauseTypeOut: { textContent: '' },
+      resFindingsCount: { textContent: '' },
+      visibleHiddenOut: { textContent: '' },
+      findingsList: { innerHTML: '', children: [] as any[], appendChild(el: any) { this.children.push(el); return el } },
+      recommendationsList: { innerHTML: '', children: [] as any[], appendChild(el: any) { this.children.push(el); return el } },
+      findingsBlock: { style: { display: 'none' } },
+      recommendationsBlock: { style: { display: 'none' } },
+    }
+
+    const createElement = createElementFactory(elements)
+    const resultsBlock = createElement('div')
+    resultsBlock.style.display = 'none'
+    resultsBlock.style.removeProperty = function (prop: string) {
+      delete (this as any)[prop]
+    }
+    resultsBlock.id = 'resultsBlock'
+
+    const docStub: any = {
+      getElementById(id: string) {
+        return elements[id] || null
+      },
+      createElement,
+    }
+    elements.resultsBlock = resultsBlock
+
+    const originalDocument = (globalThis as any).document
+    const originalWindow = (globalThis as any).window
+    const originalLocalStorage = (globalThis as any).localStorage
+    const originalTesting = (globalThis as any).__CAI_TESTING__
+
+    try {
+      ;(globalThis as any).document = docStub
+      ;(globalThis as any).window = globalThis as any
+      ;(globalThis as any).localStorage = { getItem: () => null, setItem: () => {} }
+      ;(globalThis as any).__CAI_TESTING__ = true
+
+      const mod = await import('../assets/taskpane')
+
+      const payload = {
+        summary: {
+          clause_type: 'NDA',
+          parties: [
+            {
+              registry: {
+                name: 'ACME LTD',
+                number_or_duns: '12345678',
+                status: 'active',
+                address: '1 Main Street',
+                sic_codes: ['62020'],
+              },
+            },
+          ],
+        },
+        findings: [],
+        recommendations: [],
+        meta: {
+          companies_meta: [
+            {
+              verdict: 'match',
+              from_document: { name: 'ACME LTD', number: '12345678' },
+              matched: {
+                company_name: 'ACME LIMITED',
+                company_number: '12345678',
+                company_status: 'active',
+                address_snippet: '1 MAIN STREET, LONDON',
+                sic_codes: ['62020'],
+                links: {
+                  self: 'https://api.company-information.service.gov.uk/company/12345678',
+                  officers: 'https://api.company-information.service.gov.uk/company/12345678/officers',
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      mod.renderAnalysisSummary(payload)
+
+      const chBlock = elements.companiesHouseBlock
+      expect(chBlock).toBeTruthy()
+      expect(resultsBlock.children.includes(chBlock)).toBe(true)
+
+      const entry = chBlock.children[1]
+      expect(entry).toBeTruthy()
+      const header = entry.children[0]
+      expect(header.children[0].textContent).toBe('Match')
+
+      const text = collectText(chBlock)
+      expect(text).toContain('Company number: 12345678')
+      expect(text).toContain('Status: active')
+
+      const link = findAnchor(chBlock)
+      expect(link?.href).toContain('/company/12345678')
+    } finally {
+      if (originalDocument === undefined) {
+        delete (globalThis as any).document
+      } else {
+        ;(globalThis as any).document = originalDocument
+      }
+      if (originalWindow === undefined) {
+        delete (globalThis as any).window
+      } else {
+        ;(globalThis as any).window = originalWindow
+      }
+      if (originalLocalStorage === undefined) {
+        delete (globalThis as any).localStorage
+      } else {
+        ;(globalThis as any).localStorage = originalLocalStorage
+      }
+      if (originalTesting === undefined) {
+        delete (globalThis as any).__CAI_TESTING__
+      } else {
+        ;(globalThis as any).__CAI_TESTING__ = originalTesting
+      }
+    }
+  })
+})

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -18,6 +18,7 @@ import { supports, logSupportMatrix } from './supports.ts';
 import { registerUnloadHandlers, wasUnloaded, resetUnloadFlag, withBusy, pendingFetches } from './pending.ts';
 import { checkHealth } from './health.ts';
 import { runStartupSelftest } from './startup.selftest.ts';
+import { PartyRegistry, CompaniesMetaItem } from './types.ts';
 import DiffMatchPatch from 'diff-match-patch';
 
 declare const Violins: { initAudio: () => void };
@@ -119,6 +120,239 @@ export function mustGetElementById<T extends HTMLElement>(id: string): T {
     throw new Error(`missing element #${id}`);
   }
   return el as T;
+}
+
+const CH_BLOCK_ID = 'companiesHouseBlock';
+const CH_COMPANY_BASE_URL = 'https://find-and-update.company-information.service.gov.uk/company/';
+
+const CH_VERDICT_STYLES: Record<CompaniesMetaItem['verdict'], { label: string; bg: string; color: string }> = {
+  match: { label: 'Match', bg: '#e6f4ea', color: '#1b5e20' },
+  mismatch: { label: 'Mismatch', bg: '#fdecea', color: '#b71c1c' },
+  ambiguous: { label: 'Ambiguous', bg: '#fff4e5', color: '#e65100' },
+  not_found: { label: 'Not found', bg: '#f5f5f5', color: '#424242' },
+  ok: { label: 'OK', bg: '#e3f2fd', color: '#0d47a1' },
+};
+
+function createVerdictBadge(verdict: CompaniesMetaItem['verdict']) {
+  const badge = document.createElement('span');
+  const style = CH_VERDICT_STYLES[verdict];
+  const label = style?.label || verdict.toUpperCase();
+  badge.textContent = label;
+  badge.style.display = 'inline-block';
+  badge.style.padding = '2px 6px';
+  badge.style.marginRight = '8px';
+  badge.style.borderRadius = '4px';
+  badge.style.fontSize = '12px';
+  badge.style.fontWeight = 'bold';
+  if (style) {
+    badge.style.backgroundColor = style.bg;
+    badge.style.color = style.color;
+  }
+  return badge;
+}
+
+function appendListItem(list: HTMLElement, label: string, value?: string | null) {
+  const text = value?.trim();
+  if (!text) return;
+  const li = document.createElement('li');
+  li.textContent = `${label}: ${text}`;
+  list.appendChild(li);
+}
+
+function appendSic(list: HTMLElement, label: string, sic?: string[] | null) {
+  if (!Array.isArray(sic) || !sic.length) return;
+  appendListItem(list, label, sic.join(', '));
+}
+
+function appendLinks(list: HTMLElement, label: string, links: { label: string; href: string }[]) {
+  const usable = links.filter(link => link.href);
+  if (!usable.length) return;
+  const li = document.createElement('li');
+  const span = document.createElement('span');
+  span.textContent = `${label}: `;
+  li.appendChild(span);
+  usable.forEach((link, idx) => {
+    if (idx > 0) {
+      const sep = document.createElement('span');
+      sep.textContent = ' | ';
+      li.appendChild(sep);
+    }
+    const a = document.createElement('a');
+    a.href = link.href;
+    a.textContent = link.label;
+    a.target = '_blank';
+    li.appendChild(a);
+  });
+  list.appendChild(li);
+}
+
+function normalizeValue(value?: string | null) {
+  return (value || '').trim();
+}
+
+function findMatchingMeta(
+  registry: PartyRegistry,
+  metaItems: CompaniesMetaItem[],
+  usedMeta: Set<CompaniesMetaItem>,
+): CompaniesMetaItem | undefined {
+  const normalizedNumber = normalizeValue(registry.number_or_duns).toLowerCase();
+  if (normalizedNumber) {
+    const numberMatch = metaItems.find(item => {
+      if (usedMeta.has(item)) return false;
+      const docNumber = normalizeValue(item.from_document?.number).toLowerCase();
+      const matchedNumber = normalizeValue(item.matched?.company_number).toLowerCase();
+      return docNumber === normalizedNumber || matchedNumber === normalizedNumber;
+    });
+    if (numberMatch) {
+      return numberMatch;
+    }
+  }
+
+  const normalizedName = normalizeValue(registry.name).toLowerCase();
+  if (normalizedName) {
+    return metaItems.find(item => {
+      if (usedMeta.has(item)) return false;
+      const docName = normalizeValue(item.from_document?.name).toLowerCase();
+      const matchedName = normalizeValue(item.matched?.company_name).toLowerCase();
+      return (docName && docName === normalizedName) || (matchedName && matchedName === normalizedName);
+    });
+  }
+
+  return undefined;
+}
+
+function ensureContainer(parent: HTMLElement) {
+  let container = document.getElementById(CH_BLOCK_ID) as HTMLElement | null;
+  if (!container) {
+    if (typeof (parent as any).appendChild !== 'function') {
+      return null;
+    }
+    container = document.createElement('div');
+    container.id = CH_BLOCK_ID;
+    parent.appendChild(container);
+  }
+  return container;
+}
+
+export function renderCompaniesHouse(
+  registries: PartyRegistry[] | undefined,
+  metaItems: CompaniesMetaItem[] | undefined,
+) {
+  const parties = Array.isArray(registries) ? registries.filter(Boolean) : [];
+  const companiesMeta = Array.isArray(metaItems) ? metaItems.filter(Boolean) : [];
+
+  const containerExisting = document.getElementById(CH_BLOCK_ID) as HTMLElement | null;
+  if (!parties.length && !companiesMeta.length) {
+    if (containerExisting) {
+      if (containerExisting.parentElement && typeof containerExisting.parentElement.removeChild === 'function') {
+        containerExisting.parentElement.removeChild(containerExisting);
+      } else if (typeof (containerExisting as any).remove === 'function') {
+        (containerExisting as any).remove();
+      }
+    }
+    return;
+  }
+
+  const parent = mustGetElementById<HTMLElement>('resultsBlock');
+  const container = ensureContainer(parent);
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Companies House';
+  container.appendChild(heading);
+
+  const usedMeta = new Set<CompaniesMetaItem>();
+  const entries: { registry?: PartyRegistry; meta?: CompaniesMetaItem }[] = [];
+
+  parties.forEach(registry => {
+    const match = findMatchingMeta(registry, companiesMeta, usedMeta);
+    if (match) {
+      usedMeta.add(match);
+    }
+    entries.push({ registry, meta: match });
+  });
+
+  companiesMeta.forEach(item => {
+    if (!usedMeta.has(item)) {
+      entries.push({ meta: item });
+    }
+  });
+
+  if (!entries.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No Companies House data available.';
+    container.appendChild(empty);
+    return;
+  }
+
+  entries.forEach(({ registry, meta }) => {
+    const entry = document.createElement('div');
+    container.appendChild(entry);
+
+    const header = document.createElement('div');
+    if (meta?.verdict) {
+      header.appendChild(createVerdictBadge(meta.verdict));
+    }
+    const title = document.createElement('strong');
+    title.textContent = normalizeValue(
+      registry?.name || meta?.from_document?.name || meta?.matched?.company_name || 'Company',
+    );
+    header.appendChild(title);
+    entry.appendChild(header);
+
+    const documentInfoExists =
+      registry?.number_or_duns ||
+      registry?.status ||
+      registry?.address ||
+      registry?.sic_codes?.length ||
+      registry?.incorp_date ||
+      meta?.from_document?.number;
+
+    if (documentInfoExists) {
+      const docTitle = document.createElement('div');
+      docTitle.textContent = 'Document';
+      entry.appendChild(docTitle);
+      const docList = document.createElement('ul');
+      appendListItem(docList, 'Number', registry?.number_or_duns || meta?.from_document?.number);
+      appendListItem(docList, 'Status', registry?.status);
+      appendListItem(docList, 'Address', registry?.address);
+      appendListItem(docList, 'Incorporated', registry?.incorp_date);
+      appendSic(docList, 'SIC', registry?.sic_codes);
+      entry.appendChild(docList);
+    }
+
+    if (meta) {
+      const chTitle = document.createElement('div');
+      chTitle.textContent = 'Companies House';
+      entry.appendChild(chTitle);
+      const chList = document.createElement('ul');
+      const companyNumber = meta.matched?.company_number || meta.from_document?.number;
+      appendListItem(chList, 'Company number', companyNumber);
+      appendListItem(chList, 'Status', meta.matched?.company_status);
+      appendListItem(chList, 'Address', meta.matched?.address_snippet);
+      appendSic(chList, 'SIC', meta.matched?.sic_codes);
+
+      const linkItems: { label: string; href: string }[] = [];
+      if (companyNumber) {
+        linkItems.push({ label: 'Profile', href: `${CH_COMPANY_BASE_URL}${companyNumber}` });
+      }
+      if (meta.matched?.links?.self) {
+        linkItems.push({ label: 'Self', href: meta.matched.links.self });
+      }
+      if (meta.matched?.links?.officers) {
+        linkItems.push({ label: 'Officers', href: meta.matched.links.officers });
+      }
+      if (meta.matched?.links?.filing_history) {
+        linkItems.push({ label: 'Filings', href: meta.matched.links.filing_history });
+      }
+      appendLinks(chList, 'Links', linkItems);
+
+      entry.appendChild(chList);
+    }
+  });
 }
 
 function updateStatusChip(schema?: string | null, cid?: string | null) {
@@ -552,6 +786,15 @@ export function renderAnalysisSummary(json: any) {
   const findings = Array.isArray(json?.findings) ? json.findings : [];
   const recs = Array.isArray(json?.recommendations) ? json.recommendations : [];
 
+  const registries: PartyRegistry[] = Array.isArray(json?.summary?.parties)
+    ? json.summary.parties
+        .map((p: any) => p?.registry)
+        .filter((reg: any): reg is PartyRegistry => Boolean(reg))
+    : [];
+  const companiesMeta: CompaniesMetaItem[] = Array.isArray(json?.meta?.companies_meta)
+    ? json.meta.companies_meta.filter((item: any): item is CompaniesMetaItem => Boolean(item))
+    : [];
+
   const thr = getRiskThreshold();
   const visibleFindings = filterByThreshold(findings, thr);
   const visible = visibleFindings.length;
@@ -626,6 +869,8 @@ export function renderAnalysisSummary(json: any) {
   // Показать блок результатов (если был скрыт стилями)
   const rb = mustGetElementById<HTMLElement>("resultsBlock");
   rb.style.removeProperty("display");
+
+  renderCompaniesHouse(registries, companiesMeta);
 }
 
 function renderResults(res: any) {

--- a/word_addin_dev/app/assets/types.ts
+++ b/word_addin_dev/app/assets/types.ts
@@ -1,0 +1,28 @@
+export interface PartyRegistry {
+  name: string
+  number_or_duns?: string
+  status?: string
+  address?: string
+  incorp_date?: string
+  sic_codes?: string[]
+}
+
+export interface CompaniesMetaItem {
+  verdict: 'match' | 'mismatch' | 'ambiguous' | 'not_found' | 'ok'
+  from_document: {
+    name?: string
+    number?: string
+  }
+  matched?: {
+    company_name?: string
+    company_number?: string
+    company_status?: string
+    address_snippet?: string
+    sic_codes?: string[]
+    links?: {
+      self?: string
+      officers?: string
+      filing_history?: string
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared types for Companies House registry and metadata payloads
- render a Companies House details block in the task pane summary using party registry and meta data
- add a unit test that verifies the Companies House widget renders expected fields and links

## Testing
- npm run test -s *(fails: suite expects extensive Office DOM stubs and reports unrelated baseline failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cf136c1d848325a5824e375817f256