### PR TITLE
Add TRACE artifact flag bootstrap

### DIFF
--- a/contract_review_app/trace_artifacts.py
+++ b/contract_review_app/trace_artifacts.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .types_trace import TConstraints, TDispatch, TFeatures, TProposals
+
+
+def build_features(*args: Any, **kwargs: Any) -> TFeatures:
+    return {}
+
+
+def build_dispatch(*args: Any, **kwargs: Any) -> TDispatch:
+    return {}
+
+
+def build_constraints(*args: Any, **kwargs: Any) -> TConstraints:
+    return {}
+
+
+def build_proposals(*args: Any, **kwargs: Any) -> TProposals:
+    return {}

--- a/contract_review_app/types_trace.py
+++ b/contract_review_app/types_trace.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, TypedDict
+
+
+class TFeatures(TypedDict, total=False):
+    doc: Dict[str, Any]
+    segments: List[Dict[str, Any]]
+
+
+class TRulesetStats(TypedDict, total=False):
+    loaded: int
+    evaluated: int
+    triggered: int
+
+
+class TDispatch(TypedDict, total=False):
+    ruleset: TRulesetStats
+    candidates: List[Dict[str, Any]]
+
+
+class TConstraintCheck(TypedDict, total=False):
+    id: str
+    scope: str
+    result: Literal["pass", "fail", "skip"]
+    details: Dict[str, Any]
+
+
+class TConstraints(TypedDict, total=False):
+    checks: List[TConstraintCheck]
+
+
+class TProposals(TypedDict, total=False):
+    drafts: List[Dict[str, Any]]
+    merged: List[Dict[str, Any]]
+
+
+class TTraceMeta(TypedDict, total=False):
+    risk_threshold: Literal["low", "medium", "high", "critical"]

--- a/tests/integration/test_trace_flag_bootstrap.py
+++ b/tests/integration/test_trace_flag_bootstrap.py
@@ -1,0 +1,90 @@
+import importlib
+import os
+import sys
+from typing import Tuple
+
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.models import SCHEMA_VERSION
+
+
+_TRACE_KEYS = ("features", "dispatch", "constraints", "proposals")
+
+
+def _headers() -> dict[str, str]:
+    return {"x-api-key": "dummy", "x-schema-version": SCHEMA_VERSION}
+
+
+def _build_client(flag: str) -> Tuple[TestClient, list[str]]:
+    modules = [
+        "contract_review_app.api",
+        "contract_review_app.api.app",
+    ]
+    for name in modules:
+        sys.modules.pop(name, None)
+    os.environ["LLM_PROVIDER"] = "mock"
+    os.environ["FEATURE_TRACE_ARTIFACTS"] = flag
+    from contract_review_app.api import app as app_module
+
+    importlib.reload(app_module)
+
+    def fake_analyze(text: str):
+        return {
+            "analysis": {"issues": ["dummy"]},
+            "results": {},
+            "clauses": [],
+            "document": {"text": text},
+        }
+
+    app_module._analyze_document = fake_analyze
+    client = TestClient(app_module.app)
+    return client, modules
+
+
+def _cleanup(client: TestClient, modules: list[str]) -> None:
+    try:
+        client.close()
+    finally:
+        for name in modules:
+            sys.modules.pop(name, None)
+        os.environ.pop("LLM_PROVIDER", None)
+        os.environ.pop("FEATURE_TRACE_ARTIFACTS", None)
+
+
+def test_trace_flag_disabled():
+    client, modules = _build_client("0")
+    try:
+        response = client.post(
+            "/api/analyze", headers=_headers(), json={"text": "Hi"}
+        )
+        assert response.status_code == 200
+        cid = response.headers.get("x-cid")
+        assert cid
+        trace = client.get(f"/api/trace/{cid}")
+        assert trace.status_code == 200
+        payload = trace.json()
+        for key in _TRACE_KEYS:
+            assert key not in payload
+    finally:
+        _cleanup(client, modules)
+
+
+def test_trace_flag_enabled():
+    client, modules = _build_client("1")
+    try:
+        response = client.post(
+            "/api/analyze", headers=_headers(), json={"text": "Hi"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "results" in data
+        cid = response.headers.get("x-cid")
+        assert cid
+        trace = client.get(f"/api/trace/{cid}")
+        assert trace.status_code == 200
+        payload = trace.json()
+        for key in _TRACE_KEYS:
+            assert key in payload
+            assert payload[key] == {}
+    finally:
+        _cleanup(client, modules)


### PR DESCRIPTION
## Summary
- add the FEATURE_TRACE_ARTIFACTS flag and stub builders for the new trace artifacts
- define TypedDict stubs for trace artifacts metadata
- add an integration test covering the trace artifacts bootstrap flag

## Testing
- pytest -q tests/integration/test_trace_flag_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68d001dca0748325a8ecaa3d942cd25e