### PR TITLE
Propagate L0 entity offsets to dispatcher reasons

### DIFF
--- a/tests/integration/test_trace_dispatch_structured.py
+++ b/tests/integration/test_trace_dispatch_structured.py
@@ -64,6 +64,9 @@ def test_dispatch_trace_limits_and_reason_shape(monkeypatch):
                 assert isinstance(reason["labels"], list)
                 assert isinstance(reason["patterns"], list)
                 assert isinstance(reason["gates"], dict)
+                for bucket in ("amounts", "durations", "law", "jurisdiction"):
+                    bucket_value = reason.get(bucket)
+                    assert isinstance(bucket_value, list)
                 for pattern in reason["patterns"]:
                     assert pattern.get("kind") in {"regex", "keyword"}
                     assert isinstance(pattern.get("offsets"), list)

--- a/tests/integration/test_trace_features_to_reasons_offsets.py
+++ b/tests/integration/test_trace_features_to_reasons_offsets.py
@@ -1,0 +1,102 @@
+from contract_review_app.core.lx_types import LxFeatureSet, LxSegment
+from contract_review_app.legal_rules.dispatcher import select_candidate_rules
+
+
+def _entity_offset_set(entries: list[dict]) -> set[tuple[int, int]]:
+    spans: set[tuple[int, int]] = set()
+    for entry in entries:
+        start = entry.get("start")
+        end = entry.get("end")
+        if not isinstance(start, int) or not isinstance(end, int):
+            continue
+        if end < start:
+            continue
+        spans.add((start, end))
+    return spans
+
+
+def _reason_offset_set(candidates, label: str, attr: str) -> set[tuple[int, int]]:
+    spans: set[tuple[int, int]] = set()
+    for candidate in candidates:
+        for reason in getattr(candidate, "reasons", []) or []:
+            if label not in getattr(reason, "labels", ()):  # tuple[str, ...]
+                continue
+            for entry in getattr(reason, attr, ()) or ():
+                for span in getattr(entry, "offsets", ()) or ():
+                    try:
+                        start, end = int(span[0]), int(span[1])
+                    except (TypeError, ValueError, IndexError):
+                        continue
+                    if end < start:
+                        continue
+                    spans.add((start, end))
+    return spans
+
+
+def test_dispatch_reasons_receive_feature_offsets():
+    segment = LxSegment(
+        segment_id=101,
+        text="Supplier shall be paid USD 100. Payment is due within thirty days. "
+        "This Agreement is governed by the laws of England and disputes belong to England courts.",
+    )
+
+    feature_set = LxFeatureSet(labels=["payment", "duration", "law", "jurisdiction"])
+    feature_set.entities = {
+        "amounts": [
+            {
+                "start": 20,
+                "end": 27,
+                "value": {"currency": "USD", "amount": 100},
+            }
+        ],
+        "durations": [
+            {
+                "start": 46,
+                "end": 56,
+                "value": {"duration": "P30D", "days": 30},
+            }
+        ],
+        "law": [
+            {
+                "start": 87,
+                "end": 94,
+                "value": {"code": "ENG"},
+            }
+        ],
+        "jurisdiction": [
+            {
+                "start": 125,
+                "end": 132,
+                "value": {"code": "ENG"},
+            }
+        ],
+    }
+    # Force dispatcher to rely on entities for offsets.
+    feature_set.amounts = []
+    feature_set.durations = {}
+    feature_set.law_signals = ["England"]
+    feature_set.jurisdiction = "England"
+
+    candidates = select_candidate_rules(segment, feature_set)
+    assert candidates, "expected dispatcher candidates"
+
+    expected_amount_offsets = _entity_offset_set(feature_set.entities["amounts"])
+    expected_duration_offsets = _entity_offset_set(feature_set.entities["durations"])
+    expected_law_offsets = _entity_offset_set(feature_set.entities["law"])
+    expected_juris_offsets = _entity_offset_set(feature_set.entities["jurisdiction"])
+
+    assert expected_amount_offsets
+    assert expected_duration_offsets
+    assert expected_law_offsets
+    assert expected_juris_offsets
+
+    reason_amount_offsets = _reason_offset_set(candidates, "amount", "amounts")
+    reason_duration_offsets = _reason_offset_set(candidates, "duration", "durations")
+    reason_law_offsets = _reason_offset_set(candidates, "law", "law")
+    reason_juris_offsets = _reason_offset_set(candidates, "jurisdiction", "jurisdiction")
+
+    assert reason_amount_offsets == expected_amount_offsets
+    assert reason_duration_offsets == expected_duration_offsets
+    assert reason_law_offsets == expected_law_offsets
+    assert reason_juris_offsets == expected_juris_offsets
+


### PR DESCRIPTION
## Summary
- propagate L0 entity offsets into dispatcher reasons by reusing extracted entity spans and deduplicating pattern offsets
- extend the dispatch trace clamp test to assert the structured reason buckets are present
- add an integration test that verifies offsets from features appear in reason payloads

## Testing
- pytest tests/integration/test_trace_features_to_reasons_offsets.py tests/integration/test_trace_dispatch_reason_offsets.py tests/integration/test_trace_dispatch_structured.py


------
https://chatgpt.com/codex/tasks/task_e_68d2b1b7e0b083259372635782e8128c