### PR TITLE
Use offset anchoring before cascaded fallbacks

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/annotate.ts
@@ -25,6 +25,7 @@ export async function safeInsertComment(range: Word.Range, text: string): Promis
     return false;
   }
   const context: any = (range as any).context;
+  let lastErr: any = null;
   try {
     const anyDoc = (context?.document as any);
     if (anyDoc?.comments?.["add"]) {
@@ -286,28 +287,27 @@ export async function annotateFindingsIntoWord(findings: AnalyzeFindingEx[]): Pr
       let target: any = null;
       let anchorMethod: AnchorMethod | undefined;
 
-      if (typeof desired === "number" && Number.isFinite(desired) && desired >= 0) {
-        const normalizedCandidates = [
-          op.normalized_fallback && op.normalized_fallback !== op.raw ? op.normalized_fallback : null,
-          op.norm && op.norm !== op.raw ? op.norm : null,
-        ];
-        try {
-          target = await anchorByOffsets({
-            body,
-            snippet: op.raw,
-            start: op.start,
-            end: op.end,
-            nth: desired,
-            searchOptions,
-            normalizedCandidates,
-            token: pickLongToken(op.raw),
-            onMethod: m => {
-              anchorMethod = m;
-            }
-          }) as Word.Range | null;
-        } catch (err) {
-          console.warn("anchorByOffsets failed", err);
-        }
+      const normalizedCandidates = [
+        op.normalized_fallback && op.normalized_fallback !== op.raw ? op.normalized_fallback : null,
+        op.norm && op.norm !== op.raw ? op.norm : null,
+      ];
+
+      try {
+        target = await anchorByOffsets({
+          body,
+          snippet: op.raw,
+          start: op.start,
+          end: op.end,
+          nth: typeof desired === "number" ? desired : undefined,
+          searchOptions,
+          normalizedCandidates,
+          token: pickLongToken(op.raw),
+          onMethod: m => {
+            anchorMethod = m;
+          }
+        }) as Word.Range | null;
+      } catch (err) {
+        console.warn("anchorByOffsets failed", err);
       }
 
       if (!target) {

--- a/word_addin_dev/app/__tests__/annotate.anchor_by_offsets.spec.ts
+++ b/word_addin_dev/app/__tests__/annotate.anchor_by_offsets.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const safeBodySearchMock = vi.fn();
+
+vi.mock('../assets/safeBodySearch.ts', async () => {
+  const actual = await vi.importActual<typeof import('../assets/safeBodySearch.ts')>('../assets/safeBodySearch.ts');
+  return {
+    ...actual,
+    safeBodySearch: safeBodySearchMock
+  };
+});
+
+describe('anchorByOffsets behaviour', () => {
+  const makeBody = () => ({
+    context: {
+      sync: vi.fn(async () => {}),
+      trackedObjects: { add: vi.fn() }
+    }
+  });
+
+  beforeEach(() => {
+    safeBodySearchMock.mockReset();
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).__cfg_anchorOffsets;
+  });
+
+  it('prefers the closest range when offsets are provided', async () => {
+    const { anchorByOffsets } = await import('../assets/anchors');
+    const body = makeBody();
+    const target = { start: 42, end: 50 };
+    const far = { start: 420, end: 428 };
+
+    safeBodySearchMock.mockResolvedValueOnce({ items: [far, target] });
+
+    const onMethod = vi.fn();
+    const range = await anchorByOffsets({
+      body: body as any,
+      snippet: 'Sample text',
+      start: 42,
+      end: 50,
+      nth: 0,
+      searchOptions: { matchCase: false, matchWholeWord: false },
+      onMethod
+    });
+
+    expect(range).toBe(target);
+    expect(onMethod).toHaveBeenCalledWith('offset');
+    expect(body.context.trackedObjects.add).toHaveBeenCalledWith(target);
+    expect(safeBodySearchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to normalized search when snippet text diverges', async () => {
+    const { anchorByOffsets } = await import('../assets/anchors');
+    const body = makeBody();
+    const normalizedRange = { start: 12, end: 20 };
+
+    let callCount = 0;
+    safeBodySearchMock.mockImplementation(async (_body, needle) => {
+      callCount++;
+      if (needle === 'foo bar' && callCount > 2) {
+        return { items: [normalizedRange] };
+      }
+      return { items: [] };
+    });
+
+    const onMethod = vi.fn();
+    const range = await anchorByOffsets({
+      body: body as any,
+      snippet: 'Foo\nBar',
+      start: 10,
+      end: 18,
+      nth: 0,
+      searchOptions: { matchCase: false, matchWholeWord: false },
+      normalizedCandidates: ['foo bar'],
+      onMethod
+    });
+
+    expect(range).toBe(normalizedRange);
+    expect(onMethod).toHaveBeenLastCalledWith('normalized');
+    expect(safeBodySearchMock.mock.calls.some(call => call[1] === 'foo bar')).toBe(true);
+  });
+});

--- a/word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts
+++ b/word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts
@@ -175,4 +175,24 @@ describe('annotate flow offsets', () => {
     expect(preferredRange.load).toHaveBeenCalledWith(['start', 'end']);
     expect(anchorsMock).toHaveBeenCalledWith(expect.anything(), snippet, { nth: 2 });
   });
+
+  it('keeps findings ordered by offsets and skips overlaps while preserving offsets', async () => {
+    const baseText = 'alpha beta gamma delta epsilon zeta';
+    (globalThis as any).__lastAnalyzed = baseText;
+
+    const annotateMod = await import('../assets/annotate');
+    const { planAnnotations } = annotateMod;
+
+    const findings = [
+      { rule_id: 'r1', snippet: 'alpha', start: 0, end: 5, nth: 0 },
+      { rule_id: 'r2', snippet: 'beta', start: 4, end: 8 },
+      { rule_id: 'r3', snippet: 'delta', start: baseText.indexOf('delta'), end: baseText.indexOf('delta') + 'delta'.length }
+    ];
+
+    const plan = planAnnotations(findings as any);
+
+    expect(plan.map(p => p.rule_id)).toEqual(['r1', 'r3']);
+    expect(plan[0]).toMatchObject({ start: 0, end: 5, nth: 0 });
+    expect(plan[1]).toMatchObject({ start: findings[2].start, end: findings[2].end });
+  });
 });

--- a/word_addin_dev/app/assets/annotate.ts
+++ b/word_addin_dev/app/assets/annotate.ts
@@ -25,6 +25,7 @@ export async function safeInsertComment(range: Word.Range, text: string): Promis
     return false;
   }
   const context: any = (range as any).context;
+  let lastErr: any = null;
   try {
     const anyDoc = (context?.document as any);
     if (anyDoc?.comments?.["add"]) {
@@ -286,28 +287,27 @@ export async function annotateFindingsIntoWord(findings: AnalyzeFindingEx[]): Pr
       let target: any = null;
       let anchorMethod: AnchorMethod | undefined;
 
-      if (typeof desired === "number" && Number.isFinite(desired) && desired >= 0) {
-        const normalizedCandidates = [
-          op.normalized_fallback && op.normalized_fallback !== op.raw ? op.normalized_fallback : null,
-          op.norm && op.norm !== op.raw ? op.norm : null,
-        ];
-        try {
-          target = await anchorByOffsets({
-            body,
-            snippet: op.raw,
-            start: op.start,
-            end: op.end,
-            nth: desired,
-            searchOptions,
-            normalizedCandidates,
-            token: pickLongToken(op.raw),
-            onMethod: m => {
-              anchorMethod = m;
-            }
-          }) as Word.Range | null;
-        } catch (err) {
-          console.warn("anchorByOffsets failed", err);
-        }
+      const normalizedCandidates = [
+        op.normalized_fallback && op.normalized_fallback !== op.raw ? op.normalized_fallback : null,
+        op.norm && op.norm !== op.raw ? op.norm : null,
+      ];
+
+      try {
+        target = await anchorByOffsets({
+          body,
+          snippet: op.raw,
+          start: op.start,
+          end: op.end,
+          nth: typeof desired === "number" ? desired : undefined,
+          searchOptions,
+          normalizedCandidates,
+          token: pickLongToken(op.raw),
+          onMethod: m => {
+            anchorMethod = m;
+          }
+        }) as Word.Range | null;
+      } catch (err) {
+        console.warn("anchorByOffsets failed", err);
       }
 
       if (!target) {


### PR DESCRIPTION
## Summary
- ensure the Word annotate routine always attempts offset-based anchoring before cascading through nth, normalized, token, and content-control fallbacks while preserving comment error handling in both dev and prod bundles
- add Vitest coverage for the offset anchoring happy path, mismatch fallback, and plan ordering/overlap handling

## Testing
- npx vitest run app/__tests__/annotate.anchor_by_offsets.spec.ts app/__tests__/annotate.flow.offsets.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cfc32708308325960c35e6fc1511f1