### PR TITLE
Add contract test verifying analyze response keys

### DIFF
--- a/tests/integration/test_api_contract_no_new_keys.py
+++ b/tests/integration/test_api_contract_no_new_keys.py
@@ -16,8 +16,21 @@ def test_api_contract_no_new_keys():
         response = client.post("/api/analyze", headers=_headers(), json={"text": "Hello"})
         assert response.status_code == 200
         payload = response.json()
-        for key in {"features", "dispatch", "constraints", "proposals"}:
-            assert key not in payload
+        expected_keys = {
+            "analysis",
+            "cid",
+            "clauses",
+            "document",
+            "findings",
+            "meta",
+            "recommendations",
+            "results",
+            "rules_coverage",
+            "schema_version",
+            "status",
+            "summary",
+        }
+        assert set(payload) == expected_keys
     finally:
         _cleanup(client, modules)
         if previous_flag is None:


### PR DESCRIPTION
## Summary
- update the /api/analyze contract test to freeze the set of root response keys
- ensure the endpoint response contains exactly the expected keys

## Testing
- pytest -q tests/integration/test_api_contract_no_new_keys.py

------
https://chatgpt.com/codex/tasks/task_e_68d1271bcf4c8325ae6a5f75f7b857db