### PR TITLE
Add per-entry trace size guard and tests

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -143,9 +143,10 @@ log.info("[PANEL] build token: %s", PANEL_BUILD_TOKEN)
 
 TRACE_MAX = int(os.getenv("TRACE_MAX", "200"))
 TRACE_MAX_SIZE_BYTES = int(os.getenv("TRACE_MAX_SIZE_BYTES", "0"))
+TRACE_PER_ENTRY_MAX_BYTES = int(os.getenv("TRACE_PER_ENTRY_MAX_BYTES", "0"))
 
 
-TRACE = TraceStore(TRACE_MAX, TRACE_MAX_SIZE_BYTES)
+TRACE = TraceStore(TRACE_MAX, TRACE_MAX_SIZE_BYTES, TRACE_PER_ENTRY_MAX_BYTES)
 
 # flag indicating whether rule engine is usable
 _RULE_ENGINE_OK = True


### PR DESCRIPTION
## Summary
- add optional per-entry size guard to `TraceStore` that trims large dispatch candidates and feature segments when a limit is enforced
- wire new TRACE_PER_ENTRY_MAX_BYTES env variable into API initialization
- extend integration tests to cover per-entry trimming and ensure fetch performance remains stable

## Testing
- `TRACE_PER_ENTRY_MAX_BYTES=262144 pytest -q tests/integration/test_trace_perf_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_68d124e5c9b083258fe3d1459d08c772