### PR TITLE
Reload rule loader before building client in trace perf guard test

### DIFF
--- a/tests/integration/test_trace_perf_guard.py
+++ b/tests/integration/test_trace_perf_guard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Final
@@ -75,6 +76,7 @@ def test_trace_perf_guard() -> None:
     client = None
     modules: list[str] = []
     try:
+        sys.modules.pop("contract_review_app.legal_rules.loader", None)
         client, modules = _build_client("1")
         payload = {"text": _make_long_document()}
         analyze_response = client.post(


### PR DESCRIPTION
## Summary
- add an explicit import cleanup of `contract_review_app.legal_rules.loader` so the RULE_PACKS_DIRS override takes effect

## Testing
- pytest tests/integration/test_trace_perf_guard.py -s

------
https://chatgpt.com/codex/tasks/task_e_68d06a32e180832592bfdcbe62e833fb