### PR TITLE
Add trace size limit tests and clamp trace entity arrays

### DIFF
--- a/tests/unit/test_features_clamp.py
+++ b/tests/unit/test_features_clamp.py
@@ -1,0 +1,39 @@
+from contract_review_app.trace_artifacts import (
+    MAX_AMOUNTS_PER_SEG,
+    MAX_DURATIONS_PER_SEG,
+    MAX_ENTITY_VALUES_PER_KEY,
+    MAX_LABELS_PER_SEG,
+    build_features,
+)
+
+
+class _DocStub:
+    normalized_text = "x" * 100
+    language = "en"
+    segments = [{"lang": "en"}]
+
+
+_SEGMENT = {
+    "id": 1,
+    "start": 0,
+    "end": 10,
+    "clause_type": "type",
+    "labels": [f"label-{i}" for i in range(32)],
+    "entities": {
+        "amounts": [f"{i}" for i in range(40)],
+        "durations": [{"days": i} for i in range(40)],
+        "custom": [f"item-{i}" for i in range(50)],
+    },
+}
+
+
+def test_entities_lists_are_clamped():
+    payload = build_features(_DocStub(), [_SEGMENT])
+
+    segment = payload["segments"][0]
+    entities = segment["entities"]
+
+    assert len(segment["labels"]) == MAX_LABELS_PER_SEG
+    assert len(entities["amounts"]) == MAX_AMOUNTS_PER_SEG
+    assert len(entities["durations"]) == MAX_DURATIONS_PER_SEG
+    assert len(entities["custom"]) == MAX_ENTITY_VALUES_PER_KEY

--- a/tests/unit/test_timeout_problem_json.py
+++ b/tests/unit/test_timeout_problem_json.py
@@ -1,0 +1,35 @@
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+
+
+def test_analyze_timeout_returns_problem_json(monkeypatch):
+    client = TestClient(app)
+
+    async def _raise_timeout(awaitable, timeout=None):
+        try:
+            awaitable.close()
+        except AttributeError:
+            pass
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr("contract_review_app.api.app.asyncio.wait_for", _raise_timeout)
+
+    headers = {
+        "x-api-key": "dummy",
+        "x-schema-version": "1.4",
+    }
+
+    response = client.post("/api/analyze", json={"text": "hello"}, headers=headers)
+
+    assert response.status_code == 504
+    assert response.headers["content-type"].startswith("application/problem+json")
+    assert response.json() == {
+        "status": 504,
+        "status_text": "timeout",
+        "reason": "analyze_timeout",
+    }
+    assert response.headers.get("x-cid")
+    assert response.headers.get("X-Cid") == response.headers.get("x-cid")

--- a/tests/unit/test_trace_store_size_guard.py
+++ b/tests/unit/test_trace_store_size_guard.py
@@ -1,0 +1,20 @@
+from contract_review_app.core.trace import TraceStore
+
+
+def _payload(text: str) -> dict:
+    return {"body": {"value": text}}
+
+
+def test_trace_store_size_limit_evicts_lru():
+    store = TraceStore(maxlen=10, max_size_bytes=60)
+
+    store.put("cid-1", _payload("a" * 3))
+    store.put("cid-2", _payload("b" * 3))
+
+    assert "cid-1" in store.list()
+    assert "cid-2" in store.list()
+
+    store.put("cid-3", _payload("c" * 3))
+
+    assert store.get("cid-1") is None
+    assert store.list() == ["cid-2", "cid-3"]


### PR DESCRIPTION
## Summary
- clamp large entity lists when serializing trace features
- add regression tests for trace size guard eviction and feature list clamping
- cover analyze timeout middleware with a problem+json response test

## Testing
- pytest tests/unit/test_trace_store_size_guard.py tests/unit/test_features_clamp.py tests/unit/test_timeout_problem_json.py

------
https://chatgpt.com/codex/tasks/task_e_68d04c24f9b48325b78fb0a2811b643b