### PR TITLE
Add YAML rules lint script and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint fix test regen-snapshots test-cov corpus-demo corpus-test
+.PHONY: lint fix test regen-snapshots test-cov corpus-demo corpus-test rules-lint
 
 lint:
 	ruff check . && isort --check-only . && black --check .
@@ -20,7 +20,11 @@ corpus-demo:
 	python -m contract_review_app.corpus.ingest --dir data/corpus_demo
 
 corpus-test:
-\tpytest -q contract_review_app/tests/corpus --maxfail=1
+	pytest -q contract_review_app/tests/corpus --maxfail=1
+
+.PHONY: rules-lint
+rules-lint:
+	python tools/rules_lint.py
 
 .PHONY: retrieval-build
 retrieval-build:

--- a/tests/tools/test_rules_lint.py
+++ b/tests/tools/test_rules_lint.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from tools import rules_lint
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.write_text(dedent(content).strip() + "\n", encoding="utf-8")
+
+
+def test_rules_lint_reports_counts_and_issues(tmp_path: Path) -> None:
+    file_path = tmp_path / "pack.yml"
+    _write_yaml(
+        file_path,
+        """
+        - rule_id: rule.ok
+          channel: presence
+          salience: 10
+        - rule_id: rule.no_channel
+          salience: 30
+        - rule_id: rule.invalid_channel
+          channel: weird
+          salience: 55
+        - rule_id: rule.no_salience
+          channel: policy
+        - rule_id: rule.invalid_salience
+          channel: substantive
+          salience: 200
+        - rule_id: rule.duplicate
+          channel: drafting
+          salience: 42
+        - rule_id: rule.duplicate
+          channel: drafting
+          salience: 42
+        """,
+    )
+
+    result = rules_lint.lint_rules([tmp_path])
+
+    assert result.total_rules == 7
+    assert result.channel_count == 5
+    assert result.salience_count == 5
+
+    assert {rec.rule_id for rec in result.missing_channel} == {"rule.no_channel"}
+    assert {rec.rule_id for rec in result.invalid_channel} == {"rule.invalid_channel"}
+    assert {rec.rule_id for rec in result.missing_salience} == {"rule.no_salience"}
+    assert {rec.rule_id for rec in result.invalid_salience} == {"rule.invalid_salience"}
+    assert set(result.duplicates) == {"rule.duplicate"}
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_run_respects_strict_mode(tmp_path: Path, strict: bool) -> None:
+    file_path = tmp_path / "pack.yml"
+    _write_yaml(
+        file_path,
+        """
+        - rule_id: rule.one
+          channel: presence
+        - rule_id: rule.one
+          channel: presence
+        """,
+    )
+
+    buffer = io.StringIO()
+    exit_code = rules_lint.run([tmp_path], strict=strict, stream=buffer)
+
+    output = buffer.getvalue()
+    assert "Duplicate rule_id" in output
+    if strict:
+        assert exit_code == 1
+    else:
+        assert exit_code == 0

--- a/tools/rules_lint.py
+++ b/tools/rules_lint.py
@@ -1,0 +1,282 @@
+"""Lint migration coverage for YAML rule packs."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, TextIO
+
+import yaml
+
+try:  # Prefer the canonical configuration if available.
+    from contract_review_app.legal_rules.loader import (  # type: ignore
+        ALLOWED_RULE_EXTS as DEFAULT_ALLOWED_EXTS,
+    )
+    from contract_review_app.legal_rules.loader import (  # type: ignore
+        RULE_ROOTS as DEFAULT_RULE_ROOTS,
+    )
+except Exception:  # pragma: no cover - fallback for limited environments.
+    DEFAULT_RULE_ROOTS = [
+        "contract_review_app/legal_rules",
+        "core/rules",
+    ]
+    DEFAULT_ALLOWED_EXTS = {".yml", ".yaml"}
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+VALID_CHANNELS = {"presence", "substantive", "policy", "drafting", "fixup"}
+
+
+@dataclass
+class RuleRecord:
+    rule_id: str
+    channel: object
+    salience: object
+    path: Path
+
+
+@dataclass
+class LintResult:
+    total_rules: int
+    channel_count: int
+    salience_count: int
+    missing_channel: List[RuleRecord]
+    invalid_channel: List[RuleRecord]
+    missing_salience: List[RuleRecord]
+    invalid_salience: List[RuleRecord]
+    duplicates: Dict[str, List[RuleRecord]]
+    missing_rule_id: List[Path]
+
+    @property
+    def has_issues(self) -> bool:
+        return any(
+            [
+                self.missing_channel,
+                self.invalid_channel,
+                self.missing_salience,
+                self.invalid_salience,
+                self.duplicates,
+                self.missing_rule_id,
+            ]
+        )
+
+
+def _resolve(path: str | Path) -> Path:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = ROOT_DIR / candidate
+    return candidate
+
+
+def _iter_rules(doc: object) -> Iterable[dict]:
+    if not doc:
+        return []
+    if isinstance(doc, dict):
+        if isinstance(doc.get("rule"), dict):
+            return [doc["rule"]]
+        if isinstance(doc.get("rules"), list):
+            return [r for r in doc.get("rules", []) if isinstance(r, dict)]
+        return [doc]
+    if isinstance(doc, list):
+        return [item for item in doc if isinstance(item, dict)]
+    return []
+
+
+def _gather_records(
+    roots: Sequence[str | Path] | None,
+    *,
+    allowed_exts: Iterable[str],
+) -> tuple[List[RuleRecord], List[Path]]:
+    records: List[RuleRecord] = []
+    missing: set[Path] = set()
+    base_dirs = (
+        [_resolve(p) for p in roots]
+        if roots
+        else [_resolve(p) for p in DEFAULT_RULE_ROOTS]
+    )
+    for base in base_dirs:
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if path.is_dir():
+                continue
+            if path.suffix.lower() not in set(allowed_exts):
+                continue
+            try:
+                docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+            except Exception:
+                continue
+            for doc in docs:
+                for rule in _iter_rules(doc):
+                    rule_id = rule.get("rule_id") or rule.get("id")
+                    if not rule_id:
+                        missing.add(path)
+                        continue
+                    records.append(
+                        RuleRecord(
+                            rule_id=rule_id,
+                            channel=rule.get("channel"),
+                            salience=rule.get("salience"),
+                            path=path,
+                        )
+                    )
+    return records, sorted(missing)
+
+
+def _valid_salience(value: object) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return 0 <= value <= 100
+    return False
+
+
+def lint_rules(roots: Sequence[str | Path] | None = None) -> LintResult:
+    records, missing_rule_id = _gather_records(
+        roots, allowed_exts=DEFAULT_ALLOWED_EXTS
+    )
+    channel_count = 0
+    salience_count = 0
+    missing_channel: List[RuleRecord] = []
+    invalid_channel: List[RuleRecord] = []
+    missing_salience: List[RuleRecord] = []
+    invalid_salience: List[RuleRecord] = []
+    duplicates: Dict[str, List[RuleRecord]] = {}
+    seen: Dict[str, List[RuleRecord]] = {}
+
+    for record in records:
+        if record.channel in VALID_CHANNELS:
+            channel_count += 1
+        elif record.channel is None:
+            missing_channel.append(record)
+        else:
+            invalid_channel.append(record)
+
+        if _valid_salience(record.salience):
+            salience_count += 1
+        elif record.salience is None:
+            missing_salience.append(record)
+        else:
+            invalid_salience.append(record)
+
+        seen.setdefault(record.rule_id, []).append(record)
+
+    for rule_id, entries in seen.items():
+        if len(entries) > 1:
+            duplicates[rule_id] = entries
+
+    return LintResult(
+        total_rules=len(records),
+        channel_count=channel_count,
+        salience_count=salience_count,
+        missing_channel=missing_channel,
+        invalid_channel=invalid_channel,
+        missing_salience=missing_salience,
+        invalid_salience=invalid_salience,
+        duplicates=duplicates,
+        missing_rule_id=missing_rule_id,
+    )
+
+
+def _format_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(path)
+
+
+def _write_section(stream: TextIO, title: str, items: Iterable[str]) -> None:
+    items = list(items)
+    if not items:
+        return
+    stream.write(f"\n{title}:\n")
+    for item in items:
+        stream.write(f"  - {item}\n")
+
+
+def render_report(result: LintResult, stream: TextIO) -> None:
+    stream.write("Rules lint report\n")
+    stream.write("==================\n")
+    stream.write(
+        f"Total rules: {result.total_rules}\n"
+        f"With channel: {result.channel_count}\n"
+        f"With salience: {result.salience_count}\n"
+    )
+
+    _write_section(
+        stream,
+        "Missing channel",
+        (
+            f"{rec.rule_id} ({_format_path(rec.path)})"
+            for rec in result.missing_channel
+        ),
+    )
+    _write_section(
+        stream,
+        "Invalid channel",
+        (
+            f"{rec.rule_id}={rec.channel!r} ({_format_path(rec.path)})"
+            for rec in result.invalid_channel
+        ),
+    )
+    _write_section(
+        stream,
+        "Missing salience",
+        (
+            f"{rec.rule_id} ({_format_path(rec.path)})"
+            for rec in result.missing_salience
+        ),
+    )
+    _write_section(
+        stream,
+        "Invalid salience",
+        (
+            f"{rec.rule_id}={rec.salience!r} ({_format_path(rec.path)})"
+            for rec in result.invalid_salience
+        ),
+    )
+    _write_section(
+        stream,
+        "Duplicate rule_id",
+        (
+            f"{rule_id} -> {', '.join(_format_path(r.path) for r in records)}"
+            for rule_id, records in sorted(result.duplicates.items())
+        ),
+    )
+    _write_section(
+        stream,
+        "Missing rule_id",
+        (_format_path(path) for path in result.missing_rule_id),
+    )
+
+    if not result.has_issues:
+        stream.write("\nNo issues found.\n")
+
+
+def run(
+    roots: Sequence[str | Path] | None = None,
+    *,
+    strict: bool | None = None,
+    stream: TextIO | None = None,
+) -> int:
+    if stream is None:
+        stream = sys.stdout
+    if strict is None:
+        strict = os.getenv("FEATURE_RULES_LINT_STRICT") == "1"
+
+    result = lint_rules(roots)
+    render_report(result, stream)
+
+    return 1 if strict and result.has_issues else 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    argv = list(argv or [])
+    roots: Sequence[str | Path] | None = argv or None
+    return run(roots)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point.
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a tools/rules_lint.py script that audits YAML rules for channel/salience coverage and duplicate IDs
- cover the new behaviour with unit tests using synthetic YAML packs
- expose a make rules-lint helper to run the script locally

## Testing
- pytest tests/tools/test_rules_lint.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2aa2b8c4c832594404711aa1dae7d