### PR TITLE
Add trace features artifact snapshot

### DIFF
--- a/contract_review_app/trace_artifacts.py
+++ b/contract_review_app/trace_artifacts.py
@@ -1,12 +1,94 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterable, Mapping
+
+from contract_review_app.intake.parser import ParsedDocument
 
 from .types_trace import TConstraints, TDispatch, TFeatures, TProposals
 
+def _coerce_labels(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        raw = raw.strip()
+        return [raw] if raw else []
+    if isinstance(raw, Mapping):
+        return [str(v) for v in raw.values() if v is not None]
+    if isinstance(raw, Iterable) and not isinstance(raw, (bytes, bytearray)):
+        return [str(item) for item in raw if item is not None]
+    return [str(raw)]
 
-def build_features(*args: Any, **kwargs: Any) -> TFeatures:
-    return {}
+
+def _resolve_language(doc_norm: ParsedDocument) -> str:
+    lang = getattr(doc_norm, "language", None)
+    if isinstance(lang, str) and lang:
+        return lang
+    segments = getattr(doc_norm, "segments", None) or []
+    for seg in segments:
+        if isinstance(seg, Mapping):
+            seg_lang = seg.get("lang")
+            if isinstance(seg_lang, str) and seg_lang:
+                return seg_lang
+    return "und"
+
+
+def build_features(doc_norm: ParsedDocument, segments: Iterable[Mapping[str, Any]], hints: Any) -> TFeatures:
+    norm_text = getattr(doc_norm, "normalized_text", "") or ""
+    doc_hash = getattr(doc_norm, "checksum", None)
+    if doc_hash is None:
+        doc_hash = getattr(doc_norm, "checksum_sha256", None)
+
+    if isinstance(hints, str):
+        hints_list: list[Any] = [hints]
+    elif hints is None:
+        hints_list = []
+    else:
+        try:
+            hints_list = list(hints)
+        except TypeError:
+            hints_list = [hints]
+
+    doc_payload: dict[str, Any] = {
+        "language": _resolve_language(doc_norm),
+        "length": len(norm_text),
+        "hints": hints_list,
+    }
+    if doc_hash:
+        doc_payload["hash"] = doc_hash
+
+    segment_entries = []
+    for seg in segments or []:
+        seg_id = seg.get("id") if isinstance(seg, Mapping) else None
+        start = int(seg.get("start", 0)) if isinstance(seg, Mapping) else 0
+        end = int(seg.get("end", 0)) if isinstance(seg, Mapping) else 0
+        clause_type = None
+        labels_raw = None
+        entities = {}
+        text = ""
+        if isinstance(seg, Mapping):
+            clause_type = seg.get("clause_type")
+            labels_raw = seg.get("labels")
+            entities = seg.get("entities") or {}
+            text = seg.get("text") or ""
+
+        labels = _coerce_labels(clause_type)
+        if not labels:
+            labels = _coerce_labels(labels_raw)
+
+        segment_entries.append(
+            {
+                "id": seg_id,
+                "range": {"start": start, "end": end},
+                "labels": labels,
+                "entities": entities if isinstance(entities, Mapping) else {},
+                "tokens": {"len": len(text)},
+            }
+        )
+
+    return {
+        "doc": doc_payload,
+        "segments": segment_entries,
+    }
 
 
 def build_dispatch(*args: Any, **kwargs: Any) -> TDispatch:

--- a/tests/integration/test_trace_features.py
+++ b/tests/integration/test_trace_features.py
@@ -1,0 +1,45 @@
+from tests.integration.test_trace_flag_bootstrap import (
+    _build_client,
+    _cleanup,
+    _headers,
+)
+
+
+def test_trace_features_snapshot():
+    client, modules = _build_client("1")
+    try:
+        payload = {"text": "Section 1. Duties\nSection 2. Termination"}
+        response = client.post("/api/analyze", headers=_headers(), json=payload)
+        assert response.status_code == 200
+        cid = response.headers.get("x-cid")
+        assert cid
+
+        trace = client.get(f"/api/trace/{cid}")
+        assert trace.status_code == 200
+        body = trace.json()
+        features = body.get("features")
+        assert isinstance(features, dict)
+
+        doc = features.get("doc")
+        assert isinstance(doc, dict)
+        assert doc.get("length", 0) > 0
+        assert isinstance(doc.get("hints"), list)
+        assert doc.get("language")
+
+        segments = features.get("segments")
+        assert isinstance(segments, list)
+        assert segments  # should have entries even without rules
+        for seg in segments:
+            assert isinstance(seg, dict)
+            seg_range = seg.get("range")
+            assert isinstance(seg_range, dict)
+            start = seg_range.get("start")
+            end = seg_range.get("end")
+            assert isinstance(start, int)
+            assert isinstance(end, int)
+            assert start < end
+            tokens = seg.get("tokens", {})
+            assert isinstance(tokens, dict)
+            assert tokens.get("len") >= 0
+    finally:
+        _cleanup(client, modules)

--- a/tests/integration/test_trace_flag_bootstrap.py
+++ b/tests/integration/test_trace_flag_bootstrap.py
@@ -85,6 +85,10 @@ def test_trace_flag_enabled():
         payload = trace.json()
         for key in _TRACE_KEYS:
             assert key in payload
+        assert isinstance(payload["features"], dict)
+        assert "doc" in payload["features"]
+        assert "segments" in payload["features"]
+        for key in ("dispatch", "constraints", "proposals"):
             assert payload[key] == {}
     finally:
         _cleanup(client, modules)


### PR DESCRIPTION
## Summary
- build feature trace payloads with document metadata and segment details
- collect normalized document snapshots during analysis when trace artifacts are enabled
- exercise and validate the new feature trace structure with integration coverage

## Testing
- pytest -q tests/integration/test_trace_features.py

------
https://chatgpt.com/codex/tasks/task_e_68d005625e9c832589f5660bcad96798