### PR TITLE
Add extractor unit tests and logging fallback

### DIFF
--- a/contract_review_app/utils/logging.py
+++ b/contract_review_app/utils/logging.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 
 import os
 import sys
-from loguru import logger
+
+try:
+    from loguru import logger  # type: ignore
+except Exception:  # loguru отсутствует — уходим в stdlib
+    import logging as _pylog
+
+    logger = _pylog.getLogger("contract_ai")
+    if not logger.handlers:
+        _h = _pylog.StreamHandler()
+        _pylog.basicConfig(level=_pylog.INFO)
+        logger.addHandler(_h)
 
 
 def init_logging() -> logger.__class__:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,5 +18,5 @@ build>=1.2.1
 fpdf2>=2.7
 openapi-spec-validator>=0.7
 pytest-watch>=4.2.0
-loguru>=0.7,<1.0
+loguru==0.7.2
 sentry-sdk>=1.39,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pyyaml
 pytest-cov
 requests
 SQLAlchemy>=2.0,<3.0
-loguru>=0.7,<1.0
+loguru==0.7.2
 sentry-sdk>=1.39,<2
 fastapi==0.115.*
 uvicorn[standard]==0.30.*

--- a/tests/unit/test_extractors.py
+++ b/tests/unit/test_extractors.py
@@ -1,0 +1,49 @@
+import re
+
+from contract_review_app.analysis import extractors as ex
+
+
+def test_extract_amounts_basic():
+    txt = "The Contract Price is £10,000 and an additional USD 2,500 may apply."
+    amounts = ex.extract_amounts(txt)
+    joined = " ".join(
+        " ".join(
+            str(part)
+            for part in (
+                (entry.get("value") or {}).get("currency"),
+                (entry.get("value") or {}).get("amount"),
+            )
+            if part not in (None, "")
+        )
+        for entry in amounts or []
+    )
+    assert "10,000" in joined or "10000" in joined
+    assert any(token in joined for token in ("USD", "$", "2,500", "2500"))
+
+
+def test_detect_durations_days_and_business_days():
+    samples = [
+        "payable within 30 days",
+        "no later than 15 days",
+        "due within 6 months",
+    ]
+    ok = 0
+    for sample in samples:
+        durations = ex.extract_durations(sample)
+        if any("duration" in (entry.get("value") or {}) for entry in durations or []):
+            ok += 1
+    assert ok >= 2
+
+
+def test_percentages_basic():
+    txt = "Service credits: 5% per week capped at 20% of monthly fees."
+    percentages = ex.extract_percentages(txt)
+    joined = " ".join(
+        " ".join(
+            str(value)
+            for value in (entry.get("value") or {}).values()
+            if value not in (None, "")
+        )
+        for entry in percentages or []
+    )
+    assert re.search(r"\b(5|20)\b", joined)


### PR DESCRIPTION
## Summary
- pin loguru to 0.7.2 in both runtime and development requirement files
- add a stdlib logging fallback when loguru is unavailable
- cover extractor helpers with a basic unit test for amounts, durations, and percentages

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest -q tests/unit/test_labels_taxonomy.py`
- `pytest -q tests/unit/test_extractors.py`
- `pytest -q tests/unit/test_labels_corpus_snapshot.py`
- `pytest -q tests/integration/test_trace_features_labels.py`
- `pytest -q tests/integration/test_trace_dispatch_structured.py`
- `pytest -q tests/integration/test_trace_privacy_no_text.py`
- `pytest -q tests/integration/test_api_contract_no_new_keys.py`
- `pytest -q tests/integration/test_trace_perf_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_68d12fbf9b9c8325a92d3f99d2a8a7de