### PR TITLE
feat: add offset anchor cascade

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.anchor_by_offsets.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.anchor_by_offsets.spec.ts
@@ -1,22 +1,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+const safeBodySearchMock = vi.fn();
 const searchNthMock = vi.fn();
 const findAnchorsMock = vi.fn();
 let annotateMod: Awaited<typeof import('../annotate.ts')>;
 let annotateFindingsIntoWord: (typeof import('../annotate.ts'))['annotateFindingsIntoWord'];
+
+vi.mock('../safeBodySearch.ts', () => ({
+  safeBodySearch: safeBodySearchMock,
+}));
 
 vi.mock('../anchors.ts', async () => {
   const actual = await vi.importActual<typeof import('../anchors.ts')>('../anchors.ts');
   return {
     ...actual,
     searchNth: searchNthMock,
-    findAnchors: findAnchorsMock
+    findAnchors: findAnchorsMock,
   };
 });
 
 describe('annotate anchor by offsets', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    safeBodySearchMock.mockReset();
     searchNthMock.mockReset();
     findAnchorsMock.mockReset();
     (globalThis as any).__lastAnalyzed = '';
@@ -28,143 +34,212 @@ describe('annotate anchor by offsets', () => {
   afterEach(() => {
     delete (globalThis as any).Word;
     delete (globalThis as any).__lastAnalyzed;
+    delete (globalThis as any).__cfg_anchorOffsets;
     delete (globalThis as any).document;
     vi.restoreAllMocks();
   });
 
-  it('priority: nth -> normalized -> token -> cc', async () => {
-    const safeInsertSpy = vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: true } as any);
-    const fallbackSpy = vi
-      .spyOn(annotateMod, 'fallbackAnnotateWithContentControl')
-      .mockResolvedValue({ ok: true });
-
-    const calls: string[] = [];
-    const range = {
-      start: 0,
-      end: 20,
-      load: vi.fn(),
-      context: { sync: vi.fn(async () => {}) },
-      insertComment: vi.fn(),
-      insertContentControl: () => ({
-        tag: '',
-        title: '',
-        color: '',
-        insertText: vi.fn()
-      })
-    } as any;
-
-    const token = 'Supercalifragilistic';
-    const rawSnippet = 'Quote — “' + token + '”';
-    const normalizedSnippet = 'Quote - "' + token + '"';
-
-    searchNthMock.mockImplementation(async (_body, needle) => {
-      calls.push(needle);
-      if (needle === token) return range;
-      return null;
-    });
-
-    findAnchorsMock.mockResolvedValue([]);
-
-    (globalThis as any).__lastAnalyzed = rawSnippet;
-
-    const ccRangeStub = () => ({
-      context: { sync: vi.fn(async () => {}) },
-      insertContentControl: () => ({
-        tag: '',
-        title: '',
-        color: '',
-        insertText: vi.fn()
-      })
-    });
-
-    const ctx = {
-      document: {
-        body: {
-          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
-          getRange: vi.fn(() => ccRangeStub())
-        }
-      },
-      sync: vi.fn(async () => {})
-    } as any;
-
-    (globalThis as any).Word = {
-      InsertLocation: { end: 'end' },
-      run: async (cb: any) => cb(ctx)
-    };
-
-    const findings = [
-      { rule_id: 'r1', snippet: rawSnippet, start: 0, end: rawSnippet.length }
-    ];
-
-    const inserted = await annotateFindingsIntoWord(findings as any);
-    expect(inserted).toBe(1);
-    expect(calls[0]).toBe(rawSnippet);
-    expect(calls[1]).toBe(normalizedSnippet);
-    expect(calls[2]).toBe(token);
-    expect(fallbackSpy).not.toHaveBeenCalled();
-  });
-
-  it('normalized fallback handles mixed quotes and dashes', async () => {
+  it('anchors directly by offsets before searching nth', async () => {
+    (globalThis as any).__cfg_anchorOffsets = 1;
     vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: true } as any);
     vi.spyOn(annotateMod, 'fallbackAnnotateWithContentControl').mockResolvedValue({ ok: false });
 
-    const normalizedNeedle = 'alpha - "beta"';
-    const rawSnippet = 'alpha — “beta”';
-    const expectedRange = {
-      start: 5,
-      end: 15,
+    const snippet = 'Term 45 / Pay 60';
+    const range = {
+      start: 42,
+      end: 42 + snippet.length,
       load: vi.fn(),
       context: { sync: vi.fn(async () => {}) },
       insertComment: vi.fn(),
-      insertContentControl: () => ({
+      insertContentControl: vi.fn(() => ({
         tag: '',
         title: '',
         color: '',
-        insertText: vi.fn()
-      })
+        insertText: vi.fn(),
+      })),
     } as any;
 
-    searchNthMock.mockImplementation(async (_body, needle) => {
-      if (needle === rawSnippet) return null;
-      if (needle === normalizedNeedle) return expectedRange;
-      return null;
-    });
-
+    safeBodySearchMock.mockImplementation(async () => ({ items: [range] }));
     findAnchorsMock.mockResolvedValue([]);
 
-    (globalThis as any).__lastAnalyzed = rawSnippet;
-
-    const ccRangeStub = () => ({
-      context: { sync: vi.fn(async () => {}) },
-      insertContentControl: () => ({
-        tag: '',
-        title: '',
-        color: '',
-        insertText: vi.fn()
-      })
-    });
+    (globalThis as any).__lastAnalyzed = snippet;
 
     const ctx = {
       document: {
         body: {
           context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
-          getRange: vi.fn(() => ccRangeStub())
-        }
+          getRange: vi.fn(() => range),
+        },
       },
-      sync: vi.fn(async () => {})
+      sync: vi.fn(async () => {}),
     } as any;
 
     (globalThis as any).Word = {
       InsertLocation: { end: 'end' },
-      run: async (cb: any) => cb(ctx)
+      run: async (cb: any) => cb(ctx),
     };
 
     const findings = [
-      { rule_id: 'r2', snippet: rawSnippet, start: 0, end: rawSnippet.length }
+      { rule_id: 'r1', snippet, start: 42, end: 42 + snippet.length },
     ];
 
     const inserted = await annotateFindingsIntoWord(findings as any);
     expect(inserted).toBe(1);
-    expect(searchNthMock).toHaveBeenCalledWith(expect.anything(), normalizedNeedle, expect.any(Number), expect.any(Object));
+    expect(safeBodySearchMock).toHaveBeenCalled();
+  });
+
+  it('falls back to nth search when offset lookup misses', async () => {
+    (globalThis as any).__cfg_anchorOffsets = 1;
+    vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: true } as any);
+    vi.spyOn(annotateMod, 'fallbackAnnotateWithContentControl').mockResolvedValue({ ok: false });
+
+    const snippet = 'Clause Value';
+    const range = {
+      start: 10,
+      end: 22,
+      load: vi.fn(),
+      context: { sync: vi.fn(async () => {}) },
+      insertComment: vi.fn(),
+      insertContentControl: vi.fn(() => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn(),
+      })),
+    } as any;
+
+    const queue = [
+      { items: [] },
+      { items: [] },
+      { items: [range] },
+    ];
+    safeBodySearchMock.mockImplementation(async () => queue.shift() ?? { items: [] });
+    findAnchorsMock.mockResolvedValue([]);
+
+    (globalThis as any).__lastAnalyzed = snippet;
+
+    const ctx = {
+      document: {
+        body: {
+          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
+          getRange: vi.fn(() => range),
+        },
+      },
+      sync: vi.fn(async () => {}),
+    } as any;
+
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => cb(ctx),
+    };
+
+    const findings = [
+      { rule_id: 'r2', snippet, start: 10, end: 22, nth: 0 },
+    ];
+
+    const inserted = await annotateFindingsIntoWord(findings as any);
+    expect(inserted).toBe(1);
+  });
+
+  it('falls back to token search when nth searches fail', async () => {
+    (globalThis as any).__cfg_anchorOffsets = 1;
+    vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: true } as any);
+    vi.spyOn(annotateMod, 'fallbackAnnotateWithContentControl').mockResolvedValue({ ok: false });
+
+    const token = 'Supercalifragilistic';
+    const snippet = `Quote — “${token}”`;
+    const tokenRange = {
+      start: 70,
+      end: 70 + token.length,
+      load: vi.fn(),
+      context: { sync: vi.fn(async () => {}) },
+      insertComment: vi.fn(),
+      insertContentControl: vi.fn(() => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn(),
+      })),
+    } as any;
+
+    const queue = [
+      { items: [] },
+      { items: [] },
+      { items: [] },
+      { items: [] },
+      { items: [tokenRange] },
+    ];
+    safeBodySearchMock.mockImplementation(async () => queue.shift() ?? { items: [] });
+    findAnchorsMock.mockResolvedValue([]);
+
+    (globalThis as any).__lastAnalyzed = snippet;
+
+    const ctx = {
+      document: {
+        body: {
+          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
+          getRange: vi.fn(() => tokenRange),
+        },
+      },
+      sync: vi.fn(async () => {}),
+    } as any;
+
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => cb(ctx),
+    };
+
+    const findings = [
+      { rule_id: 'r3', snippet, start: 70, end: 70 + snippet.length },
+    ];
+
+    const inserted = await annotateFindingsIntoWord(findings as any);
+    expect(inserted).toBe(1);
+  });
+
+  it('falls back to content control when no anchor is found', async () => {
+    (globalThis as any).__cfg_anchorOffsets = 1;
+    vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: false } as any);
+    vi.spyOn(annotateMod, 'fallbackAnnotateWithContentControl').mockResolvedValue({ ok: true });
+
+    const snippet = 'Missing anchor snippet';
+
+    safeBodySearchMock.mockImplementation(async () => ({ items: [] }));
+    findAnchorsMock.mockResolvedValue([]);
+
+    (globalThis as any).__lastAnalyzed = snippet;
+
+    const ccRange = {
+      context: { sync: vi.fn(async () => {}) },
+      insertContentControl: vi.fn(() => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn(),
+      })),
+    } as any;
+
+    const ctx = {
+      document: {
+        body: {
+          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
+          getRange: vi.fn(() => ccRange),
+        },
+      },
+      sync: vi.fn(async () => {}),
+    } as any;
+
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => cb(ctx),
+    };
+
+    const findings = [
+      { rule_id: 'r4', snippet, start: 0, end: snippet.length },
+    ];
+
+    const inserted = await annotateFindingsIntoWord(findings as any);
+    expect(inserted).toBe(1);
+    expect(ccRange.insertContentControl).toHaveBeenCalled();
   });
 });

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -1,6 +1,7 @@
 import { AnalyzeFinding } from "./api-client.ts";
 import { dedupeFindings, normalizeText } from "./dedupe.ts";
-import { findAnchors, normalizeSnippetForSearch, pickLongToken, searchNth } from "./anchors.ts";
+import { anchorByOffsets, findAnchors, pickLongToken } from "./anchors.ts";
+import type { AnchorMethod as AnchorCascadeMethod } from "./anchors.ts";
 import { normalizeIntakeText } from "./normalize_intake.ts";
 import type { AnalyzeFindingEx, AnnotationPlanEx } from "./types.ts";
 
@@ -159,64 +160,7 @@ export function computeNthFromOffsets(text: string, snippet: string, start?: num
   return count;
 }
 
-export type AnchorMethod = 'nth' | 'normalized' | 'token' | 'cc';
-
-export interface AnchorOpts {
-  body: Word.Body;
-  searchOptions?: Word.SearchOptions;
-  normalizedCandidates?: Array<string | null | undefined>;
-  token?: string | null;
-  onMethod?: (method: AnchorMethod) => void;
-}
-
-export async function anchorByOffsets(snippet: string, nth: number, opts: AnchorOpts): Promise<Word.Range | null> {
-  if (!opts?.body || !snippet) return null;
-  const safeNth = typeof nth === 'number' && Number.isFinite(nth) && nth >= 0 ? Math.floor(nth) : 0;
-  const searchOptions = opts.searchOptions || { matchCase: false, matchWholeWord: false };
-  const logMethod = (method: AnchorMethod) => {
-    try {
-      opts.onMethod?.(method);
-    } catch {}
-  };
-
-  let range = await searchNth(opts.body as any, snippet, safeNth, searchOptions);
-  if (range) {
-    logMethod('nth');
-    return range as Word.Range;
-  }
-
-  const variants = new Set<string>();
-  const pushVariant = (cand: string | null | undefined) => {
-    if (!cand) return;
-    const normalized = normalizeSnippetForSearch(cand);
-    if (!normalized || normalized === snippet) return;
-    variants.add(normalized);
-  };
-
-  pushVariant(normalizeSnippetForSearch(snippet));
-  for (const cand of opts.normalizedCandidates || []) {
-    pushVariant(cand || undefined);
-  }
-
-  for (const variant of variants) {
-    range = await searchNth(opts.body as any, variant, safeNth, searchOptions);
-    if (range) {
-      logMethod('normalized');
-      return range as Word.Range;
-    }
-  }
-
-  const token = opts.token ?? pickLongToken(snippet);
-  if (token) {
-    const tokenRange = await searchNth(opts.body as any, token, 0, searchOptions);
-    if (tokenRange) {
-      logMethod('token');
-      return tokenRange as Word.Range;
-    }
-  }
-
-  return null;
-}
+type AnchorMethod = AnchorCascadeMethod | 'cc';
 
 function isDryRunAnnotateEnabled(): boolean {
   try {
@@ -337,15 +281,19 @@ export async function annotateFindingsIntoWord(findings: AnalyzeFindingEx[]): Pr
           op.norm && op.norm !== op.raw ? op.norm : null,
         ];
         try {
-          target = await anchorByOffsets(op.raw, desired, {
+          target = await anchorByOffsets({
             body,
+            snippet: op.raw,
+            start: op.start,
+            end: op.end,
+            nth: desired,
             searchOptions,
             normalizedCandidates,
             token: pickLongToken(op.raw),
             onMethod: m => {
               anchorMethod = m;
             }
-          });
+          }) as Word.Range | null;
         } catch (err) {
           console.warn("anchorByOffsets failed", err);
         }


### PR DESCRIPTION
## Summary
- add an `anchorByOffsets` helper to the shared anchors modules that first tries offset matching before falling back through nth, normalized, and token searches
- update the annotate flows in both bundles to call the new helper with offsets, token hints, and method tracking so the cascade is exercised before `findAnchors`
- expand panel and dev Vitest coverage to cover the offset cascade and rename the dev bundle flow test into the double-underscore suite

## Testing
- npx vitest run contract_review_app/contract_review_app/static/panel/app/assets/__tests__/annotate.anchor_by_offsets.spec.ts word_addin_dev/app/__tests__/__annotate.flow.offsets.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf9f7b021c8325a4b907603ef4decd