### PR TITLE
Add structured reason offsets to dispatch trace

### DIFF
--- a/tests/integration/test_trace_dispatch_reason_offsets.py
+++ b/tests/integration/test_trace_dispatch_reason_offsets.py
@@ -1,0 +1,81 @@
+import os
+
+from tests.integration.test_trace_flag_bootstrap import (
+    _build_client,
+    _cleanup,
+    _headers,
+)
+
+
+def _reasons_with_label(candidates, label: str) -> list[dict]:
+    matches: list[dict] = []
+    for candidate in candidates:
+        reasons = candidate.get("reasons") or []
+        for reason in reasons:
+            labels = reason.get("labels") or []
+            if label in labels:
+                matches.append(reason)
+    return matches
+
+
+def _assert_reason_offsets(reasons: list[dict], bucket_key: str) -> None:
+    assert reasons, f"expected reasons with bucket {bucket_key}"
+    seen_offsets = False
+    for reason in reasons:
+        entries = reason.get(bucket_key) or []
+        for entry in entries:
+            offsets = entry.get("offsets") or []
+            if offsets:
+                seen_offsets = True
+            assert isinstance(offsets, list)
+            for span in offsets:
+                assert isinstance(span, list)
+                assert len(span) == 2
+                assert all(isinstance(value, int) for value in span)
+            lowered_keys = {str(key).lower() for key in entry.keys()}
+            assert "text" not in lowered_keys
+    assert seen_offsets, f"expected offsets in {bucket_key} entries"
+
+
+def test_trace_dispatch_reason_offsets_in_buckets():
+    previous_flag = os.environ.get("FEATURE_LX_ENGINE")
+    os.environ["FEATURE_LX_ENGINE"] = "1"
+    client, modules = _build_client("1")
+    try:
+        payload = {
+            "text": (
+                "Supplier shall be paid £10,000 within 30 days. "
+                "This Agreement is governed by the laws of England "
+                "and the courts of England shall have exclusive jurisdiction."
+            )
+        }
+        response = client.post("/api/analyze", headers=_headers(), json=payload)
+        assert response.status_code == 200
+
+        cid = response.headers.get("x-cid")
+        assert cid
+
+        trace_response = client.get(f"/api/trace/{cid}")
+        assert trace_response.status_code == 200
+        trace_body = trace_response.json()
+
+        dispatch = trace_body.get("dispatch") or {}
+        candidates = dispatch.get("candidates") or []
+        assert candidates, "expected dispatch candidates"
+
+        amount_reasons = _reasons_with_label(candidates, "amount")
+        duration_reasons = _reasons_with_label(candidates, "duration")
+        law_reasons = _reasons_with_label(candidates, "law")
+        jurisdiction_reasons = _reasons_with_label(candidates, "jurisdiction")
+
+        _assert_reason_offsets(amount_reasons, "amounts")
+        _assert_reason_offsets(duration_reasons, "durations")
+        _assert_reason_offsets(law_reasons, "law")
+        _assert_reason_offsets(jurisdiction_reasons, "jurisdiction")
+    finally:
+        _cleanup(client, modules)
+        if previous_flag is None:
+            os.environ.pop("FEATURE_LX_ENGINE", None)
+        else:
+            os.environ["FEATURE_LX_ENGINE"] = previous_flag
+

--- a/tests/unit/test_reason_payload_shape.py
+++ b/tests/unit/test_reason_payload_shape.py
@@ -1,0 +1,45 @@
+from contract_review_app.legal_rules.dispatcher import (
+    ReasonAmount,
+    ReasonCodeRef,
+    ReasonDuration,
+    ReasonPayload,
+)
+from contract_review_app.trace_artifacts import serialize_reason_entry
+
+
+def test_serialize_reason_entry_offsets_and_types():
+    reason = ReasonPayload(
+        labels=("amount", "law"),
+        amounts=(
+            ReasonAmount(currency="GBP", value=10000, offsets=((10, 16), (30, 36))),
+        ),
+        durations=(ReasonDuration(unit="days", value=30, offsets=((40, 48),)),),
+        law=(ReasonCodeRef(code="ENG", offsets=((50, 58),)),),
+        jurisdiction=(ReasonCodeRef(code="ENG", offsets=((60, 68),)),),
+    )
+
+    payload = serialize_reason_entry(reason)
+
+    assert payload["labels"] == ["amount", "law"]
+
+    assert payload["amounts"] == [
+        {"ccy": "GBP", "value": 10000, "offsets": [[10, 16], [30, 36]]}
+    ]
+    assert payload["durations"] == [
+        {"unit": "days", "value": 30, "offsets": [[40, 48]]}
+    ]
+    assert payload["law"] == [{"code": "ENG", "offsets": [[50, 58]]}]
+    assert payload["jurisdiction"] == [{"code": "ENG", "offsets": [[60, 68]]}]
+
+    for key in ("amounts", "durations", "law", "jurisdiction"):
+        for entry in payload[key]:
+            offsets = entry["offsets"]
+            assert isinstance(offsets, list) and offsets
+            for span in offsets:
+                assert isinstance(span, list)
+                assert len(span) == 2
+                assert all(isinstance(val, int) for val in span)
+            unwanted = {field.lower() for field in entry.keys()}
+            assert "text" not in unwanted
+            assert "raw" not in unwanted
+


### PR DESCRIPTION
## Summary
- extend dispatcher reasons with typed amount, duration, law, and jurisdiction buckets carrying offsets from L0 entities
- sanitize serialize_reason_entry to emit the new buckets without raw text and ensure offsets are normalized
- add unit and integration tests covering the reason payload shape and TRACE dispatch offsets

## Testing
- pytest tests/unit/test_reason_payload_shape.py
- pytest tests/integration/test_trace_dispatch_reason_offsets.py
- pytest tests/lx/test_l1_dispatcher.py

------
https://chatgpt.com/codex/tasks/task_e_68d2ac8927648325b9b61eaae1dd2491