### PR TITLE
Add corpus label snapshot test

### DIFF
--- a/tests/fixtures/corpus/ast_employment.txt
+++ b/tests/fixtures/corpus/ast_employment.txt
@@ -1,0 +1,2 @@
+The Parties acknowledge that TUPE may apply to this transfer of undertakings and agree to consult affected staff. The Supplier shall ensure appropriate vetting including DBS background checks for all transferring employees.
+The Supplier will comply with all health and safety obligations at the facilities.

--- a/tests/fixtures/corpus/idta_transfers.txt
+++ b/tests/fixtures/corpus/idta_transfers.txt
@@ -1,0 +1,2 @@
+The Parties acknowledge that the arrangement involves an international transfer of personal data under the IDTA. The Processor shall implement appropriate technical and organisational security measures documented in Annex 2.
+In the event of a personal data breach the Processor must notify the Controller within 72 hours.

--- a/tests/fixtures/corpus/joa_governance.txt
+++ b/tests/fixtures/corpus/joa_governance.txt
@@ -1,0 +1,2 @@
+The Operator shall convene the Operating Committee (OpCom) each quarter to approve the Work Programme and Budget. Any Authorisation for Expenditure (AFE) must be circulated to all Parties five Business Days in advance.
+Failure by a Participant to fund its share constitutes a default and the non-consenting party will forfeit its voting rights.

--- a/tests/fixtures/corpus/msc_service_levels.txt
+++ b/tests/fixtures/corpus/msc_service_levels.txt
@@ -1,0 +1,2 @@
+The Service Levels are set out in Schedule 4 and monitored through KPIs agreed by the parties. If the Supplier fails to achieve the service levels, service credits will be calculated in accordance with the credit calculation table.
+The Supplier shall provide maintenance and support updates during the term to maintain performance.

--- a/tests/fixtures/corpus/nhs_liability.txt
+++ b/tests/fixtures/corpus/nhs_liability.txt
@@ -1,0 +1,2 @@
+The Supplier's aggregate liability cap shall be £1,000,000 per Contract Year. This liability cap excludes cap for death or personal injury, fraud or wilful misconduct.
+The Supplier shall indemnify the Authority against third-party claims arising from negligent acts.

--- a/tests/fixtures/corpus/po_payment.txt
+++ b/tests/fixtures/corpus/po_payment.txt
@@ -1,0 +1,2 @@
+Invoices shall be issued monthly and the Authority shall pay valid invoices within thirty (30) days of receipt. Amounts due within this payment terms clause accrue interest on late payment at a rate of base rate + 4%.
+No payment shall be withheld by way of set-off.

--- a/tests/unit/test_labels_corpus_snapshot.py
+++ b/tests/unit/test_labels_corpus_snapshot.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from contract_review_app.analysis import resolve_labels
+
+
+CORPUS_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "corpus"
+
+CORPUS_SNAPSHOT: dict[str, dict[str, object]] = {
+    "nhs_liability.txt": {
+        "heading": "Limitation of Liability",
+        "expected": {
+            "liability_cap_amount",
+            "liability_carveouts",
+            "indemnity_general",
+            "limitation_of_liability",
+        },
+    },
+    "msc_service_levels.txt": {
+        "heading": "Service Levels",
+        "expected": {
+            "parties",
+            "service_levels_sla",
+            "service_credits",
+            "support_maintenance",
+            "term",
+            "warranty_doas_rma",
+        },
+    },
+    "idta_transfers.txt": {
+        "heading": "International Data Transfers",
+        "expected": {
+            "dp_breach_notification",
+            "dp_international_transfers",
+            "dp_roles",
+            "dp_security_measures",
+            "hazardous_substances",
+            "parties",
+        },
+    },
+    "ast_employment.txt": {
+        "heading": "Employment Matters",
+        "expected": {
+            "joa_authorisation_for_expenditure",
+            "health_and_safety",
+            "parties",
+            "staff_vetting",
+            "tupe",
+        },
+    },
+    "joa_governance.txt": {
+        "heading": "Joint Operating Committee",
+        "expected": {
+            "construction_programme",
+            "dp_lawful_basis",
+            "joa_authorisation_for_expenditure",
+            "joa_default_nonconsent",
+            "joa_opcom",
+            "joa_operator",
+            "joa_work_program_budget",
+            "parties",
+        },
+    },
+    "po_payment.txt": {
+        "heading": "Payment Terms",
+        "expected": {
+            "late_payment_interest",
+            "payment_terms",
+            "set_off",
+            "term",
+        },
+    },
+}
+
+
+@pytest.mark.parametrize("filename", sorted(CORPUS_SNAPSHOT))
+def test_labels_corpus_snapshot(filename: str) -> None:
+    config = CORPUS_SNAPSHOT[filename]
+    heading = config["heading"]
+    expected = set(config["expected"])
+
+    text = (CORPUS_ROOT / filename).read_text(encoding="utf-8")
+    resolved = resolve_labels(text, heading)
+
+    assert resolved == expected


### PR DESCRIPTION
## Summary
- add anonymised corpus snippets covering NHS, MSC, IDTA, AST, JOA and PO document types
- snapshot expected labels resolved from each fragment to guard taxonomy regressions

## Testing
- pytest -q tests/unit/test_labels_corpus_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d1250138ac83258f23b6c5d6f02ea3