### PR TITLE
Align dev QA recheck risk handling

### DIFF
--- a/word_addin_dev/app/__tests__/analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.flow.spec.ts
@@ -1,9 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { components } from '../../../docs/api';
+import type { AnalyzeFinding } from '../assets/api-client.ts';
 
 type AnalyzeRequest = components['schemas']['AnalyzeRequest'];
 
 describe('analyze flow', () => {
+  afterEach(() => {
+    delete (globalThis as any).__CAI_TESTING__;
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+    delete (globalThis as any).localStorage;
+    delete (globalThis as any).fetch;
+  });
+
   it('posts flat payload with schema', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
     (globalThis as any).fetch = fetchMock;
@@ -17,5 +26,22 @@ describe('analyze flow', () => {
     const body = JSON.parse(opts.body);
     expect(body).toMatchObject({ text: 'hello', mode: 'live', schema: '1.4', risk: 'medium' });
     expect(opts.headers['x-schema-version']).toBe('1.4');
+  });
+
+  it('filters QA findings to high and above', async () => {
+    vi.resetModules();
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).window = { addEventListener() {}, removeEventListener() {}, location: { search: '' } } as any;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
+    const { filterFindingsByRiskForTests } = await import('../assets/taskpane.ts');
+    const findings: AnalyzeFinding[] = [
+      { rule_id: 'low', snippet: 'l', severity: 'low' } as AnalyzeFinding,
+      { rule_id: 'med', snippet: 'm', severity: 'medium' } as AnalyzeFinding,
+      { rule_id: 'hi', snippet: 'h', severity: 'high' } as AnalyzeFinding,
+      { rule_id: 'crit', snippet: 'c', severity: 'critical' } as AnalyzeFinding,
+      { rule_id: 'upper', snippet: 'u', severity: 'CRITICAL' as any } as AnalyzeFinding,
+    ];
+    const filtered = filterFindingsByRiskForTests(findings, 'high');
+    expect(filtered.map(f => f.rule_id)).toEqual(['hi', 'crit', 'upper']);
   });
 });

--- a/word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts
+++ b/word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts
@@ -68,10 +68,12 @@ describe('qa recheck navigation', () => {
       li.scrollIntoView = () => {};
       fl.appendChild(li);
     });
-    await postJSON('/api/qa-recheck', { document_id: 'doc1', rules: {} });
+    const select = document.getElementById('selectRiskThreshold') as HTMLSelectElement;
+    const expectedRisk = select?.value?.toLowerCase?.() || 'medium';
+    await postJSON('/api/qa-recheck', { document_id: 'doc1', rules: {}, risk: expectedRisk });
     resultsEl.dispatchEvent(new CustomEvent('ca.qa', { detail: qaResp }));
 
-    expect(postJSON).toHaveBeenCalledWith('/api/qa-recheck', { document_id: 'doc1', rules: {} });
+    expect(postJSON).toHaveBeenCalledWith('/api/qa-recheck', { document_id: 'doc1', rules: {}, risk: expectedRisk });
 
     const items = (window as any).__findings;
     expect(items).toEqual(qaResp.analysis.findings);

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -303,18 +303,22 @@ export async function apiSummaryGet() {
 
 
 export async function apiQaRecheck(
-  input: { document_id?: string; text?: string; rules?: any } | string,
+  input: { document_id?: string; text?: string; rules?: any; risk?: string } | string,
   rules: any = {},
 ) {
   let payload: any;
+  let risk: string | undefined;
   if (typeof input === 'string') {
     payload = { text: input };
   } else {
     payload = input.document_id ? { document_id: input.document_id } : { text: input.text };
     rules = input.rules ?? {};
+    risk = input.risk ?? risk;
   }
   const dict = Array.isArray(rules) ? Object.assign({}, ...rules) : (rules || {});
-  const { resp, json } = await postJSON('/api/qa-recheck', { ...payload, rules: dict });
+  const body = { ...payload, rules: dict };
+  if (risk) body.risk = risk;
+  const { resp, json } = await postJSON('/api/qa-recheck', body);
   const meta = metaFromResponse({ headers: resp.headers, json, status: resp.status });
   try { applyMetaToBadges(meta); } catch {}
   return { ok: resp.ok, json, resp, meta };

--- a/word_addin_dev/app/assets/dedupe.ts
+++ b/word_addin_dev/app/assets/dedupe.ts
@@ -1,5 +1,8 @@
 import { AnalyzeFinding } from "./api-client.ts";
 
+export const RISK_LEVELS = ["low", "medium", "high", "critical"] as const;
+export type RiskLevel = typeof RISK_LEVELS[number];
+
 export function normalizeText(s: string | undefined | null): string {
   if (!s) return "";
   return s
@@ -10,9 +13,19 @@ export function normalizeText(s: string | undefined | null): string {
     .trim();
 }
 
-export function severityRank(s?: string): number {
-  const m = (s || "").toLowerCase();
-  return m === "high" ? 3 : m === "medium" ? 2 : 1;
+export function normalizeSeverity(val: unknown): RiskLevel | null {
+  if (typeof val !== "string") return null;
+  const v = val.trim().toLowerCase();
+  if (v === "low" || v === "medium" || v === "high" || v === "critical") {
+    return v;
+  }
+  return null;
+}
+
+export function severityRank(val: unknown): number {
+  const sev = normalizeSeverity(val);
+  if (!sev) return RISK_LEVELS.indexOf("medium");
+  return RISK_LEVELS.indexOf(sev);
 }
 
 export function dedupeFindings(findings: AnalyzeFinding[]): AnalyzeFinding[] {


### PR DESCRIPTION
## Summary
- normalize severity ranking utilities so dev bundle can share risk levels with filtering logic
- include the selected risk threshold in QA recheck requests and reuse the shared ranking helper for client-side filtering
- extend automated tests to cover QA risk filtering and updated QA recheck payload expectations

## Testing
- `npx vitest run word_addin_dev/app/__tests__/analyze.payload.spec.ts word_addin_dev/app/__tests__/analyze.flow.spec.ts`
- `npx vitest run contract_review_app/contract_review_app/static/panel/app/assets/__tests__/props/normalized_equivalence.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/__annotate.anchor_by_offsets.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/render.ch.spec.ts word_addin_dev/app/__tests__/props/normalized_equivalence.spec.ts word_addin_dev/app/__tests__/__annotate.flow.offsets.spec.ts word_addin_dev/app/__tests__/render.ch.spec.ts word_addin_dev/app/__tests__/analyze.payload.spec.ts word_addin_dev/app/__tests__/analyze.flow.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68cfa3eb4ffc8325b767905ce830e59f