### PR TITLE
Sanitize trace dispatch payloads

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -2507,14 +2507,25 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
                         if not isinstance(span, Mapping):
                             continue
                         match_payload: Dict[str, Any] = {}
+                        span_payload: Dict[str, int] = {}
                         start_val = span.get("start")
                         end_val = span.get("end")
                         if isinstance(start_val, (int, float)):
-                            match_payload["start"] = seg_start + int(start_val)
+                            span_payload["start"] = seg_start + int(start_val)
                         if isinstance(end_val, (int, float)):
-                            match_payload["end"] = seg_start + int(end_val)
+                            span_payload["end"] = seg_start + int(end_val)
+                        if span_payload:
+                            match_payload["span"] = span_payload
+
+                        text_value: Optional[str] = None
                         if idx < len(evidence) and evidence[idx] is not None:
-                            match_payload["text"] = str(evidence[idx])
+                            text_value = str(evidence[idx])
+
+                        if text_value:
+                            digest = hashlib.sha256(text_value.encode("utf-8")).hexdigest()
+                            match_payload["hash8"] = digest[:8]
+                            match_payload["len"] = len(text_value)
+
                         if match_payload:
                             matches.append(match_payload)
 

--- a/tests/integration/test_trace_dispatch.py
+++ b/tests/integration/test_trace_dispatch.py
@@ -64,5 +64,15 @@ def test_trace_dispatch_rules_match_findings():
         for candidate in gated_matches:
             rule_id = str(candidate.get("rule_id"))
             assert rule_id in finding_ids or rule_id in failed_constraint_rules
+            triggers = candidate.get("triggers") or {}
+            matched = triggers.get("matched") or []
+            for match in matched:
+                assert isinstance(match, dict)
+                lowered = {str(k).lower() for k in match.keys()}
+                assert "text" not in lowered
+                span = match.get("span") if isinstance(match.get("span"), dict) else {}
+                has_span = bool(span)
+                has_hash = "hash8" in match and "len" in match
+                assert has_span or has_hash, "expected span or hash/len metadata"
     finally:
         _cleanup(client, modules)

--- a/tests/integration/test_trace_no_raw_text.py
+++ b/tests/integration/test_trace_no_raw_text.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import pytest
+
+from tests.integration.test_trace_flag_bootstrap import (
+    _build_client,
+    _cleanup,
+    _headers,
+)
+
+FORBIDDEN_KEYS = {"text", "before", "after", "context", "raw"}
+
+
+def _walk_forbidden(
+    value: Any,
+    path: Tuple[str, ...],
+    errors: list[str],
+    allow_snippet: bool,
+) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            lower = str(key).lower()
+            current_path = path + (str(key),)
+            if lower in FORBIDDEN_KEYS:
+                errors.append("/".join(current_path))
+                continue
+            if lower == "snippet":
+                if not allow_snippet:
+                    errors.append("/".join(current_path))
+                    continue
+                if not isinstance(item, str):
+                    errors.append("/".join(current_path))
+                    continue
+                if len(item) > 200:
+                    errors.append("/".join(current_path))
+                    continue
+                continue
+            _walk_forbidden(item, current_path, errors, allow_snippet)
+    elif isinstance(value, (list, tuple, set)):
+        for idx, item in enumerate(value):
+            _walk_forbidden(item, path + (str(idx),), errors, allow_snippet)
+
+
+def _assert_section_clean(section: Any, allow_snippet: bool = False) -> None:
+    if section is None:
+        return
+    errors: list[str] = []
+    _walk_forbidden(section, tuple(), errors, allow_snippet)
+    if errors:
+        pytest.fail(
+            "forbidden raw-text keys found: " + ", ".join(sorted(errors))
+        )
+
+
+def test_trace_no_raw_text_leaks():
+    client, modules = _build_client("trace-no-raw")
+    try:
+        payload = {"text": "This agreement shall terminate if payment is not made."}
+        response = client.post("/api/analyze", headers=_headers(), json=payload)
+        assert response.status_code == 200
+
+        cid = response.headers.get("x-cid")
+        assert cid
+        trace_response = client.get(f"/api/trace/{cid}")
+        assert trace_response.status_code == 200
+        trace_body = trace_response.json()
+
+        _assert_section_clean(trace_body.get("features"))
+        _assert_section_clean(trace_body.get("dispatch"))
+        _assert_section_clean(trace_body.get("constraints"))
+        _assert_section_clean(trace_body.get("proposals"), allow_snippet=True)
+    finally:
+        _cleanup(client, modules)


### PR DESCRIPTION
## Summary
- sanitize dispatch trigger matches to drop raw text and include only allow-listed metadata
- ensure the analyze API forwards sanitized trigger match structures with span offsets and hashed text details
- add regression coverage verifying trace payloads omit raw document excerpts

## Testing
- pytest tests/integration/test_trace_dispatch.py tests/integration/test_trace_no_raw_text.py

------
https://chatgpt.com/codex/tasks/task_e_68d06101cbd88325adfa8e031b186020