### PR TITLE
Align frontend normalization with server offsets

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/normalize.full.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/normalize.full.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+let normalizeTextFull: (typeof import('../normalize_intake'))['normalizeTextFull'];
+let normalizeIntakeText: (typeof import('../normalize_intake'))['normalizeIntakeText'];
+
+beforeAll(async () => {
+  const mod = await import('../normalize_intake');
+  normalizeTextFull = mod.normalizeTextFull;
+  normalizeIntakeText = mod.normalizeIntakeText;
+});
+
+describe('normalizeTextFull', () => {
+  it('normalizes smart punctuation and builds offset map', () => {
+    const sample = '“A”\u00A0B\u200B\r\nC\u2014D';
+    const result = normalizeTextFull(sample);
+    expect(result.text).toBe('"A" B\nC-D');
+    expect(result.map).toEqual([0, 1, 2, 3, 4, 6, 8, 9, 10]);
+    expect(result.map.length).toBe(result.text.length);
+  });
+
+  it('trims and collapses whitespace while maintaining offsets', () => {
+    const sample = '\u200B  Foo\u00A0 \tBar\u200D  ';
+    const result = normalizeTextFull(sample);
+    expect(result.text).toBe('Foo Bar');
+    expect(result.map).toEqual([3, 4, 5, 6, 9, 10, 11]);
+    expect(result.map.length).toBe(result.text.length);
+  });
+
+  it('matches normalizeIntakeText output for representative samples', () => {
+    const samples = [
+      'Simple text',
+      ' “Quote” — dash ',
+      'A\u00A0B\u200B C',
+      'Line1\rLine2',
+      'Zero\u200DWidth'
+    ];
+    for (const sample of samples) {
+      const result = normalizeTextFull(sample);
+      expect(result.text).toBe(normalizeIntakeText(sample));
+      expect(result.map.length).toBe(result.text.length);
+      const sorted = [...result.map].sort((a, b) => a - b);
+      expect(result.map).toEqual(sorted);
+    }
+  });
+
+  it('returns empty result for falsy input', () => {
+    expect(normalizeTextFull(null)).toEqual({ text: '', map: [] });
+    expect(normalizeTextFull(undefined)).toEqual({ text: '', map: [] });
+    expect(normalizeTextFull('')).toEqual({ text: '', map: [] });
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/anchors.ts
@@ -1,9 +1,9 @@
-import { normalizeIntakeText } from "./normalize_intake.ts";
+import { normalizeIntakeText, normalizeTextFull } from "./normalize_intake.ts";
 import { safeBodySearch } from "./safeBodySearch.ts";
 
 export function normalizeSnippetForSearch(snippet: string | null | undefined): string {
   if (!snippet) return "";
-  return normalizeIntakeText(String(snippet));
+  return normalizeTextFull(String(snippet)).text;
 }
 
 export function pickLongToken(snippet: string | null | undefined): string | null {

--- a/contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts
@@ -2,7 +2,7 @@ import { AnalyzeFinding } from "./api-client.ts";
 import { dedupeFindings, normalizeText } from "./dedupe.ts";
 import { anchorByOffsets, findAnchors, pickLongToken } from "./anchors.ts";
 import type { AnchorMethod as AnchorCascadeMethod } from "./anchors.ts";
-import { normalizeIntakeText } from "./normalize_intake.ts";
+import { normalizeIntakeText, normalizeTextFull, type NormalizeTextFullResult } from "./normalize_intake.ts";
 import type { AnalyzeFindingEx, AnnotationPlanEx } from "./types.ts";
 
 /** Utilities for inserting comments into Word with batching and retries. */
@@ -112,15 +112,20 @@ function nthOccurrenceIndex(hay: string, needle: string, startPos?: number): num
   return n;
 }
 
-const normalizedCache = new Map<string, string>();
+const normalizedFullCache = new Map<string, NormalizeTextFullResult>();
 
-function normalizeCached(text: string): string {
-  let cached = normalizedCache.get(text);
-  if (cached == null) {
-    cached = normalizeIntakeText(text).trim();
-    normalizedCache.set(text, cached);
+function getNormalizedFull(text: string): NormalizeTextFullResult {
+  let cached = normalizedFullCache.get(text);
+  if (!cached) {
+    cached = normalizeTextFull(text);
+    normalizedFullCache.set(text, cached);
   }
   return cached;
+}
+
+function normalizeCached(text: string): string {
+  if (!text) return "";
+  return getNormalizedFull(text).text;
 }
 
 export function computeNthFromOffsets(text: string, snippet: string, start?: number): number | null {
@@ -129,17 +134,23 @@ export function computeNthFromOffsets(text: string, snippet: string, start?: num
   const normSnippet = normalizeIntakeText(snippet).trim();
   if (!normSnippet) return null;
 
-  const normText = normalizeCached(text);
-  const prefix = text.slice(0, Math.max(0, Math.min(text.length, Math.floor(start))));
-  const normPrefix = normalizeIntakeText(prefix).trim();
-
+  const { text: normText, map } = getNormalizedFull(text);
   if (!normText) return null;
+
+  const floorStart = Math.floor(start);
+  let prefixLimit = map.length;
+  for (let i = 0; i < map.length; i++) {
+    if (map[i] >= floorStart) {
+      prefixLimit = i;
+      break;
+    }
+  }
 
   let count = 0;
   let searchIdx = 0;
   while (true) {
     const foundIdx = normText.indexOf(normSnippet, searchIdx);
-    if (foundIdx === -1 || foundIdx >= normPrefix.length) break;
+    if (foundIdx === -1 || foundIdx >= prefixLimit) break;
     count++;
     searchIdx = foundIdx + Math.max(normSnippet.length, 1);
   }

--- a/word_addin_dev/app/__tests__/normalize.full.spec.ts
+++ b/word_addin_dev/app/__tests__/normalize.full.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+let normalizeTextFull: (typeof import('../assets/normalize_intake'))['normalizeTextFull'];
+let normalizeIntakeText: (typeof import('../assets/normalize_intake'))['normalizeIntakeText'];
+
+beforeAll(async () => {
+  const mod = await import('../assets/normalize_intake');
+  normalizeTextFull = mod.normalizeTextFull;
+  normalizeIntakeText = mod.normalizeIntakeText;
+});
+
+describe('normalizeTextFull', () => {
+  it('normalizes smart punctuation and builds offset map', () => {
+    const sample = '“A”\u00A0B\u200B\r\nC\u2014D';
+    const result = normalizeTextFull(sample);
+    expect(result.text).toBe('"A" B\nC-D');
+    expect(result.map).toEqual([0, 1, 2, 3, 4, 6, 8, 9, 10]);
+    expect(result.map.length).toBe(result.text.length);
+  });
+
+  it('trims and collapses whitespace while maintaining offsets', () => {
+    const sample = '\u200B  Foo\u00A0 \tBar\u200D  ';
+    const result = normalizeTextFull(sample);
+    expect(result.text).toBe('Foo Bar');
+    expect(result.map).toEqual([3, 4, 5, 6, 9, 10, 11]);
+    expect(result.map.length).toBe(result.text.length);
+  });
+
+  it('matches normalizeIntakeText output for representative samples', () => {
+    const samples = [
+      'Simple text',
+      ' “Quote” — dash ',
+      'A\u00A0B\u200B C',
+      'Line1\rLine2',
+      'Zero\u200DWidth'
+    ];
+    for (const sample of samples) {
+      const result = normalizeTextFull(sample);
+      expect(result.text).toBe(normalizeIntakeText(sample));
+      expect(result.map.length).toBe(result.text.length);
+      const sorted = [...result.map].sort((a, b) => a - b);
+      expect(result.map).toEqual(sorted);
+    }
+  });
+
+  it('returns empty result for falsy input', () => {
+    expect(normalizeTextFull(null)).toEqual({ text: '', map: [] });
+    expect(normalizeTextFull(undefined)).toEqual({ text: '', map: [] });
+    expect(normalizeTextFull('')).toEqual({ text: '', map: [] });
+  });
+});

--- a/word_addin_dev/app/assets/anchors.ts
+++ b/word_addin_dev/app/assets/anchors.ts
@@ -1,9 +1,9 @@
-import { normalizeIntakeText } from "./normalize_intake.ts";
+import { normalizeIntakeText, normalizeTextFull } from "./normalize_intake.ts";
 import { safeBodySearch } from "./safeBodySearch.ts";
 
 export function normalizeSnippetForSearch(snippet: string | null | undefined): string {
   if (!snippet) return "";
-  return normalizeIntakeText(String(snippet));
+  return normalizeTextFull(String(snippet)).text;
 }
 
 export function pickLongToken(snippet: string | null | undefined): string | null {


### PR DESCRIPTION
## Summary
- add normalizeTextFull to the panel and add-in normalization utilities and reuse it for snippet search fallbacks
- compute nth-from-offsets using the cached normalizeTextFull map so anchoring aligns with server normalization
- cover the new normalization path with normalize.full.spec.ts tests that assert output text and offset map integrity

## Testing
- npm --prefix word_addin_dev test -- normalize.full.spec.ts
- npm --prefix word_addin_dev test -- app/__tests__/annotate_plan.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cfa685b81c8325b5249531b123d78c