### PR TITLE
Add structured dispatch reasons with trace limits

### DIFF
--- a/contract_review_app/types_trace.py
+++ b/contract_review_app/types_trace.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, TypedDict, Union
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 
 
 class TRange(TypedDict):
@@ -38,9 +38,29 @@ class TRulesetStats(TypedDict, total=False):
     triggered: int
 
 
+class TDispatchReasonPattern(TypedDict, total=False):
+    kind: Literal["regex", "keyword"]
+    offsets: List[List[int]]
+
+
+class TDispatchReason(TypedDict, total=False):
+    labels: List[str]
+    patterns: List[TDispatchReasonPattern]
+    gates: Dict[str, bool]
+
+
+class TDispatchCandidate(TypedDict, total=False):
+    rule_id: str
+    gates: Dict[str, Any]
+    gates_passed: bool
+    triggers: Dict[str, Any]
+    reason_not_triggered: Optional[str]
+    reasons: List[TDispatchReason]
+
+
 class TDispatch(TypedDict, total=False):
     ruleset: TRulesetStats
-    candidates: List[Dict[str, Any]]
+    candidates: List[TDispatchCandidate]
 
 
 class TConstraintCheck(TypedDict, total=False):

--- a/tests/integration/test_trace_dispatch_structured.py
+++ b/tests/integration/test_trace_dispatch_structured.py
@@ -1,0 +1,71 @@
+import importlib
+
+from contract_review_app.legal_rules.dispatcher import ReasonPattern, ReasonPayload
+
+
+class _DummyCandidate:
+    def __init__(self, idx: int, reasons: tuple[ReasonPayload, ...]):
+        self.rule_id = f"rule-{idx}"
+        self.gates = {"packs": True, "lang": True, "doctypes": True}
+        self.gates_passed = True
+        self.expected_any = [f"trigger-{idx}"]
+        self.matched = [
+            {
+                "start": idx,
+                "end": idx + 1,
+                "pattern_id": f"pat-{idx}",
+            }
+        ]
+        self.reasons = reasons
+        self.reason = None
+
+
+def _make_reason(rule_idx: int, reason_idx: int) -> ReasonPayload:
+    return ReasonPayload(
+        labels=(f"label-{rule_idx}-{reason_idx}",),
+        patterns=(
+            ReasonPattern(
+                kind="keyword",
+                offsets=((reason_idx, reason_idx + rule_idx + 1),),
+            ),
+        ),
+        gates=(("packs", reason_idx % 2 == 0), ("lang", True)),
+    )
+
+
+def test_dispatch_trace_limits_and_reason_shape(monkeypatch):
+    monkeypatch.setenv("DISPATCH_MAX_CANDIDATES_PER_SEGMENT", "3")
+    monkeypatch.setenv("DISPATCH_MAX_REASONS_PER_RULE", "2")
+
+    from contract_review_app import trace_artifacts as trace_mod
+
+    importlib.reload(trace_mod)
+
+    try:
+        candidates = []
+        for idx in range(6):
+            reasons = tuple(_make_reason(idx, r) for r in range(5))
+            candidates.append(_DummyCandidate(idx, reasons))
+
+        dispatch = trace_mod.build_dispatch(10, 9, 4, candidates)
+
+        candidates_payload = dispatch.get("candidates") or []
+        assert len(candidates_payload) == 3
+
+        for entry in candidates_payload:
+            reasons_payload = entry.get("reasons") or []
+            assert len(reasons_payload) <= 2
+            for reason in reasons_payload:
+                assert "labels" in reason
+                assert "patterns" in reason
+                assert "gates" in reason
+                assert isinstance(reason["labels"], list)
+                assert isinstance(reason["patterns"], list)
+                assert isinstance(reason["gates"], dict)
+                for pattern in reason["patterns"]:
+                    assert pattern.get("kind") in {"regex", "keyword"}
+                    assert isinstance(pattern.get("offsets"), list)
+    finally:
+        monkeypatch.delenv("DISPATCH_MAX_CANDIDATES_PER_SEGMENT", raising=False)
+        monkeypatch.delenv("DISPATCH_MAX_REASONS_PER_RULE", raising=False)
+        importlib.reload(trace_mod)


### PR DESCRIPTION
## Summary
- replace dispatcher reason strings with structured payloads that capture labels, pattern metadata, and gating details
- serialize structured reasons into dispatch trace output while honoring per-segment candidate and per-rule reason limits
- update trace typing and add an integration test that exercises the new structured dispatch trace snapshot

## Testing
- DISPATCH_MAX_CANDIDATES_PER_SEGMENT=50 DISPATCH_MAX_REASONS_PER_RULE=12 pytest -q tests/integration/test_trace_dispatch_structured.py

------
https://chatgpt.com/codex/tasks/task_e_68d11f2eacd483258fd31798164fc399