### PR TITLE
feat: improve comment support detection fallback

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/supports.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/supports.ts
@@ -7,14 +7,36 @@ export type FeatureSupport = {
 };
 
 export function detectSupports(): FeatureSupport {
-  const req = !!(globalThis as any).Office?.context?.requirements?.isSetSupported?.('WordApi', '1.4');
-  const w: any = (globalThis as any).Word || {};
-  const rev = req && !!w?.Revision;
-  const srch = req && !!w?.SearchOptions;
-  const cc = req && !!w?.ContentControl;
-  const com = req;
-  const reason = req ? 'WordApi 1.4' : 'WordApi < 1.4';
-  return { revisions: rev, comments: com, search: srch, contentControls: cc, commentsReason: reason };
+  const g: any = globalThis as any;
+  const req = !!g.Office?.context?.requirements?.isSetSupported?.('WordApi', '1.4');
+  const w: any = g.Word || {};
+
+  const hasWordComment = !!w?.Comment;
+  const forcedComments = (() => {
+    try {
+      const raw = g.localStorage?.getItem?.('cai.force.comments');
+      if (!raw) return false;
+      const val = String(raw).trim().toLowerCase();
+      return val !== '0' && val !== 'false' && val !== 'no';
+    } catch {
+      return false;
+    }
+  })();
+
+  const comments = !!(req || forcedComments || hasWordComment);
+  const commentsReason = forcedComments
+    ? 'forced by cai.force.comments'
+    : req
+      ? 'WordApi 1.4'
+      : hasWordComment
+        ? 'Word.Comment'
+        : 'WordApi < 1.4';
+
+  const revisions = !!(req && w?.Revision);
+  const search = !!(req && w?.SearchOptions);
+  const contentControls = !!(req && w?.ContentControl);
+
+  return { revisions, comments, search, contentControls, commentsReason };
 }
 
 export const supports = {

--- a/word_addin_dev/app/assets/__tests__/supports.test.ts
+++ b/word_addin_dev/app/assets/__tests__/supports.test.ts
@@ -16,10 +16,10 @@ describe('comments support detection', () => {
     delete (globalThis as any).Office;
   });
 
-  it('requires WordApi 1.4 regardless of Word.Comment', () => {
+  it('uses Word.Comment when requirement set is unsupported', () => {
     (globalThis as any).Word = { Comment: function() {} };
     (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false } } };
-    expect(detectSupports().comments).toBe(false);
+    expect(detectSupports().comments).toBe(true);
   });
 
   it('respects localStorage override', () => {


### PR DESCRIPTION
## Summary
- allow the panel to treat Word.Comment support or a localStorage override as enabling comments
- propagate the detection update to both copies of the panel sources and align the Vitest coverage

## Testing
- `npm --prefix word_addin_dev test` *(fails: existing suite failures unrelated to change)*
- `npx vitest run app/assets/__tests__/supports.test.ts` (from word_addin_dev)


------
https://chatgpt.com/codex/tasks/task_e_68cfb1357e9083258ba312910dfe42af