### PR TITLE
Fix dispatch reason serialization when offsets disabled

### DIFF
--- a/contract_review_app/api/app.py
+++ b/contract_review_app/api/app.py
@@ -2712,15 +2712,14 @@ def api_analyze(request: Request, body: dict = Body(..., example={"text": "Hello
                             "expected_any": expected_any,
                             "matched": matches,
                             "reasons": [
-                                serialize_reason_entry(
-                                    reason, include_offsets=FEATURE_REASON_OFFSETS
-                                )
+                                reason
                                 for reason in (
                                     list(
                                         dispatch_reasons_by_rule.get(
                                             str(rule_id), {}
                                         ).values()
-                                    )[:
+                                    )[
+                                        :
                                         DISPATCH_MAX_REASONS_PER_RULE
                                         if DISPATCH_MAX_REASONS_PER_RULE > 0
                                         else None


### PR DESCRIPTION
## Summary
- stop serializing dispatch candidate reasons inside the API handler so trace artifacts can apply feature flags correctly

## Testing
- pytest tests/api/test_reason_offsets_feature_flag.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c19c59f08325aa85d78f174d0aef