### PR TITLE
Add collapsible JSON sections to trace HTML output

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -1847,7 +1847,35 @@ async def get_trace_html(cid: str):
         )
         _set_std_headers(resp, cid=cid, xcache="miss", schema=SCHEMA_VERSION)
         return resp
-    html = "<pre>" + html_escape(json.dumps(trace, indent=2)) + "</pre>"
+    body = dict(trace.get("body") or {})
+    features_json = html_escape(
+        json.dumps(body.get("features") or {}, indent=2, ensure_ascii=False)
+    )
+    dispatch_json = html_escape(
+        json.dumps(body.get("dispatch") or {}, indent=2, ensure_ascii=False)
+    )
+    constraints_json = html_escape(
+        json.dumps(body.get("constraints") or {}, indent=2, ensure_ascii=False)
+    )
+    proposals_json = html_escape(
+        json.dumps(body.get("proposals") or {}, indent=2, ensure_ascii=False)
+    )
+    raw_trace = html_escape(json.dumps(trace, indent=2, ensure_ascii=False))
+    html = (
+        "<!DOCTYPE html>"
+        "<html><head><meta charset='utf-8'><title>Trace</title>"
+        "<style>body{font-family:Arial, sans-serif;margin:20px;}"
+        "details{margin-top:16px;}"
+        "pre{background:#f5f5f5;border:1px solid #ccc;padding:12px;overflow:auto;white-space:pre-wrap;}</style>"
+        "</head><body>"
+        "<h1>Trace payload</h1>"
+        f"<pre id='raw-trace'>{raw_trace}</pre>"
+        f"<details><summary>Features</summary><pre id='features'>{features_json}</pre></details>"
+        f"<details><summary>Dispatch</summary><pre id='dispatch'>{dispatch_json}</pre></details>"
+        f"<details><summary>Constraints</summary><pre id='constraints'>{constraints_json}</pre></details>"
+        f"<details><summary>Proposals</summary><pre id='proposals'>{proposals_json}</pre></details>"
+        "</body></html>"
+    )
     resp = Response(content=html, media_type="text/html; charset=utf-8")
     _set_schema_headers(resp)
     _set_std_headers(resp, cid=cid, xcache="miss", schema=SCHEMA_VERSION)

--- a/contract_review_app/engine/report_html.py
+++ b/contract_review_app/engine/report_html.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from html import escape
+import json
 from typing import Any, Dict
 
 
@@ -26,6 +27,9 @@ def render_html_report(trace: Dict[str, Any]) -> str:
         f"<b>Created:</b> {escape(trace.get('created_at',''))} | "
         f"<b>Model:</b> {escape(str(meta.get('model','')))}</div>"
     )
+    def _pretty_json(value: Any) -> str:
+        return escape(json.dumps(value or {}, indent=2, ensure_ascii=False))
+
     html = f"""<!DOCTYPE html>
 <html><head><meta charset='utf-8'><title>Contract AI Report</title>
 <style>body{{font-family:Arial, sans-serif;margin:20px;}}
@@ -39,5 +43,9 @@ def render_html_report(trace: Dict[str, Any]) -> str:
 <h2>Findings</h2>
 <table><thead><tr><th>Severity</th><th>Rule</th><th>Excerpt</th><th>Advice</th></tr></thead>
 <tbody>{findings_html}</tbody></table>
+<details><summary>Features</summary><pre id='features'>{_pretty_json(trace.get('features'))}</pre></details>
+<details><summary>Dispatch</summary><pre id='dispatch'>{_pretty_json(trace.get('dispatch'))}</pre></details>
+<details><summary>Constraints</summary><pre id='constraints'>{_pretty_json(trace.get('constraints'))}</pre></details>
+<details><summary>Proposals</summary><pre id='proposals'>{_pretty_json(trace.get('proposals'))}</pre></details>
 </body></html>"""
     return html

--- a/tests/integration/test_trace_html_sections.py
+++ b/tests/integration/test_trace_html_sections.py
@@ -1,0 +1,26 @@
+from tests.integration.test_trace_flag_bootstrap import (
+    _build_client,
+    _cleanup,
+    _headers,
+)
+
+
+def test_trace_html_sections_present():
+    client, modules = _build_client("1")
+    try:
+        response = client.post(
+            "/api/analyze", headers=_headers(), json={"text": "Sample"}
+        )
+        assert response.status_code == 200
+        cid = response.headers.get("x-cid")
+        assert cid
+
+        trace_html = client.get(f"/api/trace/{cid}.html")
+        assert trace_html.status_code == 200
+        body = trace_html.text
+        assert ">Features<" in body
+        assert ">Dispatch<" in body
+        assert ">Constraints<" in body
+        assert ">Proposals<" in body
+    finally:
+        _cleanup(client, modules)


### PR DESCRIPTION
## Summary
- add collapsible sections to the trace HTML response with pretty-printed JSON for key payload sections
- mirror the collapsible sections in the HTML report renderer
- add an integration test to ensure the new sections render in the trace HTML endpoint

## Testing
- pytest -q tests/integration/test_trace_html_sections.py

------
https://chatgpt.com/codex/tasks/task_e_68d019bd5cec83258435b9ba15d35146