### PR TITLE
Restore panel HTML slots for add-in bundles

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/taskpane.html
+++ b/contract_review_app/contract_review_app/static/panel/taskpane.html
@@ -1,30 +1,416 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Contract AI Panel (Dev Fixture)</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Cache-Control" content="no-store, must-revalidate"/>
+  <meta http-equiv="Pragma" content="no-cache"/>
+  <meta http-equiv="Expires" content="0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contract AI - Draft Assistant</title>
+  <link rel="stylesheet" href="./app/assets/notifier.css" />
   <link rel="stylesheet" href="./app/assets/taskpane.css" />
-  <script type="module" src="taskpane.bundle.js?b=build-20250921-085759"></script>
+  <!-- hdrWarn block removed -->
+  <style>
+    :root{
+      --bg:            #0b1e2e;
+      --card:          #0f2740;
+      --muted:         #8fa7bd;
+      --text:          #e8f0fa;
+      --outline:       #93a9c4;
+      --shadow:        rgba(5, 20, 35, 0.45);
+      --btn:           #8fb1ff;
+      --btn-contrast:  #0a1a2a;
+      --btn2:          #5aa0ff;
+      --pill:          #1a3550;
+      --border:        #2a4666;
+      --input-bg:      #0a1c2c;
+    }
+    html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Segoe UI,Arial,sans-serif}
+    .wrap{padding:12px}
+    .row{margin:10px 0}
+    .card{
+      background:var(--card);
+      border-radius:8px;
+      padding:10px;
+      border:1px solid var(--border);
+      box-shadow:0 6px 18px var(--shadow);
+    }
+    .flex{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+    input,textarea,select{
+      width:100%;
+      box-sizing:border-box;
+      border:1px solid var(--border);
+      border-radius:6px;
+      background:var(--input-bg);
+      color:var(--text);
+      padding:8px;
+      box-shadow:0 6px 18px var(--shadow);
+      outline-color:var(--outline);
+    }
+    textarea{min-height:110px;resize:vertical}
+    button{
+      border:0;border-radius:6px;padding:8px 12px;cursor:pointer;
+      transition:box-shadow .2s ease;
+      box-shadow:0 4px 12px var(--shadow);
+    }
+    .btn{background:var(--btn);color:var(--btn-contrast)}
+    .btn2{background:var(--btn2);color:#fff}
+    .btn-grey{background:#304a67;color:var(--text);border:1px solid var(--border)}
+    .btn:hover,.btn:focus,.btn2:hover,.btn2:focus,.btn-grey:hover,.btn-grey:focus{
+      box-shadow:0 10px 24px var(--shadow);
+    }
+    .badge,.pill{
+      display:inline-block;padding:3px 8px;border-radius:999px;
+      background:var(--pill);color:var(--text);font-size:12px;margin-right:6px;
+      border:1px solid var(--border);
+    }
+    .muted{color:var(--muted);font-size:12px}
+    #console{
+      background:var(--input-bg);
+      border-radius:8px;padding:8px;white-space:pre-wrap;max-height:170px;overflow:auto;
+      border:1px solid var(--border);
+      box-shadow:0 6px 18px var(--shadow);
+    }
+    .topline{display:flex;justify-content:space-between;align-items:center}
+    .list{margin:0;padding-left:18px}
+    .list li{margin:4px 0}
+    .grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+    .kv{display:flex;gap:6px;align-items:center}
+    .kv span{font-size:12px}
+    pre{
+      background:var(--input-bg);
+      border:1px solid var(--border);
+      border-radius:8px;padding:8px;overflow:auto;max-height:220px;
+      box-shadow:0 6px 18px var(--shadow);
+    }
+    .pre{
+      background:var(--input-bg);
+      border:1px solid var(--border);
+      border-radius:8px;padding:8px;overflow:auto;max-height:220px;
+      box-shadow:0 6px 18px var(--shadow);
+      white-space:pre-wrap;
+    }
+    .toggle{cursor:pointer;text-decoration:underline}
+    .right{margin-left:auto}
+    .inline{display:inline-flex;gap:6px;align-items:center;flex-wrap:wrap}
+    .sep{height:1px;background:var(--border);margin:8px 0}
+    .sug-card{
+      border:1px solid var(--border);
+      border-radius:8px;padding:8px;margin:6px 0;background:var(--card);
+      box-shadow:0 6px 18px var(--shadow);
+      color:var(--text);
+    }
+    .sug-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px}
+    .sug-title{font-weight:600}
+    .sug-meta{font-size:12px;color:var(--muted)}
+    .hidden{display:none}
+    #doc-snapshot table{width:100%;border-collapse:collapse;margin-top:6px}
+    #doc-snapshot th,#doc-snapshot td{border-bottom:1px solid var(--border);padding:4px 6px;text-align:left;font-size:12px}
+    #doc-snapshot th{color:var(--muted);font-weight:600}
+    code{color:var(--outline)}
+  </style>
+
+  <style>
+    [data-busy="1"] .js-busy-indicator { display:inline-block; }
+    .js-busy-indicator { display:none; margin-left:6px; }
+    .is-busy { opacity:.6; pointer-events:none; }
+  </style>
+
+  <!-- Office.js -->
+  <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+
+  <!-- Guard to avoid double wiring; bundle will set 'ready' -->
+  <script>
+    window.__CAI_WIRED__ = false;
+    window.__DEV_DEFAULT_API_KEY__ = "{{DEFAULT_API_KEY}}";
+  </script>
+
+  <script src="./taskpane.bundle.js?b=build-20250921-085759"></script>
+
   <script nomodule>
-    document.body.innerHTML = '<div style="padding:12px;color:#f66">Your runtime is too old for ES modules. Please update your browser.</div>';
+    document.body.innerHTML =
+      '<div style=\"padding:12px;color:#f66\">This Office runtime does not support ES modules. '+
+      'Please update Office to a recent build.</div>';
   </script>
 </head>
-<body>
-  <div class="wrap">
+<body data-build="build-20250921-085759">
+<div class="wrap">
+  <div id="hdrWarn" style="display:none;color:#f66;margin-bottom:8px;">Missing headers</div>
+  <div class="topline">
+    <h3 style="margin:6px 0;">Contract AI - Draft Assistant</h3>
+    <span class="pill">Build: <span id="buildInfo">build-20250921-085759</span></span>
+    <span class="pill">Provider: <span id="providerMeta">—</span></span>
+    <span class="pill" id="status-chip">schema: — | cid: —</span>
+  </div>
+
+  <div class="row muted">Endpoints: <code>/health</code> · <code>/api/analyze</code> · <code>/api/gpt-draft</code> · <code>/api/qa-recheck</code></div>
+  <div class="row muted">Rules without matching document type are marked as <code>doc_type_mismatch</code>.</div>
+  <div class="row card">
+    <div class="row"><input id="backendUrl" placeholder="https://127.0.0.1:9443" /></div>
     <div class="row flex">
-      <button id="btnTest" class="btn-grey" type="button">Test</button>
-      <button id="btnAnalyze" class="btn" type="button">Analyze</button>
-      <span id="busyBar" class="js-busy-indicator" style="display:none"></span>
+      <button id="btnSave" class="btn-grey">Save</button>
+      <button id="btnTest" class="btn-grey">Test</button>
+      <span class="pill" id="connBadge">Conn: —</span>
+      <span class="pill" id="officeBadge">Office: —</span>
+      <span class="pill" id="anchorsBadge" style="display:none">⚠️ Anchors: partial</span>
+      <span class="pill right" id="doctorToggle">Doctor ▸</span>
     </div>
-    <div class="row">
-      <label for="selectRiskThreshold">Risk threshold</label>
-      <select id="selectRiskThreshold">
-        <option value="low">Low</option>
-        <option value="medium" selected>Medium</option>
-        <option value="high">High</option>
-        <option value="critical">Critical</option>
-      </select>
+    <div id="statusLine" class="muted">
+      <span class="inline">
+        <span>status:</span><span class="badge" id="status">—</span>
+        <span>cid:</span><span class="badge" id="cid">—</span>
+        <span>X-Cache:</span><span class="badge" id="xcache">—</span>
+        <span>latency:</span><span class="badge" id="latency">—</span>
+        <span>schema:</span><span class="badge" id="schema">—</span>
+        <span>provider:</span><span class="badge" id="provider">—</span>
+        <span>model:</span><span class="badge" id="model">—</span>
+        <span>mode:</span><span class="badge" id="mode">—</span><span id="mockModeBadge" class="badge" style="display:none;background:#facc15;color:#000;">MOCK</span>
+        <span>usage:</span><span class="badge" id="usage">—</span>
+      </span>
+    </div>
+    <div class="row" style="margin-top:6px">
+      <button id="btn-clear-storage" class="btn btn-sm">Clear storage & reload</button>
     </div>
   </div>
+  <script>
+  document.getElementById("btn-clear-storage").addEventListener("click", function(){
+    try { localStorage.clear(); } catch {}
+    try { if (window.caches) caches.keys().then(keys => keys.forEach(k => caches.delete(k))); } catch {}
+    try { CAI.Store.setBase(CAI.Store.DEFAULT_BASE); } catch {}
+    location.reload();
+  });
+  </script>
+
+  <div id="doc-snapshot" class="row card hidden">
+    <div class="grid">
+      <div class="kv"><strong>Type:</strong><span data-snap-type>—</span></div>
+      <div class="kv"><strong>Confidence:</strong><span data-snap-type-confidence>—</span></div>
+    </div>
+  </div>
+
+  <div id="doctorPanel" class="row card" style="display:none">
+    <div class="muted" style="margin-bottom:6px">Doctor</div>
+    <div class="grid">
+      <div class="kv"><strong>cid:</strong><span id="doctorCid">—</span></div>
+      <div class="kv"><strong>last latency(ms):</strong><span id="doctorLatency">—</span></div>
+    </div>
+    <div class="row">
+      <strong>Recent requests</strong>
+      <ul class="list" id="doctorReqList"></ul>
+    </div>
+    <div class="row">
+      <strong>Payload size</strong>
+      <div class="muted" id="doctorPayload">—</div>
+    </div>
+  </div>
+
+  <div id="officeTools" class="row card" style="display:block">
+    <div class="muted" style="margin-bottom:6px">Office tools</div>
+    <div class="flex">
+      <button id="btnUseWholeDoc">Use whole doc →</button>
+      <button id="btnAnalyze" disabled>Analyze</button>
+      <button id="btnFixNumbering" class="btn-grey">Fix numbering</button>
+    </div>
+  </div>
+
+  <div id="annotateQA" class="row card">
+    <div class="flex">
+      <div class="kv"><strong>Annotate & QA</strong></div>
+      <div class="kv">
+        <span class="muted">Risk threshold:</span>
+        <select id="selectRiskThreshold">
+          <option value="medium" selected>medium</option>
+          <option value="high">high</option>
+          <option value="critical">critical</option>
+        </select>
+      </div>
+    </div>
+    <div class="row flex" style="margin-top:6px">
+      <label class="inline" style="gap:4px;display:none"><input type="checkbox" id="chkUseSelection"/>Use selection</label>
+      <small class="js-busy-indicator" style="display:none">⏳</small>
+      <button id="btnAnnotate" class="btn2 js-disable-while-busy" disabled>Annotate</button>
+      <button id="btnPrevIssue" class="btn-grey js-disable-while-busy">Prev issue</button>
+      <button id="btnNextIssue" class="btn-grey js-disable-while-busy">Next issue</button>
+      <span id="findingIndex" class="pill">0/0</span>
+      <button id="btnQARecheck" class="btn-grey js-disable-while-busy">QA Recheck</button>
+      <button id="btnClearAnnots" class="btn-grey js-disable-while-busy" title="Select text in Word before applying edits.">Clear Annotations</button>
+      <span class="pill right" id="qaDeltaBadge" title="QA deltas">Δ: —</span>
+    </div>
+    <div class="row">
+      <label class="toggle">
+        <input id="cai-comment-on-analyze" type="checkbox" checked>
+        <span>Add comments on Analyze</span>
+      </label>
+      <input id="chkAddCommentsOnAnalyze" type="checkbox" style="display:none" checked>
+    </div>
+    <div class="row">
+      <label class="toggle">
+        <input id="cai-dry-run-annotate" type="checkbox">
+        <span>Dry-run annotate (no comments)</span>
+      </label>
+    </div>
+    <div id="qaResiduals" class="row" style="display:none">
+      <strong>Residual risks</strong>
+      <ul class="list" id="qaResidualList"></ul>
+    </div>
+  </div>
+
+  <!-- hidden field with original text -->
+  <textarea id="originalText" style="display:none"></textarea>
+
+  <!-- loading indicator -->
+  <div id="busyBar" style="display:none"></div>
+  <div id="loading-book" role="status" aria-live="polite" aria-atomic="true" class="cai-book hidden" data-test-id="loading-book">
+    <div class="cai-book__icon" aria-hidden="true"></div>
+    <span class="sr-only">Processing…</span>
+  </div>
+
+  <div class="row card">
+    <div class="muted" style="margin-bottom:6px">Original clause:</div>
+    <textarea id="originalClause" placeholder="Paste text or load from selection/document…"></textarea>
+    <div class="row flex" style="margin-top:8px">
+      <button id="btnSuggestEdit" class="btn btn-primary btn-sm" disabled>Get draft</button>
+    </div>
+    <div class="row">
+      <span class="badge" id="scoreBadge">score: —</span>
+      <span class="badge" id="riskBadge">risk: —</span>
+      <span class="badge" id="statusBadge">status: —</span>
+      <span class="badge" id="severityBadge">severity: —</span>
+    </div>
+  </div>
+
+  <div id="traceModal" class="card" style="display:none">
+    <div class="row flex" style="margin-bottom:6px">
+      <button id="traceTabJson" class="btn-grey">JSON</button>
+      <button id="traceTabReadable" class="btn-grey">Readable</button>
+      <button id="traceClose" class="btn-grey right">Close</button>
+    </div>
+    <pre id="traceJson" class="pre" style="max-height:260px"></pre>
+    <div id="traceReadable" class="pre" style="display:none;max-height:260px"></div>
+  </div>
+
+  <section id="doc-risk-summary" hidden>
+    <header>
+      <h3>Document Risk Summary</h3>
+      <div class="badges">
+        <span class="badge risk-high">High: <b id="rs-high">0</b></span>
+        <span class="badge risk-med">Medium: <b id="rs-med">0</b></span>
+        <span class="badge risk-low">Low: <b id="rs-low">0</b></span>
+        <span class="badge risk-total">Total: <b id="rs-total">0</b></span>
+      </div>
+    </header>
+    <div class="table-wrap">
+      <table id="rs-table">
+        <thead><tr><th>Rule</th><th>Severity</th><th>Category</th><th>Clause</th><th>Count</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="actions" style="display:none">
+      <button id="rs-copy">Copy summary</button>
+      <button id="rs-export-md">Export .md</button>
+      <button id="rs-export-json">Export .json</button>
+    </div>
+  </section>
+
+  <section class="row card" id="resultsBlock">
+    <div class="muted" style="margin-bottom:6px">Results</div>
+    <div class="grid">
+      <div class="kv"><strong>Clause type:</strong><span id="clauseTypeOut" data-role="clause-type">—</span></div>
+      <div class="kv"><strong>Findings:</strong><span id="resFindingsCount" data-role="findings-count">—</span></div>
+      <div class="kv"><strong>Visible / Hidden by filters:</strong><span id="visibleHiddenOut" data-role="findings-visible-hidden">—</span></div>
+    </div>
+
+    <!-- сам контейнер результатов для событий -->
+    <section id="results" class="card"></section>
+
+    <div class="row" id="findingsBlock">
+      <strong>Findings</strong>
+      <ol class="list" id="findingsList" data-role="findings"></ol>
+    </div>
+
+      <div class="row" id="recommendationsBlock">
+        <strong>Recommendations</strong>
+        <ol class="list" id="recommendationsList" data-role="recommendations"></ol>
+      </div>
+
+    <div class="row">
+      <span class="toggle" id="toggleRaw" data-role="toggle-raw-json">Show raw JSON</span>
+      <pre id="rawJson" data-role="raw-json" style="display:none"></pre>
+    </div>
+  </section>
+
+  <div id="cai-suggest" class="card mt-2">
+    <div class="card-header">Suggested edits</div>
+    <div class="card-body">
+      <div class="row" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
+        <div style="flex:1">
+          <label class="form-label">Clause</label>
+          <select id="cai-clause-select" class="form-select js-disable-while-busy"></select>
+        </div>
+        <div style="flex:1">
+          <label class="form-label">Mode</label>
+          <select id="cai-mode" class="form-select js-disable-while-busy">
+            <option value="friendly">friendly</option>
+            <option value="medium">medium</option>
+            <option value="strict">strict</option>
+          </select>
+        </div>
+        <div class="col-auto d-flex align-items-end">
+          <button id="btnSuggest" class="btn btn-primary js-disable-while-busy">Suggest</button>
+        </div>
+      </div>
+      <div id="cai-suggest-list">
+        <div id="suggestions"></div>
+        <template id="sugg-item">
+          <div class="sugg-item" data-id="">
+            <div class="sugg-head">
+              <span class="rule"></span>
+              <span class="sev"></span>
+              <span class="badge status"></span>
+            </div>
+            <div class="sugg-body">
+              <div class="before"></div>
+              <div class="after"></div>
+            </div>
+            <div class="sugg-actions">
+              <button class="btn-apply js-disable-while-busy">Apply (tracked)</button>
+              <button class="btn-accept js-disable-while-busy">Accept</button>
+              <button class="btn-reject js-disable-while-busy">Reject</button>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+
+  <section class="row card" id="draftPane">
+    <div class="muted" style="margin-bottom:6px">Proposed draft (from analysis or edited manually):</div>
+    <textarea
+  id="draftText"
+  name="proposed"
+  data-role="proposed-text"
+  placeholder="Proposed draft…"
+  rows="8"
+  spellcheck="false"
+></textarea>
+    <div class="row flex" style="margin-top:8px">
+      <button id="btnPreviewDiff" class="btn-grey" disabled>Preview diff</button>
+      <button id="btnApplyTracked" class="btn js-disable-while-busy" disabled title="Select text in Word before applying edits.">Apply (tracked + comment)</button>
+      <button id="btnAcceptAll" class="btn-grey js-disable-while-busy" disabled>Accept all</button>
+      <button id="btnRejectAll" class="btn-grey js-disable-while-busy" disabled>Reject all</button>
+    </div>
+    <div id="diffContainer" class="row" style="display:none;margin-top:8px">
+      <div class="muted" style="margin-bottom:4px">Diff Preview</div>
+      <div id="diffOutput" style="background:var(--input-bg);border:1px solid var(--border);border-radius:8px;padding:8px;white-space:pre-wrap"></div>
+    </div>
+    <div id="diffView" class="pre"></div>
+  </section>
+
+  <div class="row">
+    <div class="muted" style="margin-bottom:4px">Console</div>
+    <div id="console" class="console"></div>
+  </div>
+</div>
 </body>
 </html>

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -2,29 +2,415 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Contract AI Panel (Dev Fixture)</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="Cache-Control" content="no-store, must-revalidate"/>
+  <meta http-equiv="Pragma" content="no-cache"/>
+  <meta http-equiv="Expires" content="0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contract AI - Draft Assistant</title>
+  <link rel="stylesheet" href="./app/assets/notifier.css" />
   <link rel="stylesheet" href="./app/assets/taskpane.css" />
-  <script type="module" src="taskpane.bundle.js?b=build-20250921-085759"></script>
+  <!-- hdrWarn block removed -->
+  <style>
+    :root{
+      --bg:            #0b1e2e;
+      --card:          #0f2740;
+      --muted:         #8fa7bd;
+      --text:          #e8f0fa;
+      --outline:       #93a9c4;
+      --shadow:        rgba(5, 20, 35, 0.45);
+      --btn:           #8fb1ff;
+      --btn-contrast:  #0a1a2a;
+      --btn2:          #5aa0ff;
+      --pill:          #1a3550;
+      --border:        #2a4666;
+      --input-bg:      #0a1c2c;
+    }
+    html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Segoe UI,Arial,sans-serif}
+    .wrap{padding:12px}
+    .row{margin:10px 0}
+    .card{
+      background:var(--card);
+      border-radius:8px;
+      padding:10px;
+      border:1px solid var(--border);
+      box-shadow:0 6px 18px var(--shadow);
+    }
+    .flex{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+    input,textarea,select{
+      width:100%;
+      box-sizing:border-box;
+      border:1px solid var(--border);
+      border-radius:6px;
+      background:var(--input-bg);
+      color:var(--text);
+      padding:8px;
+      box-shadow:0 6px 18px var(--shadow);
+      outline-color:var(--outline);
+    }
+    textarea{min-height:110px;resize:vertical}
+    button{
+      border:0;border-radius:6px;padding:8px 12px;cursor:pointer;
+      transition:box-shadow .2s ease;
+      box-shadow:0 4px 12px var(--shadow);
+    }
+    .btn{background:var(--btn);color:var(--btn-contrast)}
+    .btn2{background:var(--btn2);color:#fff}
+    .btn-grey{background:#304a67;color:var(--text);border:1px solid var(--border)}
+    .btn:hover,.btn:focus,.btn2:hover,.btn2:focus,.btn-grey:hover,.btn-grey:focus{
+      box-shadow:0 10px 24px var(--shadow);
+    }
+    .badge,.pill{
+      display:inline-block;padding:3px 8px;border-radius:999px;
+      background:var(--pill);color:var(--text);font-size:12px;margin-right:6px;
+      border:1px solid var(--border);
+    }
+    .muted{color:var(--muted);font-size:12px}
+    #console{
+      background:var(--input-bg);
+      border-radius:8px;padding:8px;white-space:pre-wrap;max-height:170px;overflow:auto;
+      border:1px solid var(--border);
+      box-shadow:0 6px 18px var(--shadow);
+    }
+    .topline{display:flex;justify-content:space-between;align-items:center}
+    .list{margin:0;padding-left:18px}
+    .list li{margin:4px 0}
+    .grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+    .kv{display:flex;gap:6px;align-items:center}
+    .kv span{font-size:12px}
+    pre{
+      background:var(--input-bg);
+      border:1px solid var(--border);
+      border-radius:8px;padding:8px;overflow:auto;max-height:220px;
+      box-shadow:0 6px 18px var(--shadow);
+    }
+    .pre{
+      background:var(--input-bg);
+      border:1px solid var(--border);
+      border-radius:8px;padding:8px;overflow:auto;max-height:220px;
+      box-shadow:0 6px 18px var(--shadow);
+      white-space:pre-wrap;
+    }
+    .toggle{cursor:pointer;text-decoration:underline}
+    .right{margin-left:auto}
+    .inline{display:inline-flex;gap:6px;align-items:center;flex-wrap:wrap}
+    .sep{height:1px;background:var(--border);margin:8px 0}
+    .sug-card{
+      border:1px solid var(--border);
+      border-radius:8px;padding:8px;margin:6px 0;background:var(--card);
+      box-shadow:0 6px 18px var(--shadow);
+      color:var(--text);
+    }
+    .sug-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px}
+    .sug-title{font-weight:600}
+    .sug-meta{font-size:12px;color:var(--muted)}
+    .hidden{display:none}
+    #doc-snapshot table{width:100%;border-collapse:collapse;margin-top:6px}
+    #doc-snapshot th,#doc-snapshot td{border-bottom:1px solid var(--border);padding:4px 6px;text-align:left;font-size:12px}
+    #doc-snapshot th{color:var(--muted);font-weight:600}
+    code{color:var(--outline)}
+  </style>
+
+  <style>
+    [data-busy="1"] .js-busy-indicator { display:inline-block; }
+    .js-busy-indicator { display:none; margin-left:6px; }
+    .is-busy { opacity:.6; pointer-events:none; }
+  </style>
+
+  <!-- Office.js -->
+  <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+
+  <!-- Guard to avoid double wiring; bundle will set 'ready' -->
+  <script>
+    window.__CAI_WIRED__ = false;
+    window.__DEV_DEFAULT_API_KEY__ = "{{DEFAULT_API_KEY}}";
+  </script>
+
+  <script src="./taskpane.bundle.js?b=build-20250921-085759"></script>
+
   <script nomodule>
-    document.body.innerHTML = '<div style="padding:12px;color:#f66">Your runtime is too old for ES modules. Please update your browser.</div>';
+    document.body.innerHTML =
+      '<div style=\"padding:12px;color:#f66\">This Office runtime does not support ES modules. '+
+      'Please update Office to a recent build.</div>';
   </script>
 </head>
-<body>
-  <div class="wrap">
+<body data-build="build-20250921-085759">
+<div class="wrap">
+  <div id="hdrWarn" style="display:none;color:#f66;margin-bottom:8px;">Missing headers</div>
+  <div class="topline">
+    <h3 style="margin:6px 0;">Contract AI - Draft Assistant</h3>
+    <span class="pill">Build: <span id="buildInfo">build-20250921-085759</span></span>
+    <span class="pill">Provider: <span id="providerMeta">—</span></span>
+    <span class="pill" id="status-chip">schema: — | cid: —</span>
+  </div>
+
+  <div class="row muted">Endpoints: <code>/health</code> · <code>/api/analyze</code> · <code>/api/gpt-draft</code> · <code>/api/qa-recheck</code></div>
+  <div class="row muted">Rules without matching document type are marked as <code>doc_type_mismatch</code>.</div>
+  <div class="row card">
+    <div class="row"><input id="backendUrl" placeholder="https://127.0.0.1:9443" /></div>
     <div class="row flex">
-      <button id="btnTest" class="btn-grey" type="button">Test</button>
-      <button id="btnAnalyze" class="btn" type="button">Analyze</button>
-      <span id="busyBar" class="js-busy-indicator" style="display:none"></span>
+      <button id="btnSave" class="btn-grey">Save</button>
+      <button id="btnTest" class="btn-grey">Test</button>
+      <span class="pill" id="connBadge">Conn: —</span>
+      <span class="pill" id="officeBadge">Office: —</span>
+      <span class="pill" id="anchorsBadge" style="display:none">⚠️ Anchors: partial</span>
+      <span class="pill right" id="doctorToggle">Doctor ▸</span>
     </div>
-    <div class="row">
-      <label for="selectRiskThreshold">Risk threshold</label>
-      <select id="selectRiskThreshold">
-        <option value="low">Low</option>
-        <option value="medium" selected>Medium</option>
-        <option value="high">High</option>
-        <option value="critical">Critical</option>
-      </select>
+    <div id="statusLine" class="muted">
+      <span class="inline">
+        <span>status:</span><span class="badge" id="status">—</span>
+        <span>cid:</span><span class="badge" id="cid">—</span>
+        <span>X-Cache:</span><span class="badge" id="xcache">—</span>
+        <span>latency:</span><span class="badge" id="latency">—</span>
+        <span>schema:</span><span class="badge" id="schema">—</span>
+        <span>provider:</span><span class="badge" id="provider">—</span>
+        <span>model:</span><span class="badge" id="model">—</span>
+        <span>mode:</span><span class="badge" id="mode">—</span><span id="mockModeBadge" class="badge" style="display:none;background:#facc15;color:#000;">MOCK</span>
+        <span>usage:</span><span class="badge" id="usage">—</span>
+      </span>
+    </div>
+    <div class="row" style="margin-top:6px">
+      <button id="btn-clear-storage" class="btn btn-sm">Clear storage & reload</button>
     </div>
   </div>
+  <script>
+  document.getElementById("btn-clear-storage").addEventListener("click", function(){
+    try { localStorage.clear(); } catch {}
+    try { if (window.caches) caches.keys().then(keys => keys.forEach(k => caches.delete(k))); } catch {}
+    try { CAI.Store.setBase(CAI.Store.DEFAULT_BASE); } catch {}
+    location.reload();
+  });
+  </script>
+
+  <div id="doc-snapshot" class="row card hidden">
+    <div class="grid">
+      <div class="kv"><strong>Type:</strong><span data-snap-type>—</span></div>
+      <div class="kv"><strong>Confidence:</strong><span data-snap-type-confidence>—</span></div>
+    </div>
+  </div>
+
+  <div id="doctorPanel" class="row card" style="display:none">
+    <div class="muted" style="margin-bottom:6px">Doctor</div>
+    <div class="grid">
+      <div class="kv"><strong>cid:</strong><span id="doctorCid">—</span></div>
+      <div class="kv"><strong>last latency(ms):</strong><span id="doctorLatency">—</span></div>
+    </div>
+    <div class="row">
+      <strong>Recent requests</strong>
+      <ul class="list" id="doctorReqList"></ul>
+    </div>
+    <div class="row">
+      <strong>Payload size</strong>
+      <div class="muted" id="doctorPayload">—</div>
+    </div>
+  </div>
+
+  <div id="officeTools" class="row card" style="display:block">
+    <div class="muted" style="margin-bottom:6px">Office tools</div>
+    <div class="flex">
+      <button id="btnUseWholeDoc">Use whole doc →</button>
+      <button id="btnAnalyze" disabled>Analyze</button>
+      <button id="btnFixNumbering" class="btn-grey">Fix numbering</button>
+    </div>
+  </div>
+
+  <div id="annotateQA" class="row card">
+    <div class="flex">
+      <div class="kv"><strong>Annotate & QA</strong></div>
+      <div class="kv">
+        <span class="muted">Risk threshold:</span>
+        <select id="selectRiskThreshold">
+          <option value="medium" selected>medium</option>
+          <option value="high">high</option>
+          <option value="critical">critical</option>
+        </select>
+      </div>
+    </div>
+    <div class="row flex" style="margin-top:6px">
+      <label class="inline" style="gap:4px;display:none"><input type="checkbox" id="chkUseSelection"/>Use selection</label>
+      <small class="js-busy-indicator" style="display:none">⏳</small>
+      <button id="btnAnnotate" class="btn2 js-disable-while-busy" disabled>Annotate</button>
+      <button id="btnPrevIssue" class="btn-grey js-disable-while-busy">Prev issue</button>
+      <button id="btnNextIssue" class="btn-grey js-disable-while-busy">Next issue</button>
+      <span id="findingIndex" class="pill">0/0</span>
+      <button id="btnQARecheck" class="btn-grey js-disable-while-busy">QA Recheck</button>
+      <button id="btnClearAnnots" class="btn-grey js-disable-while-busy" title="Select text in Word before applying edits.">Clear Annotations</button>
+      <span class="pill right" id="qaDeltaBadge" title="QA deltas">Δ: —</span>
+    </div>
+    <div class="row">
+      <label class="toggle">
+        <input id="cai-comment-on-analyze" type="checkbox" checked>
+        <span>Add comments on Analyze</span>
+      </label>
+      <input id="chkAddCommentsOnAnalyze" type="checkbox" style="display:none" checked>
+    </div>
+    <div class="row">
+      <label class="toggle">
+        <input id="cai-dry-run-annotate" type="checkbox">
+        <span>Dry-run annotate (no comments)</span>
+      </label>
+    </div>
+    <div id="qaResiduals" class="row" style="display:none">
+      <strong>Residual risks</strong>
+      <ul class="list" id="qaResidualList"></ul>
+    </div>
+  </div>
+
+  <!-- hidden field with original text -->
+  <textarea id="originalText" style="display:none"></textarea>
+
+  <!-- loading indicator -->
+  <div id="busyBar" style="display:none"></div>
+  <div id="loading-book" role="status" aria-live="polite" aria-atomic="true" class="cai-book hidden" data-test-id="loading-book">
+    <div class="cai-book__icon" aria-hidden="true"></div>
+    <span class="sr-only">Processing…</span>
+  </div>
+
+  <div class="row card">
+    <div class="muted" style="margin-bottom:6px">Original clause:</div>
+    <textarea id="originalClause" placeholder="Paste text or load from selection/document…"></textarea>
+    <div class="row flex" style="margin-top:8px">
+      <button id="btnSuggestEdit" class="btn btn-primary btn-sm" disabled>Get draft</button>
+    </div>
+    <div class="row">
+      <span class="badge" id="scoreBadge">score: —</span>
+      <span class="badge" id="riskBadge">risk: —</span>
+      <span class="badge" id="statusBadge">status: —</span>
+      <span class="badge" id="severityBadge">severity: —</span>
+    </div>
+  </div>
+
+  <div id="traceModal" class="card" style="display:none">
+    <div class="row flex" style="margin-bottom:6px">
+      <button id="traceTabJson" class="btn-grey">JSON</button>
+      <button id="traceTabReadable" class="btn-grey">Readable</button>
+      <button id="traceClose" class="btn-grey right">Close</button>
+    </div>
+    <pre id="traceJson" class="pre" style="max-height:260px"></pre>
+    <div id="traceReadable" class="pre" style="display:none;max-height:260px"></div>
+  </div>
+
+  <section id="doc-risk-summary" hidden>
+    <header>
+      <h3>Document Risk Summary</h3>
+      <div class="badges">
+        <span class="badge risk-high">High: <b id="rs-high">0</b></span>
+        <span class="badge risk-med">Medium: <b id="rs-med">0</b></span>
+        <span class="badge risk-low">Low: <b id="rs-low">0</b></span>
+        <span class="badge risk-total">Total: <b id="rs-total">0</b></span>
+      </div>
+    </header>
+    <div class="table-wrap">
+      <table id="rs-table">
+        <thead><tr><th>Rule</th><th>Severity</th><th>Category</th><th>Clause</th><th>Count</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="actions" style="display:none">
+      <button id="rs-copy">Copy summary</button>
+      <button id="rs-export-md">Export .md</button>
+      <button id="rs-export-json">Export .json</button>
+    </div>
+  </section>
+
+  <section class="row card" id="resultsBlock">
+    <div class="muted" style="margin-bottom:6px">Results</div>
+    <div class="grid">
+      <div class="kv"><strong>Clause type:</strong><span id="clauseTypeOut" data-role="clause-type">—</span></div>
+      <div class="kv"><strong>Findings:</strong><span id="resFindingsCount" data-role="findings-count">—</span></div>
+      <div class="kv"><strong>Visible / Hidden by filters:</strong><span id="visibleHiddenOut" data-role="findings-visible-hidden">—</span></div>
+    </div>
+
+    <!-- сам контейнер результатов для событий -->
+    <section id="results" class="card"></section>
+
+    <div class="row" id="findingsBlock">
+      <strong>Findings</strong>
+      <ol class="list" id="findingsList" data-role="findings"></ol>
+    </div>
+
+      <div class="row" id="recommendationsBlock">
+        <strong>Recommendations</strong>
+        <ol class="list" id="recommendationsList" data-role="recommendations"></ol>
+      </div>
+
+    <div class="row">
+      <span class="toggle" id="toggleRaw" data-role="toggle-raw-json">Show raw JSON</span>
+      <pre id="rawJson" data-role="raw-json" style="display:none"></pre>
+    </div>
+  </section>
+
+  <div id="cai-suggest" class="card mt-2">
+    <div class="card-header">Suggested edits</div>
+    <div class="card-body">
+      <div class="row" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
+        <div style="flex:1">
+          <label class="form-label">Clause</label>
+          <select id="cai-clause-select" class="form-select js-disable-while-busy"></select>
+        </div>
+        <div style="flex:1">
+          <label class="form-label">Mode</label>
+          <select id="cai-mode" class="form-select js-disable-while-busy">
+            <option value="friendly">friendly</option>
+            <option value="medium">medium</option>
+            <option value="strict">strict</option>
+          </select>
+        </div>
+        <div class="col-auto d-flex align-items-end">
+          <button id="btnSuggest" class="btn btn-primary js-disable-while-busy">Suggest</button>
+        </div>
+      </div>
+      <div id="cai-suggest-list">
+        <div id="suggestions"></div>
+        <template id="sugg-item">
+          <div class="sugg-item" data-id="">
+            <div class="sugg-head">
+              <span class="rule"></span>
+              <span class="sev"></span>
+              <span class="badge status"></span>
+            </div>
+            <div class="sugg-body">
+              <div class="before"></div>
+              <div class="after"></div>
+            </div>
+            <div class="sugg-actions">
+              <button class="btn-apply js-disable-while-busy">Apply (tracked)</button>
+              <button class="btn-accept js-disable-while-busy">Accept</button>
+              <button class="btn-reject js-disable-while-busy">Reject</button>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+
+  <section class="row card" id="draftPane">
+    <div class="muted" style="margin-bottom:6px">Proposed draft (from analysis or edited manually):</div>
+    <textarea
+  id="draftText"
+  name="proposed"
+  data-role="proposed-text"
+  placeholder="Proposed draft…"
+  rows="8"
+  spellcheck="false"
+></textarea>
+    <div class="row flex" style="margin-top:8px">
+      <button id="btnPreviewDiff" class="btn-grey" disabled>Preview diff</button>
+      <button id="btnApplyTracked" class="btn js-disable-while-busy" disabled title="Select text in Word before applying edits.">Apply (tracked + comment)</button>
+      <button id="btnAcceptAll" class="btn-grey js-disable-while-busy" disabled>Accept all</button>
+      <button id="btnRejectAll" class="btn-grey js-disable-while-busy" disabled>Reject all</button>
+    </div>
+    <div id="diffContainer" class="row" style="display:none;margin-top:8px">
+      <div class="muted" style="margin-bottom:4px">Diff Preview</div>
+      <div id="diffOutput" style="background:var(--input-bg);border:1px solid var(--border);border-radius:8px;padding:8px;white-space:pre-wrap"></div>
+    </div>
+    <div id="diffView" class="pre"></div>
+  </section>
+
+  <div class="row">
+    <div class="muted" style="margin-bottom:4px">Console</div>
+    <div id="console" class="console"></div>
+  </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore the static panel HTML to expose the findings, recommendations, and draft action slots expected by the bundle scripts
- sync the word_addin_dev taskpane fixture with the restored markup so the dev/test harness has the same DOM contract

## Testing
- pytest tests/panel/test_slots_exist.py

------
https://chatgpt.com/codex/tasks/task_e_68d054c03d508325a127f3603df6b83a