### PR TITLE
Include rule channel and salience metadata in dispatch trace

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -2700,6 +2700,8 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
                                 "doctypes": doctypes_gate,
                             },
                             "gates_passed": bool(packs_gate and lang_gate and doctypes_gate),
+                            "channel": rule_spec.get("channel"),
+                            "salience": rule_spec.get("salience"),
                             "expected_any": expected_any,
                             "matched": matches,
                             "reasons": [

--- a/tests/integration/test_trace_dispatch_structured.py
+++ b/tests/integration/test_trace_dispatch_structured.py
@@ -18,6 +18,8 @@ class _DummyCandidate:
         ]
         self.reasons = reasons
         self.reason = None
+        self.channel = f"channel-{idx}"
+        self.salience = 10 + idx
 
 
 def _make_reason(rule_idx: int, reason_idx: int) -> ReasonPayload:
@@ -65,6 +67,16 @@ def test_dispatch_trace_limits_and_reason_shape(monkeypatch):
                 for pattern in reason["patterns"]:
                     assert pattern.get("kind") in {"regex", "keyword"}
                     assert isinstance(pattern.get("offsets"), list)
+
+        expected_meta = {
+            f"rule-{idx}": {"channel": f"channel-{idx}", "salience": 10 + idx}
+            for idx in range(3)
+        }
+        for entry in candidates_payload:
+            rule_id = entry.get("rule_id")
+            assert rule_id in expected_meta
+            assert entry.get("channel") == expected_meta[rule_id]["channel"]
+            assert entry.get("salience") == expected_meta[rule_id]["salience"]
     finally:
         monkeypatch.delenv("DISPATCH_MAX_CANDIDATES_PER_SEGMENT", raising=False)
         monkeypatch.delenv("DISPATCH_MAX_REASONS_PER_RULE", raising=False)


### PR DESCRIPTION
## Summary
- add rule channel and salience metadata to dispatch candidate snapshots so trace consumers can surface them
- extend dispatch trace serialization to safely carry the new metadata and cover it with integration assertions

## Testing
- pytest tests/integration/test_trace_dispatch_structured.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a7cdf58083258b51dcc34da6ef69