### PR TITLE
Fix GPT draft alias compatibility and CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,23 @@ jobs:
       - name: Build panel
         run: npm run build:panel
       - name: Run tests
-        run: pytest -q tests/test_analyze_api.py tests/panel/test_panel_analyze_smoke.py
+        run: |
+          mkdir -p reports
+          pytest -q tests/test_analyze_api.py tests/panel/test_panel_analyze_smoke.py \
+            --junitxml=reports/pytest.xml
+      - name: Upload pytest report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-report
+          path: reports/pytest.xml
+      - name: Upload TRACE artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trace-artifacts
+          path: |
+            TRACE
+            trace
+            timings
+          if-no-files-found: ignore

--- a/tests/api/test_gpt_draft_alias_backcompat.py
+++ b/tests/api/test_gpt_draft_alias_backcompat.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from contract_review_app.api.app import app
+from contract_review_app.api.models import SCHEMA_VERSION
+
+
+client = TestClient(app)
+
+
+def _headers() -> dict[str, str]:
+    return {"x-api-key": "local-test-key-123", "x-schema-version": SCHEMA_VERSION}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"text": "Legacy"}, id="top-level-text"),
+        pytest.param({"payload": {"text": "Nested clause content for draft."}}, id="nested-payload-text"),
+        pytest.param({"clause": "Clause coming from legacy clients."}, id="clause-field"),
+    ],
+)
+def test_gpt_draft_alias_accepts_legacy_payloads(payload):
+    resp = client.post("/api/gpt-draft", json=payload, headers=_headers())
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["status"] == "ok"
+    assert data["schema"] == SCHEMA_VERSION
+    assert data["draft_text"].strip()
+    assert data["draft_text"].startswith("Draft:")
+
+
+def test_gpt_draft_alias_preserves_original_text_when_present():
+    payload = {"text": "   Some clause from legacy payload   "}
+    resp = client.post("/api/gpt-draft", json=payload, headers=_headers())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["original_text"].strip().startswith("Some clause")


### PR DESCRIPTION
## Summary
- add a legacy payload adapter for `/api/gpt-draft` so text/payload.text/clause inputs are normalised into the new `DraftRequest`
- return the legacy draft response envelope while delegating to `/api/gpt/draft` and cover old payload shapes with unit tests
- ensure CI keeps installing dev requirements, emits junit reports and uploads TRACE/timing artefacts for easier triage

## Testing
- python -V
- pip install -r requirements-dev.txt
- pytest -q tests/api/test_gpt_draft_alias_backcompat.py tests/panel/test_gpt_draft_payload.py

## Root cause
1. `/api/gpt-draft` accepted only the new DTO, so legacy payloads triggered 422s. The adapter now flattens old request shapes, fills safe defaults, calls the new endpoint and remaps the response into the legacy schema.
2. `test_pytest_watch_installed` failed in CI because the workflow could skip installing `requirements-dev.txt`, leaving `pytest-watch` unavailable. The pipeline step now installs dev requirements and publishes pytest/TRACE artefacts for debugging.

## CI
- pending once Actions run on this PR

------
https://chatgpt.com/codex/tasks/task_e_68d2b8e2ad688325b8e8996256c258ef