### PR TITLE
Add feature trace serialization

### DIFF
--- a/contract_review_app/types_trace.py
+++ b/contract_review_app/types_trace.py
@@ -1,11 +1,35 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, TypedDict
+from typing import Any, Dict, List, Literal, TypedDict, Union
+
+
+class TRange(TypedDict):
+    start: int
+    end: int
+
+
+class TFeatureTokens(TypedDict, total=False):
+    len: int
+
+
+class TFeatureSeg(TypedDict, total=False):
+    id: Union[int, str]
+    range: TRange
+    labels: List[str]
+    entities: Dict[str, Any]
+    tokens: TFeatureTokens
+
+
+class TFeatureDoc(TypedDict, total=False):
+    language: str
+    length: int
+    hash: str
+    hints: List[Any]
 
 
 class TFeatures(TypedDict, total=False):
-    doc: Dict[str, Any]
-    segments: List[Dict[str, Any]]
+    doc: TFeatureDoc
+    segments: List[TFeatureSeg]
 
 
 class TRulesetStats(TypedDict, total=False):

--- a/tests/integration/test_trace_artifacts.py
+++ b/tests/integration/test_trace_artifacts.py
@@ -1,0 +1,53 @@
+from tests.integration.test_trace_flag_bootstrap import (
+    _build_client,
+    _cleanup,
+    _headers,
+)
+
+
+def test_features_block_present():
+    client, modules = _build_client("1")
+    try:
+        payload = {"text": "Payment is due within 30 days.\nThe term lasts 12 months."}
+        response = client.post("/api/analyze", headers=_headers(), json=payload)
+        assert response.status_code == 200
+        body = response.json()
+        cid = response.headers.get("x-cid") or body.get("cid")
+        assert cid
+
+        trace_response = client.get(f"/api/trace/{cid}")
+        assert trace_response.status_code == 200
+        trace_body = trace_response.json()
+
+        features = trace_body.get("features")
+        assert isinstance(features, dict)
+
+        doc = features.get("doc")
+        assert isinstance(doc, dict)
+        assert isinstance(doc.get("language"), str) and doc.get("language")
+        assert isinstance(doc.get("length"), int) and doc.get("length") > 0
+        doc_hash = doc.get("hash")
+        assert isinstance(doc_hash, str) and len(doc_hash) == 64
+
+        segments = features.get("segments")
+        assert isinstance(segments, list)
+        assert segments
+
+        first_segment = segments[0]
+        assert isinstance(first_segment, dict)
+        assert first_segment.get("id") is not None
+
+        seg_range = first_segment.get("range")
+        assert isinstance(seg_range, dict)
+        assert isinstance(seg_range.get("start"), int)
+        assert isinstance(seg_range.get("end"), int)
+        assert seg_range["end"] >= seg_range["start"]
+
+        labels = first_segment.get("labels")
+        assert isinstance(labels, list)
+
+        tokens = first_segment.get("tokens")
+        assert isinstance(tokens, dict)
+        assert isinstance(tokens.get("len"), int)
+    finally:
+        _cleanup(client, modules)


### PR DESCRIPTION
## Summary
- define trace feature TypedDicts for documents and segments
- clamp and normalize feature serialization including token counts, hashes, and entities
- emit feature trace snapshots throughout the analyze pipeline and cover with integration test

## Testing
- pytest tests/integration/test_trace_artifacts.py::test_features_block_present

------
https://chatgpt.com/codex/tasks/task_e_68d03e8f4d34832586a3d2eb1d60ad60