### PR TITLE
Add feature trace serialization with L0 support

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -2167,7 +2167,7 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
         TRACE.add(
             request.state.cid,
             "features",
-            build_features(parsed_doc, parsed.segments, hints),
+            build_features(parsed_doc, parsed.segments, hints, lx_features),
         )
 
     seg_findings: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- add a serializer for feature trace artifacts that normalizes IDs, spans, and optional L0 feature payloads
- wire the analyze endpoint to populate trace features via the new serializer and pass through extracted L0 features

## Testing
- `pytest tests/integration/test_trace_features.py`


------
https://chatgpt.com/codex/tasks/task_e_68d03d03c3408325830ee43d8141bc29