### PR TITLE
Add proposal snapshots to trace output

### DIFF
--- a/tests/integration/test_trace_flag_bootstrap.py
+++ b/tests/integration/test_trace_flag_bootstrap.py
@@ -88,8 +88,12 @@ def test_trace_flag_enabled():
         assert isinstance(payload["features"], dict)
         assert "doc" in payload["features"]
         assert "segments" in payload["features"]
-        for key in ("dispatch", "proposals"):
-            assert payload[key] == {}
+        dispatch = payload["dispatch"]
+        assert isinstance(dispatch, dict)
+        proposals = payload["proposals"]
+        assert isinstance(proposals, dict)
+        assert proposals.get("drafts") == []
+        assert proposals.get("merged") == []
         constraints = payload["constraints"]
         assert isinstance(constraints, dict)
         assert constraints.get("checks") == []

--- a/tests/integration/test_trace_proposals.py
+++ b/tests/integration/test_trace_proposals.py
@@ -1,0 +1,46 @@
+from tests.integration.test_trace_flag_bootstrap import (
+    _build_client,
+    _cleanup,
+    _headers,
+)
+
+
+def test_trace_proposals_snapshots_present_and_linked_to_dispatch():
+    client, modules = _build_client("1")
+    try:
+        payload = {"text": "Payment shall be made within 30 days."}
+        response = client.post("/api/analyze", headers=_headers(), json=payload)
+        assert response.status_code == 200
+
+        cid = response.headers.get("x-cid")
+        assert cid
+
+        trace_response = client.get(f"/api/trace/{cid}")
+        assert trace_response.status_code == 200
+
+        trace_body = trace_response.json()
+        proposals = trace_body.get("proposals")
+        assert isinstance(proposals, dict)
+
+        drafts = proposals.get("drafts")
+        merged = proposals.get("merged")
+        assert isinstance(drafts, list)
+        assert isinstance(merged, list)
+
+        dispatch = trace_body.get("dispatch") or {}
+        assert isinstance(dispatch, dict)
+        candidates = dispatch.get("candidates") or []
+        candidate_rule_ids = {
+            str(candidate.get("rule_id"))
+            for candidate in candidates
+            if isinstance(candidate, dict) and candidate.get("rule_id")
+        }
+
+        for draft in drafts:
+            assert isinstance(draft, dict)
+            rule_id = draft.get("rule_id")
+            if not rule_id:
+                continue
+            assert str(rule_id) in candidate_rule_ids
+    finally:
+        _cleanup(client, modules)


### PR DESCRIPTION
## Summary
- capture pre-merge YAML findings and the merged findings in trace proposals
- implement proposal serialization helpers for drafts and merged snapshots
- exercise the proposal trace in integration tests and adjust bootstrap expectations

## Testing
- pytest -q tests/integration/test_trace_proposals.py
- pytest -q tests/integration/test_trace_flag_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68d012de2c048325bc260d17ab9265bb