### PR TITLE
Propagate channel and salience to engine findings

### DIFF
--- a/contract_review_app/legal_rules/engine.py
+++ b/contract_review_app/legal_rules/engine.py
@@ -99,23 +99,26 @@ def analyze(text: str, rules: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             for pat in r.get("patterns", []):
                 hits += len(list(pat.finditer(block.text)))
             if hits:
-                findings.append(
-                    {
-                        "rule_id": r.get("id"),
-                        "clause_type": r.get("clause_type"),
-                        "severity": r.get("severity"),
-                        "start": block.start,
-                        "end": block.end,
-                        "snippet": block.text,
-                        "advice": r.get("advice", ""),
-                        "law_refs": r.get("law_refs", []),
-                        "suggestion": r.get("suggestion"),
-                        "conflict_with": r.get("conflict_with", []),
-                        "ops": r.get("ops", []),
-                        "scope": {"unit": block.type, "nth": block.nth},
-                        "occurrences": hits,
-                    }
-                )
+                finding = {
+                    "rule_id": r.get("id"),
+                    "clause_type": r.get("clause_type"),
+                    "severity": r.get("severity"),
+                    "start": block.start,
+                    "end": block.end,
+                    "snippet": block.text,
+                    "advice": r.get("advice", ""),
+                    "law_refs": r.get("law_refs", []),
+                    "suggestion": r.get("suggestion"),
+                    "conflict_with": r.get("conflict_with", []),
+                    "ops": r.get("ops", []),
+                    "scope": {"unit": block.type, "nth": block.nth},
+                    "occurrences": hits,
+                    "salience": r.get("salience", 50),
+                }
+                channel = r.get("channel")
+                if channel is not None:
+                    finding["channel"] = channel
+                findings.append(finding)
     # Stable sort: start, end, severity desc, rule_id
     findings.sort(
         key=lambda f: (

--- a/tests/lx/test_engine_finding_channel_salience.py
+++ b/tests/lx/test_engine_finding_channel_salience.py
@@ -1,0 +1,34 @@
+import re
+
+from contract_review_app.legal_rules.engine import analyze
+
+
+def test_finding_inherits_channel_salience_from_spec():
+    text = "Important clause."
+    rule_with_channel = {
+        "id": "R-CHAN",
+        "patterns": [re.compile(r"Important")],
+        "severity": "medium",
+        "channel": "Policy",
+        "salience": 70,
+    }
+
+    findings = analyze(text, [rule_with_channel])
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["channel"] == "Policy"
+    assert finding["salience"] == 70
+
+    rule_default_salience = {
+        "id": "R-DEFAULT",
+        "patterns": [re.compile(r"clause")],
+        "severity": "medium",
+    }
+
+    default_findings = analyze(text, [rule_default_salience])
+
+    assert len(default_findings) == 1
+    default_finding = default_findings[0]
+    assert "channel" not in default_finding
+    assert default_finding["salience"] == 50


### PR DESCRIPTION
## Summary
- include channel and salience information when emitting rule findings from the engine
- ensure salience defaults to 50 and channel is only attached when provided by the spec
- cover the new behaviour with a regression test for channel and salience propagation

## Testing
- pytest tests/lx/test_engine_finding_channel_salience.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a33b3ef48325befe4fdf447576f0