### PR TITLE
Preserve offsets for annotation planning and nth anchoring

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate_plan.offsets.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate_plan.offsets.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+
+let computeNthFromOffsets: (typeof import('../annotate'))['computeNthFromOffsets'];
+let planAnnotations: (typeof import('../annotate'))['planAnnotations'];
+let parseFindings: (typeof import('../findings'))['parseFindings'];
+
+beforeAll(async () => {
+  (globalThis as any).window = globalThis as any;
+  const annotateMod = await import('../annotate');
+  computeNthFromOffsets = annotateMod.computeNthFromOffsets;
+  planAnnotations = annotateMod.planAnnotations;
+  const findingsMod = await import('../findings');
+  parseFindings = findingsMod.parseFindings;
+});
+import type { AnalyzeFindingEx } from '../types';
+
+const countOccurrences = (text: string, snippet: string) => {
+  const starts: number[] = [];
+  let idx = -1;
+  while ((idx = text.indexOf(snippet, idx + 1)) !== -1) {
+    starts.push(idx);
+  }
+  return starts;
+};
+
+describe('computeNthFromOffsets', () => {
+  it('returns null when start is missing', () => {
+    expect(computeNthFromOffsets('abc', 'a')).toBeNull();
+  });
+
+  it('returns null for empty normalized snippet', () => {
+    expect(computeNthFromOffsets('abc', '   ', 0)).toBeNull();
+  });
+
+  it('counts occurrences before offset', () => {
+    const text = 'foo bar foo bar foo bar';
+    const snippet = 'foo bar';
+    const starts = countOccurrences(text, snippet);
+    const start = starts[1];
+    expect(computeNthFromOffsets(text, snippet, start)).toBe(1);
+  });
+
+  it('handles offset at document start', () => {
+    expect(computeNthFromOffsets('foo bar', 'foo', 0)).toBe(0);
+  });
+
+  it('supports offsets beyond text length', () => {
+    const text = 'alpha beta alpha beta';
+    const snippet = 'alpha';
+    const starts = countOccurrences(text, snippet);
+    const start = text.length + 5;
+    expect(computeNthFromOffsets(text, snippet, start)).toBe(starts.length);
+  });
+
+  it('handles non ASCII punctuation', () => {
+    const text = '«quote» «quote» «quote»';
+    const snippet = '«quote»';
+    const starts = countOccurrences(text, snippet);
+    const start = starts[2];
+    expect(computeNthFromOffsets(text, snippet, start)).toBe(2);
+  });
+
+  it('normalizes whitespace before counting', () => {
+    const text = 'A\u00A0A foo A\u00A0A';
+    const snippet = 'A\u00A0A';
+    const start = text.lastIndexOf(snippet);
+    expect(computeNthFromOffsets(text, snippet, start)).toBe(1);
+  });
+
+  it('property: matches raw occurrence index for random samples', () => {
+    for (let i = 0; i < 100; i++) {
+      const occ = Math.max(2, Math.floor(Math.random() * 5) + 1);
+      const snippet = `word${i % 7}`;
+      const parts: string[] = [];
+      for (let j = 0; j < occ; j++) {
+        parts.push(snippet);
+        parts.push(` filler${j}`);
+      }
+      const text = parts.join(' ').trim();
+      const starts = countOccurrences(text, snippet);
+      const pick = starts[Math.floor(Math.random() * starts.length)];
+      const nth = computeNthFromOffsets(text, snippet, pick);
+      expect(nth).toBe(starts.indexOf(pick));
+    }
+  });
+});
+
+describe('parseFindings', () => {
+  it('preserves start and end offsets', () => {
+    const findings = parseFindings({
+      analysis: {
+        findings: [
+          { rule_id: 'r1', snippet: 'foo', start: 5, end: 8 }
+        ]
+      }
+    } as any);
+    expect(findings[0].start).toBe(5);
+    expect(findings[0].end).toBe(8);
+  });
+});
+
+describe('planAnnotations offsets', () => {
+  beforeEach(() => {
+    (globalThis as any).__lastAnalyzed = 'foo bar foo bar foo bar';
+  });
+
+  it('stores nth computed from offsets', () => {
+    const text = (globalThis as any).__lastAnalyzed as string;
+    const snippet = 'foo bar';
+    const starts = countOccurrences(text, snippet);
+    const start = starts[2];
+    const finding: AnalyzeFindingEx = { rule_id: 'r1', snippet, start, end: start + snippet.length } as any;
+    const plan = planAnnotations([finding]);
+    expect(plan[0].nth).toBe(2);
+    expect(plan[0].occIdx).toBe(2);
+    expect(plan[0].start).toBe(start);
+    expect(plan[0].end).toBe(start + snippet.length);
+  });
+
+  it('falls back to first occurrence when snippet absent in text', () => {
+    (globalThis as any).__lastAnalyzed = 'alpha beta gamma';
+    const start = 0;
+    const plan = planAnnotations([
+      { rule_id: 'r2', snippet: 'delta', start, end: start + 5 } as any
+    ]);
+    expect(plan.length).toBe(1);
+    expect(plan[0].nth).toBe(0);
+    expect(plan[0].occIdx).toBe(0);
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts
@@ -21,7 +21,7 @@ interface BodyLike {
  * keeping the longest (or first if equal). All returned ranges are added to
  * ``context.trackedObjects``.
  */
-export async function findAnchors(body: BodyLike, snippetRaw: string): Promise<RangeLike[]> {
+export async function findAnchors(body: BodyLike, snippetRaw: string, opts?: { nth?: number | null }): Promise<RangeLike[]> {
   const ctx = body.context;
   const opt = { matchCase: false, matchWholeWord: false };
 
@@ -61,6 +61,17 @@ export async function findAnchors(body: BodyLike, snippetRaw: string): Promise<R
       continue;
     }
     result.push(r);
+  }
+
+  const nth = opts?.nth;
+  if (typeof nth === 'number' && Number.isFinite(nth) && nth >= 0 && result.length) {
+    const idx = Math.min(Math.floor(nth), result.length - 1);
+    const preferred = result[idx];
+    if (preferred) {
+      const reordered = [preferred, ...result.slice(0, idx), ...result.slice(idx + 1)];
+      result.length = 0;
+      result.push(...reordered);
+    }
   }
 
   for (const r of result) {

--- a/contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts
@@ -1,6 +1,7 @@
 import { AnalyzeFinding } from "./api-client.ts";
 import { dedupeFindings, normalizeText } from "./dedupe.ts";
 import { safeBodySearch } from "./safeBodySearch.ts";
+import type { AnalyzeFindingEx, AnnotationPlanEx } from "./types.ts";
 
 /** Utilities for inserting comments into Word with batching and retries. */
 export interface CommentItem {
@@ -109,6 +110,40 @@ function nthOccurrenceIndex(hay: string, needle: string, startPos?: number): num
   return n;
 }
 
+const normalizedCache = new Map<string, string>();
+
+function normalizeCached(text: string): string {
+  let cached = normalizedCache.get(text);
+  if (cached == null) {
+    cached = normalizeText(text);
+    normalizedCache.set(text, cached);
+  }
+  return cached;
+}
+
+export function computeNthFromOffsets(text: string, snippet: string, start?: number): number | null {
+  if (!text || !snippet) return null;
+  if (typeof start !== 'number' || !Number.isFinite(start) || start < 0) return null;
+  const normSnippet = normalizeText(snippet);
+  if (!normSnippet) return null;
+
+  const normText = normalizeCached(text);
+  const prefix = text.slice(0, Math.max(0, Math.min(text.length, Math.floor(start))));
+  const normPrefix = normalizeText(prefix);
+
+  if (!normText) return null;
+
+  let count = 0;
+  let searchIdx = 0;
+  while (true) {
+    const foundIdx = normText.indexOf(normSnippet, searchIdx);
+    if (foundIdx === -1 || foundIdx >= normPrefix.length) break;
+    count++;
+    searchIdx = foundIdx + Math.max(normSnippet.length, 1);
+  }
+  return count;
+}
+
 function isDryRunAnnotateEnabled(): boolean {
   try {
     return !!(document.getElementById("cai-dry-run-annotate") as HTMLInputElement | null)?.checked;
@@ -130,7 +165,7 @@ function buildLegalComment(f: AnalyzeFinding): string {
   return `${COMMENT_PREFIX} ${parts.join("\n")}`;
 }
 
-export interface AnnotationPlan {
+export interface AnnotationPlan extends AnnotationPlanEx {
   raw: string;
   norm: string;
   occIdx: number;
@@ -144,10 +179,11 @@ export const MAX_ANNOTATE_OPS = 200;
 /**
  * Prepare annotate operations from analysis findings without touching Word objects.
  */
-export function planAnnotations(findings: AnalyzeFinding[]): AnnotationPlan[] {
-  const base = normalizeText((globalThis as any).__lastAnalyzed || "");
+export function planAnnotations(findings: AnalyzeFindingEx[]): AnnotationPlan[] {
+  const baseText = String((globalThis as any).__lastAnalyzed || "");
+  const baseNorm = normalizeText(baseText);
   const list = Array.isArray(findings) ? findings : [];
-  const deduped = dedupeFindings(list);
+  const deduped = dedupeFindings(list as AnalyzeFinding[]);
   const sorted = deduped
     .slice()
     .sort((a, b) => (a.start ?? Number.POSITIVE_INFINITY) - (b.start ?? Number.POSITIVE_INFINITY));
@@ -170,14 +206,18 @@ export function planAnnotations(findings: AnalyzeFinding[]): AnnotationPlan[] {
       continue;
     }
     const norm = normalizeText(snippet);
-    const occIdx = nthOccurrenceIndex(base, norm, start);
+    const nth = computeNthFromOffsets(baseText, snippet, start);
+    const occIdx = typeof nth === "number" ? nth : nthOccurrenceIndex(baseNorm, norm, start);
     ops.push({
       raw: snippet,
       norm,
       occIdx,
       msg: buildLegalComment(f),
       rule_id: f.rule_id,
-      normalized_fallback: normalizeText((f as any).normalized_snippet || "")
+      normalized_fallback: normalizeText((f as any).normalized_snippet || ""),
+      start,
+      end,
+      nth: nth ?? undefined
     });
 
     lastEnd = end;
@@ -193,7 +233,7 @@ export function planAnnotations(findings: AnalyzeFinding[]): AnnotationPlan[] {
 /**
  * Convert findings directly into Word comments using a two-phase plan.
  */
-export async function findingsToWord(findings: AnalyzeFinding[]): Promise<number> {
+export async function findingsToWord(findings: AnalyzeFindingEx[]): Promise<number> {
   const ops = planAnnotations(findings);
   if (!ops.length) return 0;
   const g: any = globalThis as any;
@@ -210,16 +250,17 @@ export async function findingsToWord(findings: AnalyzeFinding[]): Promise<number
     };
 
     for (const op of ops) {
+      const desired = typeof op.nth === "number" ? op.nth : op.occIdx;
       let target: any = null;
 
       const sRaw = await safeBodySearch(body, op.raw, searchOpts);
-      target = pick(sRaw, op.occIdx);
+      target = pick(sRaw, desired);
 
       if (!target) {
         const fb = op.normalized_fallback && op.normalized_fallback !== op.norm ? op.normalized_fallback : op.norm;
         if (fb && fb.trim()) {
           const sNorm = await safeBodySearch(body, fb, searchOpts);
-          target = pick(sNorm, op.occIdx);
+          target = pick(sNorm, desired);
         }
       }
 

--- a/contract_review_app/contract_review_app/static/panel/app/assets/findings.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/findings.ts
@@ -1,0 +1,19 @@
+import { parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse } from './api-client.ts';
+import type { AnalyzeFindingEx } from './types.ts';
+
+export function coerceOffset(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+export function parseFindings(resp: AnalyzeResponse | AnalyzeFinding[]): AnalyzeFindingEx[] {
+  const arr = (apiParseFindings(resp as any) || []) as AnalyzeFindingEx[];
+  return arr
+    .filter(f => f && f.rule_id && f.snippet)
+    .map(f => ({
+      ...f,
+      start: coerceOffset(f.start),
+      end: coerceOffset(f.end),
+      clause_type: f.clause_type || 'Unknown'
+    }))
+    .filter(f => f.clause_type);
+}

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -1,4 +1,6 @@
-import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, analyze, apiQaRecheck } from "./api-client.ts";
+import { applyMetaToBadges, AnalyzeFinding, AnalyzeResponse, postRedlines, analyze, apiQaRecheck } from "./api-client.ts";
+import type { AnalyzeFindingEx } from "./types.ts";
+import { parseFindings } from "./findings.ts";
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, dedupeFindings } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
@@ -78,13 +80,7 @@ export function logRichError(e: any, tag = "Word") {
   } catch {}
 }
 
-function parseFindings(resp: AnalyzeResponse | AnalyzeFinding[]): AnalyzeFinding[] {
-  const arr = apiParseFindings(resp as any) || [];
-  return arr
-    .filter(f => f && f.rule_id && f.snippet)
-    .map(f => ({ ...f, clause_type: f.clause_type || 'Unknown' }))
-    .filter(f => f.clause_type);
-}
+export { parseFindings };
 
 const g: any = globalThis as any;
 g.parseFindings = g.parseFindings || parseFindings;

--- a/contract_review_app/contract_review_app/static/panel/app/assets/types.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/types.ts
@@ -1,3 +1,5 @@
+import type { AnalyzeFinding } from "./api-client.ts";
+
 export interface PartyRegistry {
   name: string
   number_or_duns?: string
@@ -25,4 +27,15 @@ export interface CompaniesMetaItem {
       filing_history?: string
     }
   }
+}
+
+export interface AnalyzeFindingEx extends AnalyzeFinding {
+  start?: number
+  end?: number
+}
+
+export interface AnnotationPlanEx {
+  start?: number
+  end?: number
+  nth?: number | null
 }

--- a/word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts
+++ b/word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const anchorsMock = vi.fn();
+
+vi.mock('../assets/anchors', () => ({
+  findAnchors: anchorsMock
+}));
+
+describe('annotate flow offsets', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    anchorsMock.mockReset();
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } };
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).Word;
+    delete (globalThis as any).Office;
+    delete (globalThis as any).__lastAnalyzed;
+    vi.restoreAllMocks();
+  });
+
+  it('requests anchors using nth derived from offsets', async () => {
+    const baseText = 'foo bar foo bar foo bar foo bar';
+    (globalThis as any).__lastAnalyzed = baseText;
+    const snippet = 'foo bar';
+    const starts: number[] = [];
+    let idx = -1;
+    while ((idx = baseText.indexOf(snippet, idx + 1)) !== -1) {
+      starts.push(idx);
+    }
+    const start = starts[2];
+
+    const targetRange = { start, end: start + snippet.length, load: vi.fn() } as any;
+    const otherRanges = [
+      { start: starts[0], end: starts[0] + snippet.length, load: vi.fn() },
+      { start: starts[1], end: starts[1] + snippet.length, load: vi.fn() }
+    ];
+
+    const annotateMod = await import('../assets/annotate');
+    const { annotateFindingsIntoWord } = annotateMod;
+
+    const insertedStarts: number[] = [];
+    const wrapRange = (range: any) => ({
+      ...range,
+      context: { sync: vi.fn(async () => {}), document: {} },
+      parentContentControl: null,
+      insertContentControl: () => {
+        insertedStarts.push(range.start);
+        return {
+          tag: '',
+          title: '',
+          color: '',
+          insertText: vi.fn()
+        };
+      }
+    });
+
+    const ranges = [...otherRanges.map(wrapRange), wrapRange(targetRange)];
+    anchorsMock.mockImplementation(async (_body, _snippet, opts) => {
+      expect(opts?.nth).toBe(2);
+      return ranges;
+    });
+
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => {
+        const ctx = {
+          document: {
+            body: {
+              context: { sync: vi.fn(async () => {}), trackedObjects: { add: () => {} } }
+            }
+          },
+          sync: vi.fn(async () => {})
+        };
+        return await cb(ctx);
+      }
+    };
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false } } };
+
+    const findings = [
+      { rule_id: 'r1', snippet, start, end: start + snippet.length }
+    ];
+
+    const inserted = await annotateFindingsIntoWord(findings as any);
+    expect(inserted).toBe(1);
+    expect(insertedStarts).toEqual([targetRange.start]);
+  });
+});

--- a/word_addin_dev/app/assets/anchors.ts
+++ b/word_addin_dev/app/assets/anchors.ts
@@ -21,7 +21,7 @@ interface BodyLike {
  * keeping the longest (or first if equal). All returned ranges are added to
  * ``context.trackedObjects``.
  */
-export async function findAnchors(body: BodyLike, snippetRaw: string): Promise<RangeLike[]> {
+export async function findAnchors(body: BodyLike, snippetRaw: string, opts?: { nth?: number | null }): Promise<RangeLike[]> {
   const ctx = body.context;
   const opt = { matchCase: false, matchWholeWord: false };
 
@@ -61,6 +61,17 @@ export async function findAnchors(body: BodyLike, snippetRaw: string): Promise<R
       continue;
     }
     result.push(r);
+  }
+
+  const nth = opts?.nth;
+  if (typeof nth === 'number' && Number.isFinite(nth) && nth >= 0 && result.length) {
+    const idx = Math.min(Math.floor(nth), result.length - 1);
+    const preferred = result[idx];
+    if (preferred) {
+      const reordered = [preferred, ...result.slice(0, idx), ...result.slice(idx + 1)];
+      result.length = 0;
+      result.push(...reordered);
+    }
   }
 
   for (const r of result) {

--- a/word_addin_dev/app/assets/findings.ts
+++ b/word_addin_dev/app/assets/findings.ts
@@ -1,0 +1,19 @@
+import { parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse } from './api-client.ts';
+import type { AnalyzeFindingEx } from './types.ts';
+
+export function coerceOffset(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+export function parseFindings(resp: AnalyzeResponse | AnalyzeFinding[]): AnalyzeFindingEx[] {
+  const arr = (apiParseFindings(resp as any) || []) as AnalyzeFindingEx[];
+  return arr
+    .filter(f => f && f.rule_id && f.snippet)
+    .map(f => ({
+      ...f,
+      start: coerceOffset(f.start),
+      end: coerceOffset(f.end),
+      clause_type: f.clause_type || 'Unknown'
+    }))
+    .filter(f => f.clause_type);
+}

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -1,4 +1,6 @@
-import { applyMetaToBadges, parseFindings as apiParseFindings, AnalyzeFinding, AnalyzeResponse, postRedlines, analyze, apiQaRecheck } from "./api-client.ts";
+import { applyMetaToBadges, AnalyzeFinding, AnalyzeResponse, postRedlines, analyze, apiQaRecheck } from "./api-client.ts";
+import type { AnalyzeFindingEx } from "./types.ts";
+import { parseFindings } from "./findings.ts";
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, dedupeFindings } from "./dedupe.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
@@ -78,13 +80,7 @@ export function logRichError(e: any, tag = "Word") {
   } catch {}
 }
 
-function parseFindings(resp: AnalyzeResponse | AnalyzeFinding[]): AnalyzeFinding[] {
-  const arr = apiParseFindings(resp as any) || [];
-  return arr
-    .filter(f => f && f.rule_id && f.snippet)
-    .map(f => ({ ...f, clause_type: f.clause_type || 'Unknown' }))
-    .filter(f => f.clause_type);
-}
+export { parseFindings };
 
 const g: any = globalThis as any;
 g.parseFindings = g.parseFindings || parseFindings;

--- a/word_addin_dev/app/assets/types.ts
+++ b/word_addin_dev/app/assets/types.ts
@@ -1,3 +1,5 @@
+import type { AnalyzeFinding } from "./api-client.ts";
+
 export interface PartyRegistry {
   name: string
   number_or_duns?: string
@@ -25,4 +27,15 @@ export interface CompaniesMetaItem {
       filing_history?: string
     }
   }
+}
+
+export interface AnalyzeFindingEx extends AnalyzeFinding {
+  start?: number
+  end?: number
+}
+
+export interface AnnotationPlanEx {
+  start?: number
+  end?: number
+  nth?: number | null
 }


### PR DESCRIPTION
## Summary
- compute and persist nth-occurrence metadata from backend offsets while keeping start/end on annotation plans for both prod and dev bundles
- allow anchor resolution to accept an explicit nth index and reuse the new findings helper to coerce offsets when parsing analysis responses
- add focused vitest coverage for offset handling and the annotate flow

## Testing
- `npx vitest run contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate_plan.offsets.spec.ts word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68cf89f2a8ac8325b1eca569f73057bc