### PR TITLE
Add feature flag for trace reason offsets

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -938,6 +938,7 @@ gpt_cache = TTLCache(max_items=ANALYZE_CACHE_MAX, ttl_s=ANALYZE_CACHE_TTL_S)
 FEATURE_METRICS = os.getenv("FEATURE_METRICS", "1") == "1"
 FEATURE_LX_ENGINE = os.getenv("FEATURE_LX_ENGINE", "0") == "1"
 FEATURE_TRACE_ARTIFACTS = os.getenv("FEATURE_TRACE_ARTIFACTS", "0") == "1"
+FEATURE_REASON_OFFSETS = os.getenv("FEATURE_REASON_OFFSETS", "1") == "1"
 FEATURE_L0_LABELS = os.getenv("FEATURE_L0_LABELS", "1") == "1"
 LX_L2_CONSTRAINTS = os.getenv("LX_L2_CONSTRAINTS", "0") == "1"
 METRICS_EXPORT_DIR = Path(os.getenv("METRICS_EXPORT_DIR", "var/metrics"))
@@ -2342,7 +2343,9 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
                         if DISPATCH_MAX_REASONS_PER_RULE > 0:
                             reasons_list = reasons_list[:DISPATCH_MAX_REASONS_PER_RULE]
                         serialized_reasons = [
-                            serialize_reason_entry(reason)
+                            serialize_reason_entry(
+                                reason, include_offsets=FEATURE_REASON_OFFSETS
+                            )
                             for reason in reasons_list
                         ]
                         segment_candidates.append(
@@ -2705,7 +2708,9 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
                             "expected_any": expected_any,
                             "matched": matches,
                             "reasons": [
-                                serialize_reason_entry(reason)
+                                serialize_reason_entry(
+                                    reason, include_offsets=FEATURE_REASON_OFFSETS
+                                )
                                 for reason in (
                                     list(
                                         dispatch_reasons_by_rule.get(
@@ -2822,6 +2827,7 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
                     len(evaluated_rule_ids),
                     len(triggered_rule_ids),
                     dispatch_candidates,
+                    include_reason_offsets=FEATURE_REASON_OFFSETS,
                 ),
             )
         except Exception:

--- a/tests/api/test_reason_offsets_feature_flag.py
+++ b/tests/api/test_reason_offsets_feature_flag.py
@@ -1,0 +1,113 @@
+import copy
+from typing import Any
+
+from contract_review_app.api.models import SCHEMA_VERSION
+
+def _reset_trace(trace_store: Any) -> None:
+    trace_store._data.clear()
+    trace_store._weights.clear()
+    trace_store._total_weight = 0
+
+
+def _clear_analyze_cache(app_module: Any) -> None:
+    for cache in (app_module.an_cache, app_module.cid_index, app_module.gpt_cache):
+        cache._data.clear()
+    if hasattr(app_module, "IDEMPOTENCY_CACHE"):
+        app_module.IDEMPOTENCY_CACHE.clear()
+
+
+def _collect_reasons(trace_entry: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(trace_entry, dict):
+        return []
+    body = trace_entry.get("body")
+    if not isinstance(body, dict):
+        return []
+    dispatch = body.get("dispatch")
+    if not isinstance(dispatch, dict):
+        return []
+    reasons: list[dict[str, Any]] = []
+    candidates = dispatch.get("candidates")
+    if isinstance(candidates, list):
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            bucket = candidate.get("reasons")
+            if isinstance(bucket, list):
+                for reason in bucket:
+                    if isinstance(reason, dict):
+                        reasons.append(reason)
+    return reasons
+
+
+def _has_offsets(reason: dict[str, Any]) -> bool:
+    for key in ("patterns", "amounts", "durations", "law", "jurisdiction"):
+        bucket = reason.get(key)
+        if not isinstance(bucket, list):
+            continue
+        for entry in bucket:
+            if isinstance(entry, dict) and "offsets" in entry:
+                return True
+    return False
+
+
+def _normalize_response(data: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(data)
+    normalized.pop("cid", None)
+    meta = normalized.get("meta")
+    if isinstance(meta, dict):
+        meta = dict(meta)
+        for key in ("pipeline_id", "timings_ms", "debug"):
+            meta.pop(key, None)
+        normalized["meta"] = meta
+    return normalized
+
+
+def test_reason_offsets_feature_flag(api, monkeypatch):
+    from contract_review_app.api import app as app_module
+
+    monkeypatch.setenv("DEV_MODE", "1")
+    monkeypatch.setenv("ALLOW_DEV_KEY_INJECTION", "1")
+    monkeypatch.setenv("DEFAULT_API_KEY", "local-test-key-123")
+    monkeypatch.setenv("FEATURE_LX_ENGINE", "1")
+    monkeypatch.setenv("FEATURE_TRACE_ARTIFACTS", "1")
+    monkeypatch.setattr(app_module, "FEATURE_LX_ENGINE", True, raising=False)
+    monkeypatch.setattr(app_module, "FEATURE_TRACE_ARTIFACTS", True, raising=False)
+
+    payload = {"text": "Payment shall be made within 30 days."}
+
+    def _run(flag_enabled: bool) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        monkeypatch.setenv("FEATURE_REASON_OFFSETS", "1" if flag_enabled else "0")
+        monkeypatch.setattr(
+            app_module, "FEATURE_REASON_OFFSETS", flag_enabled, raising=False
+        )
+        _reset_trace(app_module.TRACE)
+        _clear_analyze_cache(app_module)
+
+        response = api.post(
+            "/api/analyze",
+            json=payload,
+            headers={
+                "x-api-key": "local-test-key-123",
+                "x-schema-version": SCHEMA_VERSION,
+                "x-cid": "test-cid-reason-offsets",
+            },
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        cid = response.headers.get("x-cid")
+        assert cid
+
+        trace_entry = app_module.TRACE.get(cid) or {}
+        reasons = _collect_reasons(trace_entry)
+        assert reasons, "expected at least one reason entry in TRACE"
+        return data, reasons
+
+    data_on, reasons_on = _run(True)
+    data_off, reasons_off = _run(False)
+
+    assert _normalize_response(data_on) == _normalize_response(data_off)
+
+    assert any(_has_offsets(reason) for reason in reasons_on)
+    for reason in reasons_off:
+        assert not _has_offsets(reason)


### PR DESCRIPTION
## Summary
- add the FEATURE_REASON_OFFSETS toggle and thread it through analyze trace generation
- allow trace serialization to drop offset payloads when the flag is disabled
- add an API test covering the new flag behaviour for trace output vs. API stability

## Testing
- pytest tests/api/test_reason_offsets_feature_flag.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b91c79b08325aac6e46fcd113109