### PR TITLE
Add traceable constraint checks

### DIFF
--- a/tests/integration/test_trace_constraints.py
+++ b/tests/integration/test_trace_constraints.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+
+from tests.integration.test_trace_flag_bootstrap import (
+    _build_client,
+    _cleanup,
+    _headers,
+)
+
+
+def test_trace_constraints_payload_contains_checks() -> None:
+    prev_lx_engine = os.environ.get("FEATURE_LX_ENGINE")
+    prev_l2_constraints = os.environ.get("LX_L2_CONSTRAINTS")
+    os.environ["FEATURE_LX_ENGINE"] = "1"
+    os.environ["LX_L2_CONSTRAINTS"] = "1"
+
+    client, modules = _build_client("1")
+    try:
+        payload = {"text": "Payment shall be made within thirty (30) days."}
+        response = client.post("/api/analyze", headers=_headers(), json=payload)
+        assert response.status_code == 200
+
+        cid = response.headers.get("x-cid")
+        assert cid
+
+        trace_response = client.get(f"/api/trace/{cid}")
+        assert trace_response.status_code == 200
+
+        body = trace_response.json()
+        constraints = body.get("constraints")
+        assert isinstance(constraints, dict)
+
+        checks = constraints.get("checks")
+        assert isinstance(checks, list)
+
+        for entry in checks:
+            assert isinstance(entry, dict)
+            assert entry.get("result") in {"pass", "fail", "skip"}
+    finally:
+        _cleanup(client, modules)
+        if prev_lx_engine is None:
+            os.environ.pop("FEATURE_LX_ENGINE", None)
+        else:
+            os.environ["FEATURE_LX_ENGINE"] = prev_lx_engine
+        if prev_l2_constraints is None:
+            os.environ.pop("LX_L2_CONSTRAINTS", None)
+        else:
+            os.environ["LX_L2_CONSTRAINTS"] = prev_l2_constraints

--- a/tests/integration/test_trace_flag_bootstrap.py
+++ b/tests/integration/test_trace_flag_bootstrap.py
@@ -88,7 +88,10 @@ def test_trace_flag_enabled():
         assert isinstance(payload["features"], dict)
         assert "doc" in payload["features"]
         assert "segments" in payload["features"]
-        for key in ("dispatch", "constraints", "proposals"):
+        for key in ("dispatch", "proposals"):
             assert payload[key] == {}
+        constraints = payload["constraints"]
+        assert isinstance(constraints, dict)
+        assert constraints.get("checks") == []
     finally:
         _cleanup(client, modules)

--- a/tests/lx/test_l2_ruleset_v1.py
+++ b/tests/lx/test_l2_ruleset_v1.py
@@ -232,7 +232,7 @@ CONSTRAINT_MAP = {constraint.id: constraint for constraint in load_constraints()
 def test_l2_ruleset_detects_violation(rule_id: str) -> None:
     constraint = CONSTRAINT_MAP[rule_id]
     pg = VIOLATION_FACTORIES[rule_id]()
-    findings = eval_constraints(pg, [])
+    findings, _ = eval_constraints(pg, [])
     matches = [finding for finding in findings if finding.rule_id == f"L2::{rule_id}"]
     assert matches, f"Expected finding for {rule_id}"
     finding = matches[0]
@@ -243,5 +243,5 @@ def test_l2_ruleset_detects_violation(rule_id: str) -> None:
 @pytest.mark.parametrize("rule_id", sorted(COMPLIANT_FACTORIES))
 def test_l2_ruleset_allows_compliant_case(rule_id: str) -> None:
     pg = COMPLIANT_FACTORIES[rule_id]()
-    findings = eval_constraints(pg, [])
+    findings, _ = eval_constraints(pg, [])
     assert all(finding.rule_id != f"L2::{rule_id}" for finding in findings)


### PR DESCRIPTION
## Summary
- collect structured constraint evaluation results and expose them via `ConstraintCheckResult`
- publish constraint checks into trace artifacts and keep YAML findings when L2 runs
- cover the new constraints trace payload with integration and server tests

## Testing
- pytest -q tests/integration/test_trace_constraints.py
- pytest -q tests/server/test_analyze_l2_wire.py

------
https://chatgpt.com/codex/tasks/task_e_68d00d44a30483259e07fd424ce3a7a4