### PR TITLE
Implement nth-based anchor fallback cascade

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/anchors.searchNth.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/anchors.searchNth.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let searchNth: (typeof import('../anchors'))['searchNth'];
+
+beforeEach(async () => {
+  vi.resetModules();
+  const mod = await import('../anchors');
+  searchNth = mod.searchNth;
+});
+
+describe('searchNth', () => {
+  it('returns i-th range when nth = i', async () => {
+    const items = [
+      { id: 'a' },
+      { id: 'b' },
+      { id: 'c' }
+    ];
+    const load = vi.fn();
+    const body = {
+      context: { sync: vi.fn(async () => {}) },
+      search: vi.fn(() => ({ items, load }))
+    } as any;
+
+    const range = await searchNth(body, 'needle', 2);
+    expect(body.search).toHaveBeenCalledWith('needle', { matchCase: false, matchWholeWord: false });
+    expect(range).toBe(items[2]);
+  });
+
+  it('returns null when nth exceeds available matches', async () => {
+    const items = [{ id: 'only' }];
+    const body = {
+      context: { sync: vi.fn(async () => {}) },
+      search: vi.fn(() => ({ items, load: vi.fn() }))
+    } as any;
+
+    const range = await searchNth(body, 'needle', 5);
+    expect(range).toBeNull();
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.anchor_by_offsets.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.anchor_by_offsets.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const searchNthMock = vi.fn();
+const findAnchorsMock = vi.fn();
+let annotateMod: Awaited<typeof import('../annotate.ts')>;
+let annotateFindingsIntoWord: (typeof import('../annotate.ts'))['annotateFindingsIntoWord'];
+
+vi.mock('../anchors.ts', async () => {
+  const actual = await vi.importActual<typeof import('../anchors.ts')>('../anchors.ts');
+  return {
+    ...actual,
+    searchNth: searchNthMock,
+    findAnchors: findAnchorsMock
+  };
+});
+
+describe('annotate anchor by offsets', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    searchNthMock.mockReset();
+    findAnchorsMock.mockReset();
+    (globalThis as any).__lastAnalyzed = '';
+    (globalThis as any).document = { getElementById: () => null };
+    annotateMod = await import('../annotate.ts');
+    annotateFindingsIntoWord = annotateMod.annotateFindingsIntoWord;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).Word;
+    delete (globalThis as any).__lastAnalyzed;
+    delete (globalThis as any).document;
+    vi.restoreAllMocks();
+  });
+
+  it('priority: nth -> normalized -> token -> cc', async () => {
+    const safeInsertSpy = vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: true } as any);
+    const fallbackSpy = vi
+      .spyOn(annotateMod, 'fallbackAnnotateWithContentControl')
+      .mockResolvedValue({ ok: true });
+
+    const calls: string[] = [];
+    const range = {
+      start: 0,
+      end: 20,
+      load: vi.fn(),
+      context: { sync: vi.fn(async () => {}) },
+      insertComment: vi.fn(),
+      insertContentControl: () => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn()
+      })
+    } as any;
+
+    const token = 'Supercalifragilistic';
+    const rawSnippet = 'Quote — “' + token + '”';
+    const normalizedSnippet = 'Quote - "' + token + '"';
+
+    searchNthMock.mockImplementation(async (_body, needle) => {
+      calls.push(needle);
+      if (needle === token) return range;
+      return null;
+    });
+
+    findAnchorsMock.mockResolvedValue([]);
+
+    (globalThis as any).__lastAnalyzed = rawSnippet;
+
+    const ccRangeStub = () => ({
+      context: { sync: vi.fn(async () => {}) },
+      insertContentControl: () => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn()
+      })
+    });
+
+    const ctx = {
+      document: {
+        body: {
+          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
+          getRange: vi.fn(() => ccRangeStub())
+        }
+      },
+      sync: vi.fn(async () => {})
+    } as any;
+
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => cb(ctx)
+    };
+
+    const findings = [
+      { rule_id: 'r1', snippet: rawSnippet, start: 0, end: rawSnippet.length }
+    ];
+
+    const inserted = await annotateFindingsIntoWord(findings as any);
+    expect(inserted).toBe(1);
+    expect(calls[0]).toBe(rawSnippet);
+    expect(calls[1]).toBe(normalizedSnippet);
+    expect(calls[2]).toBe(token);
+    expect(fallbackSpy).not.toHaveBeenCalled();
+  });
+
+  it('normalized fallback handles mixed quotes and dashes', async () => {
+    vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: true } as any);
+    vi.spyOn(annotateMod, 'fallbackAnnotateWithContentControl').mockResolvedValue({ ok: false });
+
+    const normalizedNeedle = 'alpha - "beta"';
+    const rawSnippet = 'alpha — “beta”';
+    const expectedRange = {
+      start: 5,
+      end: 15,
+      load: vi.fn(),
+      context: { sync: vi.fn(async () => {}) },
+      insertComment: vi.fn(),
+      insertContentControl: () => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn()
+      })
+    } as any;
+
+    searchNthMock.mockImplementation(async (_body, needle) => {
+      if (needle === rawSnippet) return null;
+      if (needle === normalizedNeedle) return expectedRange;
+      return null;
+    });
+
+    findAnchorsMock.mockResolvedValue([]);
+
+    (globalThis as any).__lastAnalyzed = rawSnippet;
+
+    const ccRangeStub = () => ({
+      context: { sync: vi.fn(async () => {}) },
+      insertContentControl: () => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn()
+      })
+    });
+
+    const ctx = {
+      document: {
+        body: {
+          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
+          getRange: vi.fn(() => ccRangeStub())
+        }
+      },
+      sync: vi.fn(async () => {})
+    } as any;
+
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => cb(ctx)
+    };
+
+    const findings = [
+      { rule_id: 'r2', snippet: rawSnippet, start: 0, end: rawSnippet.length }
+    ];
+
+    const inserted = await annotateFindingsIntoWord(findings as any);
+    expect(inserted).toBe(1);
+    expect(searchNthMock).toHaveBeenCalledWith(expect.anything(), normalizedNeedle, expect.any(Number), expect.any(Object));
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.flow.offsets.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.flow.offsets.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const searchNthMock = vi.fn();
+const findAnchorsMock = vi.fn();
+let annotateMod: Awaited<typeof import('../annotate.ts')>;
+let annotateFindingsIntoWord: (typeof import('../annotate.ts'))['annotateFindingsIntoWord'];
+
+vi.mock('../anchors.ts', async () => {
+  const actual = await vi.importActual<typeof import('../anchors.ts')>('../anchors.ts');
+  return {
+    ...actual,
+    searchNth: searchNthMock,
+    findAnchors: findAnchorsMock
+  };
+});
+
+describe('annotate flow offsets', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    searchNthMock.mockReset();
+    findAnchorsMock.mockReset();
+    (globalThis as any).document = { getElementById: () => null };
+    annotateMod = await import('../annotate.ts');
+    annotateFindingsIntoWord = annotateMod.annotateFindingsIntoWord;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).Word;
+    delete (globalThis as any).__lastAnalyzed;
+    delete (globalThis as any).document;
+    vi.restoreAllMocks();
+  });
+
+  it('anchors to the expected occurrence from offsets', async () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const textPath = path.resolve(here, './fixtures/texts/para_multi_occurrence.txt');
+    const payloadPath = path.resolve(here, './fixtures/payloads/finding_offsets.json');
+    const baseText = fs.readFileSync(textPath, 'utf8');
+    const finding = JSON.parse(fs.readFileSync(payloadPath, 'utf8'));
+
+    (globalThis as any).__lastAnalyzed = baseText;
+
+    vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: true } as any);
+    vi.spyOn(annotateMod, 'fallbackAnnotateWithContentControl').mockResolvedValue({ ok: false });
+
+    const targetRange = {
+      start: finding.start,
+      end: finding.end,
+      load: vi.fn(),
+      context: { sync: vi.fn(async () => {}) },
+      insertComment: vi.fn(),
+      insertContentControl: () => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn()
+      })
+    } as any;
+
+    searchNthMock.mockImplementation(async (_body, needle, nth) => {
+      expect(needle).toBe(finding.snippet);
+      expect(nth).toBe(finding.nth);
+      return targetRange;
+    });
+
+    findAnchorsMock.mockResolvedValue([]);
+
+    const ctx = {
+      document: {
+        body: {
+          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
+          getRange: vi.fn(() => ({
+            context: { sync: vi.fn(async () => {}) },
+            insertContentControl: () => ({
+              tag: '',
+              title: '',
+              color: '',
+              insertText: vi.fn()
+            })
+          }))
+        }
+      },
+      sync: vi.fn(async () => {})
+    } as any;
+
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => cb(ctx)
+    };
+
+    const inserted = await annotateFindingsIntoWord([finding] as any);
+    expect(inserted).toBe(1);
+    expect(targetRange.load).toHaveBeenCalledWith(['start', 'end']);
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/fixtures/payloads/finding_offsets.json
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/fixtures/payloads/finding_offsets.json
@@ -1,0 +1,7 @@
+{
+  "rule_id": "r-liability",
+  "snippet": "The liability clause applies equally to each party.",
+  "start": 142,
+  "end": 193,
+  "nth": 2
+}

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/fixtures/texts/para_multi_occurrence.txt
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/fixtures/texts/para_multi_occurrence.txt
@@ -1,0 +1,4 @@
+This clause repeats the same snippet.
+The liability clause applies equally to each party.
+The liability clause applies equally to each party.
+The liability clause applies equally to each party.

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/props/normalized_equivalence.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/props/normalized_equivalence.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+let normalizeSnippetForSearch: (typeof import('../../anchors'))['normalizeSnippetForSearch'];
+
+beforeAll(async () => {
+  const mod = await import('../../anchors');
+  normalizeSnippetForSearch = mod.normalizeSnippetForSearch;
+});
+
+describe('normalizeSnippetForSearch equivalence', () => {
+  const base = 'Alpha - "beta\'s" clause';
+  const replacements: Record<string, string[]> = {
+    '"': ['"', '“', '”', '„', '‟', '«', '»'],
+    "'": ["'", '’', '‘', '‚', '‛'],
+    '-': ['-', '—', '–', '−'],
+    ' ': [' ', '\u00A0'],
+    '\n': ['\n', '\r', '\r\n']
+  };
+
+  const randomReplace = (ch: string): string => {
+    const options = replacements[ch];
+    if (!options) return ch;
+    const pick = options[Math.floor(Math.random() * options.length)];
+    return pick.replace('\\n', '\n').replace('\\r', '\r');
+  };
+
+  it('property: smart quotes/dashes normalize to base string', () => {
+    for (let i = 0; i < 100; i++) {
+      let mutated = '';
+      for (const ch of base) {
+        mutated += randomReplace(ch);
+      }
+      mutated = mutated.replace('clause', 'clause\nline');
+      const newlineVariants = ['\n', '\r', '\r\n'];
+      const newline = newlineVariants[Math.floor(Math.random() * newlineVariants.length)].replace('\\n', '\n').replace('\\r', '\r');
+      mutated = mutated.replace('\n', newline);
+      const normalized = normalizeSnippetForSearch(mutated);
+      expect(normalized).toBe('Alpha - "beta\'s" clause\nline');
+    }
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts
@@ -1,6 +1,57 @@
 import { normalizeText } from "./dedupe.ts";
 import { safeBodySearch } from "./safeBodySearch.ts";
 
+const quoteMap: Record<string, string> = {
+  '\u201C': '"',
+  '\u201D': '"',
+  '\u201E': '"',
+  '\u201F': '"',
+  '\u00AB': '"',
+  '\u00BB': '"',
+  '\u2033': '"',
+  '\u2036': '"',
+  '\u2018': "'",
+  '\u2019': "'",
+  '\u201A': "'",
+  '\u201B': "'",
+  '\u2032': "'",
+  '\u2035': "'",
+};
+
+const dashMap: Record<string, string> = {
+  '\u2010': '-',
+  '\u2011': '-',
+  '\u2012': '-',
+  '\u2013': '-',
+  '\u2014': '-',
+  '\u2015': '-',
+  '\u2212': '-',
+};
+
+export function normalizeSnippetForSearch(snippet: string | null | undefined): string {
+  if (!snippet) return "";
+  let res = String(snippet);
+  res = res.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  res = res.replace(/\u00A0/g, " ");
+  res = res.replace(/[\u2010-\u2015\u2212]/g, ch => dashMap[ch] || '-');
+  res = res.replace(/[\u00AB\u00BB\u201C-\u201F\u2033\u2036]/g, ch => quoteMap[ch] || '"');
+  res = res.replace(/[\u2018-\u201B\u2032\u2035]/g, ch => quoteMap[ch] || "'");
+  return res;
+}
+
+export function pickLongToken(snippet: string | null | undefined): string | null {
+  if (!snippet) return null;
+  const tokens = String(snippet)
+    .replace(/[^\p{L}\p{N} ]/gu, " ")
+    .split(" ")
+    .map(t => t.trim())
+    .filter(Boolean);
+  if (!tokens.length) return null;
+  const sorted = tokens.sort((a, b) => b.length - a.length);
+  const longest = sorted.find(t => t.length >= 8) || sorted[0];
+  return longest ? longest.slice(0, 64) : null;
+}
+
 interface RangeLike {
   start?: number;
   end?: number;
@@ -86,3 +137,19 @@ export async function findAnchors(body: BodyLike, snippetRaw: string, opts?: { n
 }
 
 export type { RangeLike };
+
+export async function searchNth(body: BodyLike, snippetRaw: string, nth: number, opt?: Word.SearchOptions): Promise<RangeLike | null> {
+  if (!body || !snippetRaw) return null;
+  const idx = typeof nth === 'number' && Number.isFinite(nth) && nth >= 0 ? Math.floor(nth) : 0;
+  const searchOpts = opt || { matchCase: false, matchWholeWord: false };
+  const res = await safeBodySearch(body, snippetRaw, searchOpts);
+  const items: RangeLike[] = res?.items || [];
+  if (!items.length) return null;
+  if (idx >= items.length) return null;
+  const picked = items[idx] ?? null;
+  if (!picked) return null;
+  try {
+    body.context?.trackedObjects?.add?.(picked);
+  } catch {}
+  return picked;
+}

--- a/contract_review_app/contract_review_app/static/panel/app/assets/findings.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/findings.ts
@@ -13,6 +13,7 @@ export function parseFindings(resp: AnalyzeResponse | AnalyzeFinding[]): Analyze
       ...f,
       start: coerceOffset(f.start),
       end: coerceOffset(f.end),
+      nth: coerceOffset((f as any).nth),
       clause_type: f.clause_type || 'Unknown'
     }))
     .filter(f => f.clause_type);

--- a/contract_review_app/contract_review_app/static/panel/app/assets/types.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/types.ts
@@ -32,6 +32,7 @@ export interface CompaniesMetaItem {
 export interface AnalyzeFindingEx extends AnalyzeFinding {
   start?: number
   end?: number
+  nth?: number
 }
 
 export interface AnnotationPlanEx {

--- a/word_addin_dev/app/assets/anchors.ts
+++ b/word_addin_dev/app/assets/anchors.ts
@@ -1,6 +1,57 @@
 import { normalizeText } from "./dedupe.ts";
 import { safeBodySearch } from "./safeBodySearch.ts";
 
+const quoteMap: Record<string, string> = {
+  '\u201C': '"',
+  '\u201D': '"',
+  '\u201E': '"',
+  '\u201F': '"',
+  '\u00AB': '"',
+  '\u00BB': '"',
+  '\u2033': '"',
+  '\u2036': '"',
+  '\u2018': "'",
+  '\u2019': "'",
+  '\u201A': "'",
+  '\u201B': "'",
+  '\u2032': "'",
+  '\u2035': "'",
+};
+
+const dashMap: Record<string, string> = {
+  '\u2010': '-',
+  '\u2011': '-',
+  '\u2012': '-',
+  '\u2013': '-',
+  '\u2014': '-',
+  '\u2015': '-',
+  '\u2212': '-',
+};
+
+export function normalizeSnippetForSearch(snippet: string | null | undefined): string {
+  if (!snippet) return "";
+  let res = String(snippet);
+  res = res.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  res = res.replace(/\u00A0/g, " ");
+  res = res.replace(/[\u2010-\u2015\u2212]/g, ch => dashMap[ch] || '-');
+  res = res.replace(/[\u00AB\u00BB\u201C-\u201F\u2033\u2036]/g, ch => quoteMap[ch] || '"');
+  res = res.replace(/[\u2018-\u201B\u2032\u2035]/g, ch => quoteMap[ch] || "'");
+  return res;
+}
+
+export function pickLongToken(snippet: string | null | undefined): string | null {
+  if (!snippet) return null;
+  const tokens = String(snippet)
+    .replace(/[^\p{L}\p{N} ]/gu, " ")
+    .split(" ")
+    .map(t => t.trim())
+    .filter(Boolean);
+  if (!tokens.length) return null;
+  const sorted = tokens.sort((a, b) => b.length - a.length);
+  const longest = sorted.find(t => t.length >= 8) || sorted[0];
+  return longest ? longest.slice(0, 64) : null;
+}
+
 interface RangeLike {
   start?: number;
   end?: number;
@@ -86,3 +137,19 @@ export async function findAnchors(body: BodyLike, snippetRaw: string, opts?: { n
 }
 
 export type { RangeLike };
+
+export async function searchNth(body: BodyLike, snippetRaw: string, nth: number, opt?: Word.SearchOptions): Promise<RangeLike | null> {
+  if (!body || !snippetRaw) return null;
+  const idx = typeof nth === 'number' && Number.isFinite(nth) && nth >= 0 ? Math.floor(nth) : 0;
+  const searchOpts = opt || { matchCase: false, matchWholeWord: false };
+  const res = await safeBodySearch(body, snippetRaw, searchOpts);
+  const items: RangeLike[] = res?.items || [];
+  if (!items.length) return null;
+  if (idx >= items.length) return null;
+  const picked = items[idx] ?? null;
+  if (!picked) return null;
+  try {
+    body.context?.trackedObjects?.add?.(picked);
+  } catch {}
+  return picked;
+}

--- a/word_addin_dev/app/assets/findings.ts
+++ b/word_addin_dev/app/assets/findings.ts
@@ -13,6 +13,7 @@ export function parseFindings(resp: AnalyzeResponse | AnalyzeFinding[]): Analyze
       ...f,
       start: coerceOffset(f.start),
       end: coerceOffset(f.end),
+      nth: coerceOffset((f as any).nth),
       clause_type: f.clause_type || 'Unknown'
     }))
     .filter(f => f.clause_type);

--- a/word_addin_dev/app/assets/types.ts
+++ b/word_addin_dev/app/assets/types.ts
@@ -32,6 +32,7 @@ export interface CompaniesMetaItem {
 export interface AnalyzeFindingEx extends AnalyzeFinding {
   start?: number
   end?: number
+  nth?: number
 }
 
 export interface AnnotationPlanEx {


### PR DESCRIPTION
## Summary
* Added snippet normalization utilities, nth-indexed search, and a token/CC fallback cascade to the panel annotation workflow for more resilient anchoring. 【F:contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts†L4-L155】【F:contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts†L124-L396】
* Synced the Word add-in to track nth occurrences and reuse the new anchoring logic while extending finding metadata. 【F:word_addin_dev/app/assets/anchors.ts†L4-L155】【F:word_addin_dev/app/assets/annotate.ts†L138-L360】【F:contract_review_app/contract_review_app/static/panel/app/assets/findings.ts†L1-L20】【F:contract_review_app/contract_review_app/static/panel/app/assets/types.ts†L32-L41】【F:word_addin_dev/app/assets/findings.ts†L1-L20】【F:word_addin_dev/app/assets/types.ts†L32-L41】
* Added Vitest coverage and fixtures for nth search selection, fallback ordering, and snippet normalization equivalence. 【F:contract_review_app/contract_review_app/static/panel/app/assets/__tests__/anchors.searchNth.spec.ts†L1-L38】【F:contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.anchor_by_offsets.spec.ts†L1-L169】【F:contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.flow.offsets.spec.ts†L1-L88】【F:word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts†L1-L99】【F:contract_review_app/contract_review_app/static/panel/app/assets/__tests__/props/normalized_equivalence.spec.ts†L1-L39】【F:contract_review_app/contract_review_app/static/panel/app/assets/__tests__/fixtures/texts/para_multi_occurrence.txt†L1-L4】【F:contract_review_app/contract_review_app/static/panel/app/assets/__tests__/fixtures/payloads/finding_offsets.json†L1-L7】

## Testing
* ⚠️ `npm ci` *(fails: repository does not provide a package-lock)* 【a8ce7c†L1-L24】
* ✅ `npx vitest run contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.anchor_by_offsets.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.flow.offsets.spec.ts` 【52a44c†L1-L33】
* ✅ `npx vitest run contract_review_app/contract_review_app/static/panel/app/assets/__tests__/anchors.searchNth.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/props/normalized_equivalence.spec.ts word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts` 【a9dac8†L1-L22】

------
https://chatgpt.com/codex/tasks/task_e_68cf920366648325a6bbfdf8ee551006