### PR TITLE
Build rich coverage map with seeding and tests

### DIFF
--- a/contract_review_app/legal_rules/coverage_map.yaml
+++ b/contract_review_app/legal_rules/coverage_map.yaml
@@ -1,296 +1,1823 @@
 version: 1
 zones:
-  - zone_id: "payment"
-    zone_name: "Payment & Invoicing"
-    description: "Payment obligations, invoicing, and settlement mechanics."
-    label_selectors:
-      any: ["payment", "invoice", "billing"]
-      all: []
-      none: []
-    entity_selectors:
-      amounts: true
-      durations: true
-      law: false
-      jurisdiction: false
-    rule_ids_opt: ["pay_late_interest_v1", "pay_terms_clear_v2"]
-    weight: 1.0
-    required: true
-
-  - zone_id: "term"
-    zone_name: "Term & Duration"
-    label_selectors:
-      any: ["term", "duration", "renewal"]
-      all: []
-      none: []
-    entity_selectors:
-      amounts: false
-      durations: true
-      law: false
-      jurisdiction: false
-    rule_ids_opt: ["term_auto_renewal_v1"]
-
-  - zone_id: "termination"
-    zone_name: "Termination"
-    label_selectors:
-      any: ["termination", "terminate", "termination_rights"]
-      all: []
-      none: []
-    rule_ids_opt: ["term_termination_for_cause_v1"]
-
-  - zone_id: "notices"
-    zone_name: "Notices"
-    label_selectors:
-      any: ["notice", "notices", "notification"]
-      all: []
-      none: []
-    rule_ids_opt: ["notice_method_v1"]
-
-  - zone_id: "governing_law"
-    zone_name: "Governing Law"
-    label_selectors:
-      any: ["governing law", "law", "governed_by"]
-      all: []
-      none: []
-    entity_selectors:
-      amounts: false
-      durations: false
-      law: true
-      jurisdiction: false
-    rule_ids_opt: ["gl_specify_law_v1"]
-
-  - zone_id: "jurisdiction"
-    zone_name: "Jurisdiction"
-    label_selectors:
-      any: ["jurisdiction", "venue", "forum"]
-      all: []
-      none: []
-    entity_selectors:
-      amounts: false
-      durations: false
-      law: false
-      jurisdiction: true
-    rule_ids_opt: ["jurisdiction_forum_v1"]
-
-  - zone_id: "dispute_resolution"
-    zone_name: "Dispute Resolution"
-    label_selectors:
-      any: ["dispute", "arbitration", "dr"]
-      all: []
-      none: []
-    rule_ids_opt: ["dr_escalation_v1"]
-
-  - zone_id: "liability_cap"
-    zone_name: "Liability Cap"
-    label_selectors:
-      any: ["liability", "cap", "limitation"]
-      all: []
-      none: ["no_cap"]
-    rule_ids_opt: ["liability_cap_defined_v1"]
-
-  - zone_id: "indemnity"
-    zone_name: "Indemnity"
-    label_selectors:
-      any: ["indemnity", "indemnification"]
-      all: []
-      none: []
-    rule_ids_opt: ["indemnity_scope_v1"]
-
-  - zone_id: "confidentiality"
-    zone_name: "Confidentiality"
-    label_selectors:
-      any: ["confidentiality", "nda", "confidential"]
-      all: []
-      none: []
-    rule_ids_opt: ["confidentiality_survival_v1"]
-
-  - zone_id: "ip"
-    zone_name: "Intellectual Property"
-    label_selectors:
-      any: ["intellectual property", "ip", "ownership"]
-      all: []
-      none: []
-    rule_ids_opt: ["ip_ownership_v1"]
-
-  - zone_id: "data_protection"
-    zone_name: "Data Protection"
-    label_selectors:
-      any: ["data protection", "gdpr", "privacy"]
-      all: []
-      none: []
-    rule_ids_opt: ["dp_security_measures_v1"]
-
-  - zone_id: "insurance"
-    zone_name: "Insurance"
-    label_selectors:
-      any: ["insurance", "insured", "coverage"]
-      all: []
-      none: []
-    rule_ids_opt: ["insurance_maintain_limits_v1"]
-
-  - zone_id: "force_majeure"
-    zone_name: "Force Majeure"
-    label_selectors:
-      any: ["force majeure", "fm_event"]
-      all: []
-      none: []
-    rule_ids_opt: ["force_majeure_notice_v1"]
-
-  - zone_id: "taxes"
-    zone_name: "Taxes"
-    label_selectors:
-      any: ["tax", "taxes", "withholding"]
-      all: []
-      none: []
-    rule_ids_opt: ["tax_withholding_v1"]
-
-  - zone_id: "assignment"
-    zone_name: "Assignment"
-    label_selectors:
-      any: ["assignment", "assign"]
-      all: []
-      none: []
-    rule_ids_opt: ["assignment_consent_v1"]
-
-  - zone_id: "subcontracting"
-    zone_name: "Subcontracting"
-    label_selectors:
-      any: ["subcontract", "subcontracting"]
-      all: []
-      none: []
-    rule_ids_opt: ["subcontracting_controls_v1"]
-
-  - zone_id: "order_of_precedence"
-    zone_name: "Order of Precedence"
-    label_selectors:
-      any: ["precedence", "order of precedence"]
-      all: []
-      none: []
-    rule_ids_opt: ["precedence_hierarchy_v1"]
-
-  - zone_id: "definitions"
-    zone_name: "Definitions"
-    label_selectors:
-      any: ["definition", "definitions"]
-      all: []
-      none: []
-    rule_ids_opt: []
-
-  - zone_id: "interpretation"
-    zone_name: "Interpretation"
-    label_selectors:
-      any: ["interpretation", "construction"]
-      all: []
-      none: []
-    rule_ids_opt: []
-
-  - zone_id: "acceptance"
-    zone_name: "Acceptance"
-    label_selectors:
-      any: ["acceptance", "accept"]
-      all: []
-      none: []
-    rule_ids_opt: ["acceptance_criteria_v1"]
-
-  - zone_id: "delivery"
-    zone_name: "Delivery"
-    label_selectors:
-      any: ["delivery", "deliver", "shipment"]
-      all: []
-      none: []
-    rule_ids_opt: ["delivery_schedule_v1"]
-
-  - zone_id: "service_levels"
-    zone_name: "Service Levels"
-    label_selectors:
-      any: ["service level", "sla", "service_levels"]
-      all: []
-      none: []
-    rule_ids_opt: ["sla_response_times_v1"]
-
-  - zone_id: "price_adjustment"
-    zone_name: "Price Adjustment"
-    label_selectors:
-      any: ["price adjustment", "indexation", "escalation"]
-      all: []
-      none: []
-    rule_ids_opt: ["price_adjustment_index_v1"]
-
-  - zone_id: "interest_late"
-    zone_name: "Late Interest"
-    label_selectors:
-      any: ["late interest", "interest", "overdue"]
-      all: []
-      none: []
-    rule_ids_opt: ["late_interest_rate_v1"]
-
-  - zone_id: "change_control"
-    zone_name: "Change Control"
-    label_selectors:
-      any: ["change control", "variation", "change_request"]
-      all: []
-      none: []
-    rule_ids_opt: ["change_control_process_v1"]
-
-  - zone_id: "audit_records"
-    zone_name: "Audit & Records"
-    label_selectors:
-      any: ["audit", "records", "inspection"]
-      all: []
-      none: []
-    rule_ids_opt: ["audit_rights_v1"]
-
-  - zone_id: "survival"
-    zone_name: "Survival"
-    label_selectors:
-      any: ["survival", "survive"]
-      all: []
-      none: []
-    rule_ids_opt: []
-
-  - zone_id: "personnel"
-    zone_name: "Personnel"
-    label_selectors:
-      any: ["personnel", "staff", "employees"]
-      all: []
-      none: []
-    rule_ids_opt: ["personnel_screening_v1"]
-
-  - zone_id: "cross_refs"
-    zone_name: "Cross References"
-    label_selectors:
-      any: ["cross reference", "cross_refs"]
-      all: []
-      none: []
-    rule_ids_opt: []
-
-  - zone_id: "warranties"
-    zone_name: "Warranties"
-    label_selectors:
-      any: ["warranty", "warranties"]
-      all: []
-      none: []
-    rule_ids_opt: ["warranty_scope_v1"]
-
-  - zone_id: "quality"
-    zone_name: "Quality"
-    label_selectors:
-      any: ["quality", "quality_assurance", "qa"]
-      all: []
-      none: []
-    rule_ids_opt: []
-
-  - zone_id: "compliance_abac"
-    zone_name: "Compliance & ABAC"
-    label_selectors:
-      any: ["compliance", "abac", "anti-bribery", "ethics"]
-      all: []
-      none: []
-    rule_ids_opt: ["abac_policy_v1"]
-
-  - zone_id: "transition"
-    zone_name: "Transition & Exit"
-    label_selectors:
-      any: ["transition", "exit_plan", "handover"]
-      all: []
-      none: []
-    rule_ids_opt: []
+- zone_id: payment
+  zone_name: Payment & Invoicing
+  description: Payment obligations, invoicing mechanics, withholding and set-off controls.
+  label_selectors:
+    any:
+    - late_payment_interest
+    - open_book_pricing
+    - payment_security
+    - payment_terms
+    - rate_card
+    - service_credits
+    - set_off
+    - taxes_vat
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.LAB.ISO17025
+  - P1.ALL_INCLUSIVE_RATES
+  - P10.REIMBURSABLES_NET_OF_REBATES
+  - P11.NO_PAY_IDLE_EFFICIENCY
+  - P12.RECEIVABLES_ASSIGNMENT_PERMITTED
+  - P2.INVOICE_CONTENT_VAT
+  - P3.LATE_INVOICE_TIMEBAR
+  - P4.PAYMENT_TERMS_AND_INTEREST
+  - P5.PUBLIC_30DAYS_CASCADE
+  - P6.CONSTRUCTION_PAY_NOTICES
+  - P7.SETOFF_SCOPE
+  - P8.PAY_UNDISPUTED
+  - P9.EINVOICE_PLATFORM_VAT_CONTROL
+  - payment_terms_basic
+  - pricing_payment
+  - subcontracts.ban_pay_when_paid
+  - subcontracts.step_in_third_party_alignment
+  - uk.def.business_day.precision
+  - uk.def.key_personnel.list_ld_controls
+  - uk.def.taxes.matrix_withholding_grossup
+  - uk.def.vat.registration_place_of_supply_zero_rating
+  - uk.def.work.scope_boundary_interfaces
+  - uk.int.2_2_1b.time_basis_calendar_vs_business
+  - uk.master.exhibitj.deed_formalities
+  - uk.s3.editorial.typos_numbering_block
+  - uk.s3.ld.only_remedy_gates
+  - uk.s3.ld.parameters_case_law
+  - uk_ndabasic_unexpected_payment
+  weight: 1.0
+  required: true
+- zone_id: term
+  zone_name: Term & Renewal
+  description: Contract duration, renewal cycles and suspension windows.
+  label_selectors:
+    any:
+    - renewal_auto
+    - survival
+    - suspension
+    - term
+    - usage_limits
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P4.PAYMENT_TERMS_AND_INTEREST
+  - VARIATIONS.RATE_IMMUTABILITY_BASELINE
+  - ipr.bg.licence.conflict
+  - subcontracts.data_protection_art28
+  - termination_cause
+  - termination_convenience
+  - termination_notice_basic
+  - title.delivery_up.access_right
+  - title.embedded_software.perpetual_licence
+  - title.risk.cross_reference
+  - uk.calloff.exclude_other_terms
+  - uk.def.bribe.ukba_poca_fcpa
+  - uk.def.taxes.matrix_withholding_grossup
+  - uk.int.2_2_4.precedence_calloff
+  - uk.master.incorp.heavy_terms_notice
+  - uk.master.term.extensions_notice
+  - uk.s3.ld.only_remedy_gates
+  - uk.s3.ld.parameters_case_law
+  - uk.s3.nullity.foreign_terms_3_13
+  - uk.s3.order.start_as_acceptance_guard
+  - uk.s3.po.exclude_supplier_terms
+  - universal.inform.transport_employer_items
+  - universal.performance.goods_software_incoterms
+  weight: 1.0
+  required: false
+- zone_id: termination
+  zone_name: Termination Rights
+  description: Termination for breach, convenience, insolvency and related cure steps.
+  label_selectors:
+    any:
+    - termination_assistance
+    - termination_breach
+    - termination_change_of_control
+    - termination_convenience
+    - termination_insolvency
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - cpi.use.only.for.project
+  - ic.agency.no_authority_to_bind
+  - ipr.indemnity.remedies
+  - termination_cause
+  - termination_convenience
+  - termination_notice_basic
+  - title.delivery_up.access_right
+  - title.embedded_software.perpetual_licence
+  - uk.def.bribe.ukba_poca_fcpa
+  - uk.int.2_2_2.headings_no_effect
+  - uk.master.term.extensions_notice
+  - uk.s3.ld.only_remedy_gates
+  - uk.s3.ld.parameters_case_law
+  weight: 1.0
+  required: false
+- zone_id: notices
+  zone_name: Notices
+  description: Service of notices, delivery methods and notice periods.
+  label_selectors:
+    any:
+    - escalation
+    - foi
+    - lead_times
+    - notices
+    - service_levels_sla
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.ITP.NOTICE
+  - P1.ALL_INCLUSIVE_RATES
+  - P10.REIMBURSABLES_NET_OF_REBATES
+  - P11.NO_PAY_IDLE_EFFICIENCY
+  - P12.RECEIVABLES_ASSIGNMENT_PERMITTED
+  - P2.INVOICE_CONTENT_VAT
+  - P3.LATE_INVOICE_TIMEBAR
+  - P4.PAYMENT_TERMS_AND_INTEREST
+  - P5.PUBLIC_30DAYS_CASCADE
+  - P6.CONSTRUCTION_PAY_NOTICES
+  - P7.SETOFF_SCOPE
+  - P8.PAY_UNDISPUTED
+  - P9.EINVOICE_PLATFORM_VAT_CONTROL
+  - cpi.receipt.notice_window.latent
+  - ic.ir35.offpayroll.sds_process
+  - ic.substitution.absent_or_personal_service
+  - notices
+  - quality.itp.hw_notice_5d
+  - uk.def.business_day.precision
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.int.2_2_1b.time_basis_calendar_vs_business
+  - uk.int.2_2_1h.approvals_in_writing_by_reps
+  - uk.int.2_2_1i.writing_email_esign_alignment
+  - uk.int.2_2_1k.subcontracts_flowdown_audit
+  - uk.master.incorp.heavy_terms_notice
+  - uk.master.term.extensions_notice
+  - uk.parties.identity
+  - uk.s3.order.acceptance_triggers_channels
+  - uk.s3.order.channels_align_29
+  - uk.s4.ctr.change_consent_sla
+  - uk.s4.delegation.notice_and_register
+  - uk.s4.reps.notice_channels_alignment
+  - uk_company_address_conflict
+  - uk_regulatory_prohibited_notice
+  - universal.inform.discrepancy_notice_timebar
+  - universal.inform.notice_formalities
+  - universal.performance.rsc_vs_ffp_priority
+  weight: 1.0
+  required: false
+- zone_id: governing_law
+  zone_name: Governing Law
+  description: Choice of law, statutory references and conflict rules.
+  label_selectors:
+    any:
+    - entire_agreement
+    - governing_law
+    - remedies
+    - severance
+    - third_party_rights
+    - waiver
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: true
+  rule_ids_opt:
+  - VARIATIONS.CHANGE_IN_LAW_TAXES_BUSINESS_EXCLUDED
+  - gl_england_wales
+  - gl_jurisdiction_conflict
+  - governing_law
+  - governing_law_basic
+  - jurisdiction_basic
+  - uk.def.business_day.precision
+  - uk_drafting_law_forum_mismatch
+  - universal.inform.deemed_laws_change
+  - universal.personnel.gdpr_personnel_data
+  weight: 1.0
+  required: true
+- zone_id: jurisdiction
+  zone_name: Jurisdiction & Forum
+  description: Courts, venues and escalation forums for disputes.
+  label_selectors:
+    any:
+    - arbitration
+    - dispute_resolution
+    - escalation
+    - jurisdiction
+    - mediation
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: true
+    law: false
+  rule_ids_opt:
+  - gl_jurisdiction_conflict
+  - jurisdiction_basic
+  - uk.def.business_day.precision
+  - uk_drafting_law_forum_mismatch
+  weight: 1.0
+  required: true
+- zone_id: dispute_resolution
+  zone_name: Dispute Resolution
+  description: Mediation, arbitration and escalation procedures.
+  label_selectors:
+    any:
+    - arbitration
+    - dispute_resolution
+    - escalation
+    - foi
+    - mediation
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P8.PAY_UNDISPUTED
+  - dispute_resolution
+  - uk.int.2_2_5.ambiguity_pre_dr_checks
+  weight: 1.0
+  required: true
+- zone_id: liability_cap
+  zone_name: Liability & Caps
+  description: Limitation of liability, carve outs and capped exposure.
+  label_selectors:
+    any:
+    - deductibles_limits
+    - indirect_consequential_exclusion
+    - liability_cap_amount
+    - liability_carveouts
+    - limitation_of_liability
+    - liquidated_damages
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.AUDIT.ISO19011
+  - 13.INSPECT.NO_WAIVER
+  - cpi.receipt.notice_window.latent
+  - ic.hse.carveout.required
+  - ic.vicarious.liability.supervision_language
+  - liability_cap
+  - liability_cap_basic
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.invitee.scope_and_exclusions
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.def.key_personnel.list_ld_controls
+  - uk.def.parties.calloff_specificity_crtpa
+  - uk.def.personal_injury.scope_and_el_insurance
+  - uk.def.third_party.crtpa_alignment
+  - uk.def.tupe.eli_requirements
+  - uk.int.2_2_1i.writing_email_esign_alignment
+  - uk.s3.coventurers.agent_model_cap
+  - uk.s3.ld.only_remedy_gates
+  - uk.s3.ld.parameters_case_law
+  - uk.s3.po.per_entity_responsibility
+  - uk_fraud_exclusion_invalid
+  - uk_poca_tipping_off
+  - uk_ucta_2_1_invalid
+  - universal.inform.employer_info_nonreliance
+  - universal.inform.resources_breakdown_carveouts
+  - universal.performance.resources_sufficiency
+  weight: 1.0
+  required: true
+- zone_id: indemnity
+  zone_name: Indemnities
+  description: Scope of indemnities, defence obligations and exclusions.
+  label_selectors:
+    any:
+    - dp_indemnity
+    - indemnity_general
+    - insurance_requirements
+    - ip_indemnity
+    - waiver_of_subrogation
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ipr.indemnity.remedies
+  - subcontracts.prior_consent
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.def.key_personnel.list_ld_controls
+  - uk.def.legal_fault.fm_indemnities_consistency
+  - uk.def.work.scope_boundary_interfaces
+  - uk.s3.editorial.typos_numbering_block
+  - uk.s3.ld.only_remedy_gates
+  - uk.s3.ld.parameters_case_law
+  weight: 1.0
+  required: false
+- zone_id: confidentiality
+  zone_name: Confidentiality & Publicity
+  description: Confidential information handling, permitted disclosures and publicity.
+  label_selectors:
+    any:
+    - announcements_publicity
+    - confidentiality
+    - nhs_patient_confidentiality
+    - permitted_disclosures
+    - return_or_destruction
+    - transparency_publication
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - confidentiality
+  - subcontracts.flowdown_minimum_set
+  - uk.def.business_day.precision
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.nonconformity.scope_and_priority
+  - uk.def.personnel.coverage_ir35_awr
+  - uk.def.subcontractor.flowdown_audit
+  - uk.def.work.scope_boundary_interfaces
+  - uk.int.2_2_1b.time_basis_calendar_vs_business
+  - uk.int.2_2_1g.dynamic_incorp_requires_variation
+  - uk.master.incorp.dynamic_refs_change_control
+  - uk.master.incorp.heavy_terms_notice
+  - uk.master.incorp.placeholders_clean
+  - uk.master.recitals.no_min_purchase
+  - uk.master.recitals.no_operational_shall
+  - uk.parties.identity
+  - uk_ndabasic_broad_purpose
+  - uk_ndabasic_unexpected_payment
+  - uk_poca_tipping_off
+  - universal.performance.rsc_vs_ffp_priority
+  weight: 1.0
+  required: true
+- zone_id: ip
+  zone_name: Intellectual Property
+  description: IP ownership, licensing, infringement indemnities and tooling.
+  label_selectors:
+    any:
+    - ip_indemnity
+    - ip_ownership
+    - license_grant
+    - open_source
+    - title_retention_rot
+    - tooling
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.EQUIP.CERT.LOLER_PUWER
+  - 13.SHIP.BLOCK
+  - ip_rights
+  - ip_rights_basic
+  - ipr.agreement_docs_title.company
+  - ipr.bg.licence.conflict
+  - ipr.brand.use.prohibition
+  - ipr.fg.licence.scope
+  - ipr.further_assurances.poa
+  - ipr.indemnity.remedies
+  - ipr.moral_rights.waiver
+  - ipr.oss.guardrails
+  - ipr.source_code.escrow
+  - ipr.supplied_software.definition
+  - quality.audit.iso19011
+  - quality.equipment.certificates_pre_dispatch
+  - quality.equipment.site_tests_swl
+  - quality.no_ship_without_final_inspection
+  - subcontracts.flowdown_minimum_set
+  - title.embedded_software.perpetual_licence
+  - title.vesting.early_wip_offsite
+  - uk.def.bipr.perimeter_and_license
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.site.ownership_access_risk
+  - uk.def.subcontractor.flowdown_audit
+  - uk.def.supplied_software.scope_licence_escrow
+  - uk.int.2_2_1k.subcontracts_flowdown_audit
+  - uk.s3.exclusivity.non_exclusive
+  - uk_poca_tipping_off
+  - universal.inform.resources_breakdown_carveouts
+  - universal.performance.goods_software_incoterms
+  - universal.performance.rental_equipment
+  - universal.performance.schedule_recovery
+  weight: 1.0
+  required: true
+- zone_id: data_protection
+  zone_name: Data Protection
+  description: GDPR roles, processing instructions, breach notification and sub-processing.
+  label_selectors:
+    any:
+    - dp_breach_notification
+    - dp_dpia
+    - dp_dsr
+    - dp_general
+    - dp_localisation
+    - dp_records_of_processing
+    - dp_retention_deletion
+    - dp_roles
+    - dp_security_measures
+    - dp_subprocessing
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ic.medical.data.minimisation
+  - subcontracts.data_protection_art28
+  - title.commingling.bulk_processing
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.tupe.eli_requirements
+  - uk.def.vor.process
+  - uk.s3.po.exclude_supplier_terms
+  - uk_dpa_1998_outdated
+  - universal.personnel.gdpr_personnel_data
+  weight: 1.0
+  required: true
+- zone_id: insurance
+  zone_name: Insurance Requirements
+  description: Insurance coverage, certificates, limits and waivers.
+  label_selectors:
+    any:
+    - business_continuity_bcp
+    - deductibles_limits
+    - insurance_requirements
+    - insurance_types_limits
+    - waiver_of_subrogation
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.AUDIT.ISO19011
+  - 13.COST.NOSHOW_FAIL
+  - 13.EQUIP.CERT.LOLER_PUWER
+  - 13.HIDDEN.WORKS
+  - 13.INSPECT.NO_WAIVER
+  - 13.ITP.EXISTS
+  - 13.ITP.NOTICE
+  - 13.LAB.ISO17025
+  - 13.MARKING.UKCA_CE
+  - 13.MOC.FORMAL
+  - 13.QMS.ISO9001
+  - 13.QP.REQUIRED
+  - 13.SHIP.BLOCK
+  - P1.ALL_INCLUSIVE_RATES
+  - P10.REIMBURSABLES_NET_OF_REBATES
+  - P11.NO_PAY_IDLE_EFFICIENCY
+  - P12.RECEIVABLES_ASSIGNMENT_PERMITTED
+  - P2.INVOICE_CONTENT_VAT
+  - P3.LATE_INVOICE_TIMEBAR
+  - P4.PAYMENT_TERMS_AND_INTEREST
+  - P5.PUBLIC_30DAYS_CASCADE
+  - P6.CONSTRUCTION_PAY_NOTICES
+  - P7.SETOFF_SCOPE
+  - P8.PAY_UNDISPUTED
+  - P9.EINVOICE_PLATFORM_VAT_CONTROL
+  - VARIATIONS.CHANGE_IN_LAW_TAXES_BUSINESS_EXCLUDED
+  - VARIATIONS.CONTRACTOR_INITIATED_LIMITED
+  - VARIATIONS.DISAGREE_PROCEED_NO_COND_SIGN
+  - VARIATIONS.MITIGATION_DUTY
+  - VARIATIONS.NOM_ONLY
+  - VARIATIONS.RATE_IMMUTABILITY_BASELINE
+  - VARIATIONS.RATE_PARITY_CPA
+  - VARIATIONS.TIMEBAR_IMMEDIATE_OFFSHORE_3D
+  - VARIATIONS.VOR_5BD
+  - VARIATIONS.WAIVER_CUMULATIVE_CARDINAL
+  - assignment
+  - audit
+  - company_provided_items
+  - confidentiality
+  - cpi.ccc.insurance.cover_required
+  - cpi.export.controls.sanctions
+  - cpi.incident.loss.damage.reporting
+  - cpi.marking.tracking.required
+  - cpi.no_lien.required
+  - cpi.receipt.notice_window.latent
+  - cpi.register.exhaustive_list
+  - cpi.storage.lifting.loler_puwer
+  - cpi.use.only.for.project
+  - cpi.waste.disposal.duty_of_care
+  - dispute_resolution
+  - export_hmrc
+  - force_majeure
+  - gl_england_wales
+  - governing_law
+  - governing_law_basic
+  - hse_life_saving
+  - ic.agency.no_authority_to_bind
+  - ic.awr.agency_workers_equal_treatment
+  - ic.hse.carveout.required
+  - ic.ir35.offpayroll.sds_process
+  - ic.medical.data.minimisation
+  - ic.mutuality.moo.minimum_hours
+  - ic.removal.right.objective_non_discrimination
+  - ic.status.control.methods
+  - ic.substitution.absent_or_personal_service
+  - ic.vicarious.liability.supervision_language
+  - insurance_noncompliance
+  - ip_rights
+  - ip_rights_basic
+  - ipr.agreement_docs_title.company
+  - ipr.bg.licence.conflict
+  - ipr.brand.use.prohibition
+  - ipr.fg.licence.scope
+  - ipr.further_assurances.poa
+  - ipr.indemnity.remedies
+  - ipr.moral_rights.waiver
+  - ipr.oss.guardrails
+  - ipr.source_code.escrow
+  - ipr.supplied_software.definition
+  - jurisdiction_basic
+  - liability_cap
+  - liability_cap_basic
+  - notices
+  - payment_terms_basic
+  - placeholder_police
+  - pricing_payment
+  - quality.audit.iso19011
+  - quality.company.rights.reject_nonconforming
+  - quality.costs.not_ready_or_repeat
+  - quality.equipment.certificates_pre_dispatch
+  - quality.equipment.site_tests_swl
+  - quality.hidden_work_prove_compliance
+  - quality.itp.hw_notice_5d
+  - quality.itp.required
+  - quality.moc.qms_changes
+  - quality.no_ship_without_final_inspection
+  - quality.qms.iso_required
+  - quality.qp.iso10005.required
+  - risk_structure
+  - subcontracts
+  - subcontracts.ban_pay_when_paid
+  - subcontracts.copies_audit_rights
+  - subcontracts.data_protection_art28
+  - subcontracts.flowdown_minimum_set
+  - subcontracts.prior_consent
+  - subcontracts.step_in_third_party_alignment
+  - termination_cause
+  - termination_convenience
+  - termination_notice_basic
+  - third_party_rights
+  - title.clean.free_of_liens
+  - title.commingling.bulk_processing
+  - title.customs.ior_alignment
+  - title.delivery_up.access_right
+  - title.embedded_software.perpetual_licence
+  - title.marking.register.audit
+  - title.rejection.return_reversion
+  - title.risk.cross_reference
+  - title.vesting.early_wip_offsite
+  - title.waivers.third_party_liens
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.legal_fault.fm_indemnities_consistency
+  - uk.def.personal_injury.scope_and_el_insurance
+  - uk.def.personnel.coverage_ir35_awr
+  - uk.def.property.exclusions_title_risk
+  - uk.def.site.ownership_access_risk
+  - uk.def.subcontractor.flowdown_audit
+  - uk.def.worksite.inclusion_exclusions
+  - uk.s3.order.channels_align_29
+  - uk.s3.po.exclude_supplier_terms
+  - uk.s3.po.per_entity_responsibility
+  - uk.s4.hse.stop_work_authority
+  - uk.s4.reps.notice_channels_alignment
+  - universal.inform.deemed_laws_change
+  - universal.inform.deemed_pricing_voeot
+  - universal.inform.deemed_scope_clarity
+  - universal.inform.discrepancy_notice_timebar
+  - universal.inform.employer_corrects_variation
+  - universal.inform.employer_info_nonreliance
+  - universal.inform.implied_scope_limit
+  - universal.inform.notice_formalities
+  - universal.inform.physical_conditions_unforeseen
+  - universal.inform.resources_breakdown_carveouts
+  - universal.inform.stop_work_on_conflict
+  - universal.inform.transport_employer_items
+  - universal.performance.cooperate_eot
+  - universal.performance.document_control_handover
+  - universal.performance.exhibits_policies_conflicts
+  - universal.performance.goods_software_incoterms
+  - universal.performance.inspection_acceptance_window
+  - universal.performance.instructions_variation_gate
+  - universal.performance.materials_management
+  - universal.performance.permits_rtw
+  - universal.performance.rental_equipment
+  - universal.performance.reporting_early_warning
+  - universal.performance.resources_sufficiency
+  - universal.performance.rsc_vs_ffp_priority
+  - universal.performance.schedule_recovery
+  - universal.performance.site_ptw_partial_occupation
+  - universal.performance.working_hours_overtime
+  - variations
+  - warranty
+  weight: 1.0
+  required: false
+- zone_id: force_majeure
+  zone_name: Force Majeure
+  description: Force majeure events, mitigation, suspension rights and continuity
+    planning.
+  label_selectors:
+    any:
+    - backup_restore
+    - business_continuity_bcp
+    - disaster_recovery
+    - force_majeure
+    - step_in_rights
+    - suspension
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - force_majeure
+  - uk.def.legal_fault.fm_indemnities_consistency
+  - universal.inform.resources_breakdown_carveouts
+  weight: 1.0
+  required: true
+- zone_id: taxes
+  zone_name: Taxes & Withholding
+  description: Indirect taxes, gross-up mechanics and anti-avoidance obligations.
+  label_selectors:
+    any:
+    - anti_tax_evasion
+    - payment_terms
+    - price_changes_indexation
+    - set_off
+    - taxes_vat
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P2.INVOICE_CONTENT_VAT
+  - P7.SETOFF_SCOPE
+  - P9.EINVOICE_PLATFORM_VAT_CONTROL
+  - VARIATIONS.CHANGE_IN_LAW_TAXES_BUSINESS_EXCLUDED
+  - ic.ir35.offpayroll.sds_process
+  - subcontracts.step_in_third_party_alignment
+  - uk.def.ior.calloff_requirements
+  - uk.def.key_personnel.list_ld_controls
+  - uk.def.personnel.coverage_ir35_awr
+  - uk.def.tariff_code.classification
+  - uk.def.taxes.matrix_withholding_grossup
+  - uk.def.trade_tariff.source_recency
+  - uk.def.vat.registration_place_of_supply_zero_rating
+  - uk.def.work.scope_boundary_interfaces
+  - uk.s3.editorial.typos_numbering_block
+  - uk.s3.ld.only_remedy_gates
+  - uk.s3.ld.parameters_case_law
+  weight: 1.0
+  required: true
+- zone_id: assignment
+  zone_name: Assignment
+  description: Assignment restrictions, consent requirements and transfers.
+  label_selectors:
+    any:
+    - assignment
+    - joa_assignment_consent
+    - tenancy_assignment_underlet
+    - third_party_rights
+    - title_retention_rot
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P12.RECEIVABLES_ASSIGNMENT_PERMITTED
+  - assignment
+  - subcontracts.prior_consent
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.ior.calloff_requirements
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.key_personnel.list_ld_controls
+  - uk.int.2_2_1h.approvals_in_writing_by_reps
+  - uk.s4.ctr.change_consent_sla
+  - universal.inform.transport_employer_items
+  weight: 1.0
+  required: false
+- zone_id: subcontracting
+  zone_name: Subcontracting & Flow-down
+  description: Subcontract approvals, flow-down obligations and sub-processor controls.
+  label_selectors:
+    any:
+    - dp_subprocessing
+    - staff_vetting
+    - subcontracting
+    - subprocessor_approval
+    - support_maintenance
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - subcontracts
+  - subcontracts.ban_pay_when_paid
+  - subcontracts.copies_audit_rights
+  - subcontracts.data_protection_art28
+  - subcontracts.flowdown_minimum_set
+  - subcontracts.prior_consent
+  - subcontracts.step_in_third_party_alignment
+  - title.waivers.third_party_liens
+  - uk.def.bribe.ukba_poca_fcpa
+  - uk.def.subcontractor.flowdown_audit
+  - uk.def.vor.process
+  - uk.int.2_2_1k.subcontracts_flowdown_audit
+  weight: 1.0
+  required: false
+- zone_id: order_of_precedence
+  zone_name: Order of Precedence
+  description: Hierarchy between contract documents and precedence clauses.
+  label_selectors:
+    any:
+    - entire_agreement
+    - remedies
+    - severance
+    - third_party_rights
+    - waiver
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - cpi.export.controls.sanctions
+  - gl_england_wales
+  - gl_jurisdiction_conflict
+  - governing_law
+  - governing_law_basic
+  - ipr.bg.licence.conflict
+  - subcontracts.copies_audit_rights
+  - uk.calloff.exclude_other_terms
+  - uk.calloff.formation_by_performance_controls
+  - uk.calloff.minimum_content
+  - uk.def.variation.gate
+  - uk.def.variation.order_contents
+  - uk.def.vor.process
+  - uk.int.2_2_1j.calloff_incorporates_msa
+  - uk.int.2_2_3.precedence_agreement_alpha_risk
+  - uk.int.2_2_4.precedence_calloff
+  - uk.int.2_2_5.ambiguity_pre_dr_checks
+  - uk.master.supplemental.priority
+  - uk.s3.nullity.foreign_terms_3_13
+  - uk.s3.order.acceptance_triggers_channels
+  - uk.s3.order.channels_align_29
+  - uk.s3.po.exclude_supplier_terms
+  - uk.s3.po.per_entity_responsibility
+  - uk.s4.cr.apparent_authority_controls
+  - uk.s4.governance.chain_of_command
+  - uk_company_address_conflict
+  - universal.inform.stop_work_on_conflict
+  - universal.performance.exhibits_policies_conflicts
+  weight: 1.0
+  required: false
+- zone_id: definitions
+  zone_name: Definitions
+  description: Defined terms, parties and interpretation aids.
+  label_selectors:
+    any:
+    - definitions
+    - entire_agreement
+    - interpretation
+    - parties
+    - remedies
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - gl_jurisdiction_conflict
+  - ipr.supplied_software.definition
+  - uk.def.bipr.perimeter_and_license
+  - uk.def.bribe.ukba_poca_fcpa
+  - uk.def.business_day.precision
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.invitee.scope_and_exclusions
+  - uk.def.ior.calloff_requirements
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.key_personnel.list_ld_controls
+  - uk.def.legal_fault.fm_indemnities_consistency
+  - uk.def.nonconformity.scope_and_priority
+  - uk.def.parties.calloff_specificity_crtpa
+  - uk.def.permit.authorisations_matrix
+  - uk.def.personal_injury.scope_and_el_insurance
+  - uk.def.personnel.coverage_ir35_awr
+  - uk.def.property.exclusions_title_risk
+  - uk.def.site.ownership_access_risk
+  - uk.def.specs.versioning_and_variations
+  - uk.def.subcontractor.flowdown_audit
+  - uk.def.supplied_software.scope_licence_escrow
+  - uk.def.tariff_code.classification
+  - uk.def.taxes.matrix_withholding_grossup
+  - uk.def.third_party.crtpa_alignment
+  - uk.def.trade_tariff.source_recency
+  - uk.def.tupe.eli_requirements
+  - uk.def.variation.gate
+  - uk.def.variation.order_contents
+  - uk.def.vat.registration_place_of_supply_zero_rating
+  - uk.def.vor.process
+  - uk.def.work.scope_boundary_interfaces
+  - uk.def.worksite.inclusion_exclusions
+  - uk.int.2_2_1a.xrefs_links_exist
+  - uk.int.2_2_1b.time_basis_calendar_vs_business
+  - uk.int.2_2_1c.number_gender_presumption
+  - uk.int.2_2_1d.including_is_without_limitation
+  - uk.int.2_2_1e.company_vs_Company_defined_term
+  - uk.int.2_2_1f.person_scope_broad
+  - uk.int.2_2_1g.dynamic_incorp_requires_variation
+  - uk.int.2_2_1h.approvals_in_writing_by_reps
+  - uk.int.2_2_1i.writing_email_esign_alignment
+  - uk.int.2_2_1j.calloff_incorporates_msa
+  - uk.int.2_2_1k.subcontracts_flowdown_audit
+  - uk.int.2_2_2.headings_no_effect
+  - uk.int.2_2_3.precedence_agreement_alpha_risk
+  - uk.int.2_2_4.precedence_calloff
+  - uk.int.2_2_5.ambiguity_pre_dr_checks
+  - uk.int.2_2_6.mutually_explanatory_scope_creep_guard
+  - uk.int.2_2_7.stringency_fitness_priority
+  - uk.master.term.extensions_notice
+  - uk.s3.order.channels_align_29
+  - uk.s4.reps.notice_channels_alignment
+  - uk_bribery_act_missing
+  - uk_ca_1985_outdated
+  - universal.inform.deemed_scope_clarity
+  weight: 1.0
+  required: false
+- zone_id: interpretation
+  zone_name: Interpretation
+  description: Rules of construction, severability, waiver and entire agreement boilerplate.
+  label_selectors:
+    any:
+    - entire_agreement
+    - interpretation
+    - remedies
+    - severance
+    - waiver
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P6.CONSTRUCTION_PAY_NOTICES
+  - cpi.register.exhaustive_list
+  - gl_jurisdiction_conflict
+  - subcontracts.ban_pay_when_paid
+  - uk.int.2_2_1a.xrefs_links_exist
+  - uk.int.2_2_1b.time_basis_calendar_vs_business
+  - uk.int.2_2_1c.number_gender_presumption
+  - uk.int.2_2_1d.including_is_without_limitation
+  - uk.int.2_2_1e.company_vs_Company_defined_term
+  - uk.int.2_2_1f.person_scope_broad
+  - uk.int.2_2_1g.dynamic_incorp_requires_variation
+  - uk.int.2_2_1h.approvals_in_writing_by_reps
+  - uk.int.2_2_1i.writing_email_esign_alignment
+  - uk.int.2_2_1j.calloff_incorporates_msa
+  - uk.int.2_2_1k.subcontracts_flowdown_audit
+  - uk.int.2_2_2.headings_no_effect
+  - uk.int.2_2_3.precedence_agreement_alpha_risk
+  - uk.int.2_2_4.precedence_calloff
+  - uk.int.2_2_5.ambiguity_pre_dr_checks
+  - uk.int.2_2_6.mutually_explanatory_scope_creep_guard
+  - uk.int.2_2_7.stringency_fitness_priority
+  - uk.master.recitals.no_operational_shall
+  - uk.s3.nullity.foreign_terms_3_13
+  - uk.s3.order.channels_align_29
+  - uk.s4.reps.notice_channels_alignment
+  weight: 1.0
+  required: false
+- zone_id: acceptance
+  zone_name: Acceptance & Testing
+  description: Acceptance testing, inspection rights and rejection procedures.
+  label_selectors:
+    any:
+    - acceptance_it
+    - acceptance_testing
+    - quality_control_qc
+    - service_levels_sla
+    - warranty_conformity
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.AUDIT.ISO19011
+  - 13.COST.NOSHOW_FAIL
+  - 13.EQUIP.CERT.LOLER_PUWER
+  - 13.HIDDEN.WORKS
+  - 13.INSPECT.NO_WAIVER
+  - 13.ITP.EXISTS
+  - 13.ITP.NOTICE
+  - 13.LAB.ISO17025
+  - 13.MARKING.UKCA_CE
+  - 13.MOC.FORMAL
+  - 13.QMS.ISO9001
+  - 13.QP.REQUIRED
+  - 13.SHIP.BLOCK
+  - ic.mutuality.moo.minimum_hours
+  - quality.costs.not_ready_or_repeat
+  - quality.equipment.certificates_pre_dispatch
+  - quality.equipment.site_tests_swl
+  - quality.no_ship_without_final_inspection
+  - title.rejection.return_reversion
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.nonconformity.scope_and_priority
+  - uk.def.property.exclusions_title_risk
+  - uk.s3.calloff.unacceptable_conditions_3_11
+  - uk.s3.order.acceptance_triggers_channels
+  - uk.s3.order.start_as_acceptance_guard
+  - universal.inform.physical_conditions_unforeseen
+  - universal.performance.document_control_handover
+  - universal.performance.inspection_acceptance_window
+  - universal.performance.site_ptw_partial_occupation
+  weight: 1.0
+  required: false
+- zone_id: delivery
+  zone_name: Delivery & Performance
+  description: Delivery logistics, risk transfer and packaging obligations.
+  label_selectors:
+    any:
+    - delivery
+    - delivery_terms_incoterms
+    - lead_times
+    - packaging_labelling
+    - risk_and_title
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.SHIP.BLOCK
+  - VARIATIONS.TIMEBAR_IMMEDIATE_OFFSHORE_3D
+  - cpi.ccc.insurance.cover_required
+  - ic.status.control.methods
+  - ic.substitution.absent_or_personal_service
+  - ipr.agreement_docs_title.company
+  - quality.no_ship_without_final_inspection
+  - risk_structure
+  - subcontracts.flowdown_minimum_set
+  - title.clean.free_of_liens
+  - title.commingling.bulk_processing
+  - title.customs.ior_alignment
+  - title.delivery_up.access_right
+  - title.embedded_software.perpetual_licence
+  - title.marking.register.audit
+  - title.rejection.return_reversion
+  - title.risk.cross_reference
+  - title.vesting.early_wip_offsite
+  - title.waivers.third_party_liens
+  - uk.def.bipr.perimeter_and_license
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.property.exclusions_title_risk
+  - uk.def.site.ownership_access_risk
+  - uk.def.subcontractor.flowdown_audit
+  - uk.def.supplied_software.scope_licence_escrow
+  - uk.def.taxes.matrix_withholding_grossup
+  - uk.def.variation.order_contents
+  - uk.def.vor.process
+  - uk.def.worksite.inclusion_exclusions
+  - uk.int.2_2_1i.writing_email_esign_alignment
+  - uk.int.2_2_3.precedence_agreement_alpha_risk
+  - uk.master.term.extensions_notice
+  - universal.inform.physical_conditions_unforeseen
+  - universal.inform.resources_breakdown_carveouts
+  - universal.inform.transport_employer_items
+  - universal.performance.goods_software_incoterms
+  - universal.performance.inspection_acceptance_window
+  - universal.performance.materials_management
+  - universal.performance.rental_equipment
+  - universal.performance.reporting_early_warning
+  weight: 1.0
+  required: false
+- zone_id: service_levels
+  zone_name: Service Levels & Credits
+  description: Service level metrics, uptime, support and service credits.
+  label_selectors:
+    any:
+    - quality_control_qc
+    - saas_uptime
+    - service_credits
+    - service_levels_sla
+    - support_maintenance
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ic.mutuality.moo.minimum_hours
+  - uk.calloff.formation_by_performance_controls
+  - uk.s3.order.acceptance_triggers_channels
+  - uk.s3.order.start_as_acceptance_guard
+  - uk.s3.po.exclude_supplier_terms
+  - uk.s3.po.per_entity_responsibility
+  - uk.s4.ctr.change_consent_sla
+  - universal.inform.deemed_scope_clarity
+  - universal.inform.implied_scope_limit
+  - universal.performance.cooperate_eot
+  - universal.performance.document_control_handover
+  - universal.performance.exhibits_policies_conflicts
+  - universal.performance.goods_software_incoterms
+  - universal.performance.inspection_acceptance_window
+  - universal.performance.instructions_variation_gate
+  - universal.performance.materials_management
+  - universal.performance.permits_rtw
+  - universal.performance.rental_equipment
+  - universal.performance.reporting_early_warning
+  - universal.performance.resources_sufficiency
+  - universal.performance.rsc_vs_ffp_priority
+  - universal.performance.schedule_recovery
+  - universal.performance.site_ptw_partial_occupation
+  - universal.performance.working_hours_overtime
+  weight: 1.0
+  required: false
+- zone_id: price_adjustment
+  zone_name: Price Adjustments
+  description: Indexation, benchmarking, open book pricing and most favoured terms.
+  label_selectors:
+    any:
+    - most_favoured_customer
+    - open_book_pricing
+    - price_changes_indexation
+    - rate_card
+    - usage_limits
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P1.ALL_INCLUSIVE_RATES
+  - VARIATIONS.RATE_IMMUTABILITY_BASELINE
+  - VARIATIONS.RATE_PARITY_CPA
+  - uk.calloff.minimum_content
+  - uk.def.variation.gate
+  - uk.def.variation.order_contents
+  - uk.int.2_2_1j.calloff_incorporates_msa
+  - uk.s3.calloff.minimum_contents
+  - uk.s3.ld.parameters_case_law
+  - uk.s4.instructions.trigger_vo
+  - universal.inform.deemed_pricing_voeot
+  - universal.performance.cooperate_eot
+  weight: 1.0
+  required: false
+- zone_id: interest_late
+  zone_name: Late Payment Interest
+  description: Interest regimes, statutory remedies and payment enforcement.
+  label_selectors:
+    any:
+    - late_payment_interest
+    - payment_terms
+    - service_credits
+    - set_off
+    - taxes_vat
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.EQUIP.CERT.LOLER_PUWER
+  - P11.NO_PAY_IDLE_EFFICIENCY
+  - P12.RECEIVABLES_ASSIGNMENT_PERMITTED
+  - P3.LATE_INVOICE_TIMEBAR
+  - P4.PAYMENT_TERMS_AND_INTEREST
+  - P5.PUBLIC_30DAYS_CASCADE
+  - P6.CONSTRUCTION_PAY_NOTICES
+  - P7.SETOFF_SCOPE
+  - P8.PAY_UNDISPUTED
+  - cpi.receipt.notice_window.latent
+  - gl_jurisdiction_conflict
+  - payment_terms_basic
+  - subcontracts.data_protection_art28
+  - subcontracts.step_in_third_party_alignment
+  - uk.def.invitee.scope_and_exclusions
+  - uk.def.nonconformity.scope_and_priority
+  - uk.def.trade_tariff.source_recency
+  - uk.int.2_2_1g.dynamic_incorp_requires_variation
+  - uk.int.2_2_1h.approvals_in_writing_by_reps
+  - uk.master.supplemental.priority
+  - uk.s3.calloff.contract_execution_authority
+  - uk.s3.nullity.foreign_terms_3_13
+  - uk.s4.instructions.trigger_vo
+  - uk_ca_1985_outdated
+  - uk_dpa_1998_outdated
+  - uk_poca_tipping_off
+  - universal.inform.physical_conditions_unforeseen
+  - universal.performance.document_control_handover
+  - universal.performance.schedule_recovery
+  weight: 1.0
+  required: true
+- zone_id: change_control
+  zone_name: Change Control
+  description: Change request procedures, variation mechanics and approvals.
+  label_selectors:
+    any:
+    - change_control
+    - change_management_it
+    - construction_programme
+    - construction_variations
+    - variation
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.ITP.EXISTS
+  - 13.LAB.ISO17025
+  - 13.MOC.FORMAL
+  - VARIATIONS.CHANGE_IN_LAW_TAXES_BUSINESS_EXCLUDED
+  - VARIATIONS.CONTRACTOR_INITIATED_LIMITED
+  - VARIATIONS.DISAGREE_PROCEED_NO_COND_SIGN
+  - VARIATIONS.MITIGATION_DUTY
+  - VARIATIONS.NOM_ONLY
+  - VARIATIONS.RATE_IMMUTABILITY_BASELINE
+  - VARIATIONS.RATE_PARITY_CPA
+  - VARIATIONS.TIMEBAR_IMMEDIATE_OFFSHORE_3D
+  - VARIATIONS.VOR_5BD
+  - VARIATIONS.WAIVER_CUMULATIVE_CARDINAL
+  - cpi.export.controls.sanctions
+  - cpi.use.only.for.project
+  - cpi.waste.disposal.duty_of_care
+  - ic.hse.carveout.required
+  - ic.ir35.offpayroll.sds_process
+  - ic.removal.right.objective_non_discrimination
+  - ipr.source_code.escrow
+  - quality.moc.qms_changes
+  - subcontracts.prior_consent
+  - subcontracts.step_in_third_party_alignment
+  - uk.def.legal_fault.fm_indemnities_consistency
+  - uk.def.parties.calloff_specificity_crtpa
+  - uk.def.specs.versioning_and_variations
+  - uk.def.supplied_software.scope_licence_escrow
+  - uk.def.third_party.crtpa_alignment
+  - uk.def.variation.gate
+  - uk.def.variation.order_contents
+  - uk.def.vor.process
+  - uk.def.work.scope_boundary_interfaces
+  - uk.int.2_2_1a.xrefs_links_exist
+  - uk.int.2_2_1c.number_gender_presumption
+  - uk.int.2_2_1g.dynamic_incorp_requires_variation
+  - uk.int.2_2_1i.writing_email_esign_alignment
+  - uk.int.2_2_6.mutually_explanatory_scope_creep_guard
+  - uk.int.2_2_7.stringency_fitness_priority
+  - uk.master.exhibitj.deed_formalities
+  - uk.master.incorp.dynamic_refs_change_control
+  - uk.s3.coventurers.agent_model_cap
+  - uk.s3.editorial.typos_numbering_block
+  - uk.s3.ld.parameters_case_law
+  - uk.s3.po.per_entity_responsibility
+  - uk.s4.cr.appointment_and_scope
+  - uk.s4.cr.nom_shield
+  - uk.s4.ctr.change_consent_sla
+  - uk.s4.instructions.trigger_vo
+  - uk.s4.reps.notice_channels_alignment
+  - universal.inform.deemed_laws_change
+  - universal.inform.deemed_pricing_voeot
+  - universal.inform.discrepancy_notice_timebar
+  - universal.inform.employer_corrects_variation
+  - universal.inform.implied_scope_limit
+  - universal.inform.notice_formalities
+  - universal.inform.physical_conditions_unforeseen
+  - universal.inform.stop_work_on_conflict
+  - universal.performance.instructions_variation_gate
+  - variations
+  weight: 1.0
+  required: false
+- zone_id: audit_records
+  zone_name: Audit & Records
+  description: Audit rights, record keeping and back-to-back compliance.
+  label_selectors:
+    any:
+    - audit_rights
+    - dp_audit
+    - dp_back_to_back
+    - dp_records_of_processing
+    - records_retention
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.AUDIT.ISO19011
+  - 13.COST.NOSHOW_FAIL
+  - 13.EQUIP.CERT.LOLER_PUWER
+  - 13.HIDDEN.WORKS
+  - 13.INSPECT.NO_WAIVER
+  - 13.ITP.EXISTS
+  - 13.ITP.NOTICE
+  - 13.LAB.ISO17025
+  - 13.MARKING.UKCA_CE
+  - 13.MOC.FORMAL
+  - 13.QMS.ISO9001
+  - 13.QP.REQUIRED
+  - 13.SHIP.BLOCK
+  - audit
+  - ic.medical.data.minimisation
+  - quality.audit.iso19011
+  - quality.no_ship_without_final_inspection
+  - subcontracts.copies_audit_rights
+  - subcontracts.flowdown_minimum_set
+  - title.delivery_up.access_right
+  - uk.def.bribe.ukba_poca_fcpa
+  - uk.def.site.ownership_access_risk
+  - uk.def.subcontractor.flowdown_audit
+  - uk.int.2_2_1k.subcontracts_flowdown_audit
+  - universal.performance.inspection_acceptance_window
+  weight: 1.0
+  required: false
+- zone_id: survival
+  zone_name: Survival & Exit
+  description: Clauses surviving termination, exit assistance and post-termination
+    obligations.
+  label_selectors:
+    any:
+    - dp_retention_deletion
+    - records_retention
+    - return_or_destruction
+    - survival
+    - termination_assistance
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - termination_cause
+  - termination_convenience
+  - termination_notice_basic
+  - title.embedded_software.perpetual_licence
+  - uk.def.bribe.ukba_poca_fcpa
+  - uk.master.term.extensions_notice
+  - uk.s3.ld.parameters_case_law
+  - uk.s3.po.exclude_supplier_terms
+  - uk.s3.po.per_entity_responsibility
+  weight: 1.0
+  required: false
+- zone_id: personnel
+  zone_name: Personnel & Conduct
+  description: Key personnel, onboarding, vetting and conduct expectations.
+  label_selectors:
+    any:
+    - conflicts_of_interest
+    - equality_diversity
+    - modern_slavery
+    - nhs_safeguarding
+    - onboarding_migration
+    - staff_vetting
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ic.removal.right.objective_non_discrimination
+  - ic.status.control.methods
+  - ic.substitution.absent_or_personal_service
+  - ipr.bg.licence.conflict
+  - uk.def.key_personnel.list_ld_controls
+  - uk.def.personnel.coverage_ir35_awr
+  - uk.def.tupe.eli_requirements
+  - uk_dpa_1998_outdated
+  - universal.inform.resources_breakdown_carveouts
+  - universal.performance.resources_sufficiency
+  - universal.personnel.gdpr_personnel_data
+  weight: 1.0
+  required: false
+- zone_id: cross_refs
+  zone_name: Cross References
+  description: References to other documents, transparency and publication duties.
+  label_selectors:
+    any:
+    - entire_agreement
+    - foi
+    - remedies
+    - third_party_rights
+    - transparency_publication
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - cpi.storage.lifting.loler_puwer
+  - uk.calloff.exclude_other_terms
+  - uk.calloff.minimum_content
+  - uk.def.variation.gate
+  - uk.def.variation.order_contents
+  - uk.int.2_2_1a.xrefs_links_exist
+  - uk.s3.calloff.minimum_contents
+  - uk.s3.ld.parameters_case_law
+  - uk.s4.instructions.trigger_vo
+  - universal.inform.deemed_scope_clarity
+  - universal.performance.cooperate_eot
+  - universal.performance.exhibits_policies_conflicts
+  - universal.performance.schedule_recovery
+  weight: 1.0
+  required: false
+- zone_id: warranties
+  zone_name: Warranties
+  description: Warranty scope, remedies, IP non-infringement and DOA/RMA processes.
+  label_selectors:
+    any:
+    - quality_control_qc
+    - remedies
+    - warranty_conformity
+    - warranty_doas_rma
+    - warranty_ip_noninfringe
+    - warranty_performance
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.INSPECT.NO_WAIVER
+  - cpi.receipt.notice_window.latent
+  - subcontracts.step_in_third_party_alignment
+  - uk.def.nonconformity.scope_and_priority
+  - uk.def.variation.order_contents
+  - uk.s3.editorial.typos_numbering_block
+  - uk.s3.ld.only_remedy_gates
+  - universal.performance.materials_management
+  - warranty
+  weight: 1.0
+  required: false
+- zone_id: quality
+  zone_name: Quality & Standards
+  description: Quality assurance, inspections, programme management and technical
+    standards.
+  label_selectors:
+    any:
+    - construction_defects_liability
+    - construction_eot
+    - construction_programme
+    - construction_retention
+    - construction_variations
+    - quality_control_qc
+    - spares_obsolescence
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - 13.AUDIT.ISO19011
+  - 13.COST.NOSHOW_FAIL
+  - 13.EQUIP.CERT.LOLER_PUWER
+  - 13.HIDDEN.WORKS
+  - 13.INSPECT.NO_WAIVER
+  - 13.ITP.EXISTS
+  - 13.ITP.NOTICE
+  - 13.LAB.ISO17025
+  - 13.MARKING.UKCA_CE
+  - 13.MOC.FORMAL
+  - 13.QMS.ISO9001
+  - 13.QP.REQUIRED
+  - 13.SHIP.BLOCK
+  - cpi.receipt.notice_window.latent
+  - quality.audit.iso19011
+  - quality.company.rights.reject_nonconforming
+  - quality.costs.not_ready_or_repeat
+  - quality.equipment.certificates_pre_dispatch
+  - quality.equipment.site_tests_swl
+  - quality.hidden_work_prove_compliance
+  - quality.itp.hw_notice_5d
+  - quality.itp.required
+  - quality.moc.qms_changes
+  - quality.no_ship_without_final_inspection
+  - quality.qms.iso_required
+  - quality.qp.iso10005.required
+  - uk.def.nonconformity.scope_and_priority
+  - uk.s3.editorial.typos_numbering_block
+  - universal.performance.inspection_acceptance_window
+  weight: 1.0
+  required: false
+- zone_id: health_safety
+  zone_name: Health & Safety
+  description: Health and safety duties, hazardous materials controls and serious
+    incident handling.
+  label_selectors:
+    any:
+    - construction_health_safety_cdm
+    - hazardous_substances
+    - health_and_safety
+    - nhs_safeguarding
+    - nhs_serious_incident
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - cpi.incident.loss.damage.reporting
+  - uk.s4.hse.stop_work_authority
+  - universal.inform.implied_scope_limit
+  - universal.inform.stop_work_on_conflict
+  weight: 1.0
+  required: false
+- zone_id: compliance_abac
+  zone_name: Compliance & ABAC
+  description: Anti-bribery, tax evasion, modern slavery and ethical compliance.
+  label_selectors:
+    any:
+    - anti_bribery
+    - anti_tax_evasion
+    - conflicts_of_interest
+    - equality_diversity
+    - modern_slavery
+    - sanctions_export_controls
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ic.mutuality.moo.minimum_hours
+  - quality.hidden_work_prove_compliance
+  - subcontracts.flowdown_minimum_set
+  - uk.def.bribe.ukba_poca_fcpa
+  - uk.def.ior.calloff_requirements
+  - uk.def.permit.authorisations_matrix
+  - uk.def.subcontractor.flowdown_audit
+  - uk.int.2_2_1k.subcontracts_flowdown_audit
+  - uk_bribery_act_missing
+  - universal.inform.deemed_laws_change
+  - universal.inform.stop_work_on_conflict
+  - universal.performance.materials_management
+  weight: 1.0
+  required: false
+- zone_id: change_of_control
+  zone_name: Change of Control
+  description: Change of control triggers, operator provisions and joint operating
+    agreement controls.
+  label_selectors:
+    any:
+    - joa_default_nonconsent
+    - joa_marketing
+    - joa_opcom
+    - joa_operator
+    - joa_work_program_budget
+    - termination_change_of_control
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt: []
+  weight: 1.0
+  required: false
+- zone_id: background_ip
+  zone_name: Background IP
+  description: Pre-existing IP rights, tooling and retained ownership provisions.
+  label_selectors:
+    any:
+    - joa_authorisation_for_expenditure
+    - joa_work_program_budget
+    - license_grant
+    - title_retention_rot
+    - tooling
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ipr.bg.licence.conflict
+  weight: 1.0
+  required: false
+- zone_id: foreground_ip
+  zone_name: Foreground IP
+  description: Developed IP ownership, indemnities and allocation in joint ventures.
+  label_selectors:
+    any:
+    - ip_indemnity
+    - ip_ownership
+    - joa_joint_accounting
+    - joa_marketing
+    - joa_operator
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ipr.fg.licence.scope
+  - subcontracts.flowdown_minimum_set
+  - uk.def.bipr.perimeter_and_license
+  - uk.def.indemnify.controls_and_negligence
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.subcontractor.flowdown_audit
+  - uk.def.supplied_software.scope_licence_escrow
+  - uk.def.work.scope_boundary_interfaces
+  - uk.s3.po.per_entity_responsibility
+  - universal.performance.rsc_vs_ffp_priority
+  weight: 1.0
+  required: false
+- zone_id: records_retention
+  zone_name: Records & Retention
+  description: Retention periods, localisation and destruction routines for records.
+  label_selectors:
+    any:
+    - dp_localisation
+    - dp_records_of_processing
+    - dp_retention_deletion
+    - records_retention
+    - return_or_destruction
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ic.medical.data.minimisation
+  - subcontracts.flowdown_minimum_set
+  weight: 1.0
+  required: false
+- zone_id: limitation_periods
+  zone_name: Limitation Periods
+  description: Limitation periods, carve outs and long-stop dates for claims.
+  label_selectors:
+    any:
+    - liability_cap_amount
+    - liability_carveouts
+    - limitation_of_liability
+    - liquidated_damages
+    - remedies
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P3.LATE_INVOICE_TIMEBAR
+  - VARIATIONS.TIMEBAR_IMMEDIATE_OFFSHORE_3D
+  - VARIATIONS.WAIVER_CUMULATIVE_CARDINAL
+  - cpi.no_lien.required
+  - liability_cap
+  - uk.def.ipclaim.mechanics_and_carveouts
+  - uk.s4.cr.apparent_authority_controls
+  - uk_fraud_exclusion_invalid
+  - uk_ucta_2_1_invalid
+  - universal.inform.discrepancy_notice_timebar
+  - universal.inform.employer_info_nonreliance
+  - universal.inform.notice_formalities
+  weight: 1.0
+  required: false
+- zone_id: setoff_withholding
+  zone_name: Set-off & Withholding
+  description: Rights to set-off, netting and withholding across accounts.
+  label_selectors:
+    any:
+    - anti_tax_evasion
+    - payment_security
+    - payment_terms
+    - set_off
+    - taxes_vat
+    all: []
+    none: []
+  entity_selectors:
+    amounts: true
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P10.REIMBURSABLES_NET_OF_REBATES
+  - P7.SETOFF_SCOPE
+  - uk.def.key_personnel.list_ld_controls
+  - uk.def.taxes.matrix_withholding_grossup
+  - uk.def.work.scope_boundary_interfaces
+  - uk.s3.editorial.typos_numbering_block
+  - uk.s3.ld.only_remedy_gates
+  - uk.s3.ld.parameters_case_law
+  weight: 1.0
+  required: false
+- zone_id: export_controls_sanctions
+  zone_name: Export Controls & Sanctions
+  description: Sanctions screening, export controls and trade compliance.
+  label_selectors:
+    any:
+    - anti_bribery
+    - anti_tax_evasion
+    - foi
+    - modern_slavery
+    - sanctions_export_controls
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - cpi.export.controls.sanctions
+  - export_hmrc
+  - subcontracts.flowdown_minimum_set
+  - uk.def.subcontractor.flowdown_audit
+  - uk.def.tariff_code.classification
+  - uk.def.trade_tariff.source_recency
+  - uk.s3.po.exclude_supplier_terms
+  - uk.s3.po.per_entity_responsibility
+  weight: 1.0
+  required: false
+- zone_id: escrow_source_code
+  zone_name: Source Code Escrow
+  description: Escrow arrangements, release events and contingency tooling.
+  label_selectors:
+    any:
+    - backup_restore
+    - business_continuity_bcp
+    - disaster_recovery
+    - escrow
+    - tooling
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - ipr.source_code.escrow
+  - uk.def.supplied_software.scope_licence_escrow
+  - uk.s3.po.exclude_supplier_terms
+  - uk.s3.po.per_entity_responsibility
+  weight: 1.0
+  required: false
+- zone_id: step_in_rights
+  zone_name: Step-in Rights
+  description: Step-in triggers, remediation and continuity of services.
+  label_selectors:
+    any:
+    - business_continuity_bcp
+    - disaster_recovery
+    - nhs_step_in
+    - step_in_rights
+    - support_maintenance
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - subcontracts.step_in_third_party_alignment
+  - uk.s3.ld.only_remedy_gates
+  weight: 1.0
+  required: false
+- zone_id: novation
+  zone_name: Novation & Transfer
+  description: Novation mechanics, consents and successor obligations.
+  label_selectors:
+    any:
+    - assignment
+    - joa_assignment_consent
+    - tenancy_assignment_underlet
+    - termination_change_of_control
+    - third_party_rights
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: false
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - P12.RECEIVABLES_ASSIGNMENT_PERMITTED
+  - assignment
+  - subcontracts.step_in_third_party_alignment
+  - uk.def.ior.calloff_requirements
+  - uk.def.iprights.coverage_and_moral_rights
+  - uk.def.vat.registration_place_of_supply_zero_rating
+  - universal.inform.transport_employer_items
+  weight: 1.0
+  required: false
+- zone_id: non_solicit_non_compete
+  zone_name: Non-solicit & Non-compete
+  description: Non-solicitation, restrictive covenants and safeguarding obligations.
+  label_selectors:
+    any:
+    - conflicts_of_interest
+    - equality_diversity
+    - nhs_safeguarding
+    - non_solicitation
+    - staff_vetting
+    all: []
+    none: []
+  entity_selectors:
+    amounts: false
+    durations: true
+    jurisdiction: false
+    law: false
+  rule_ids_opt:
+  - uk.s3.po.exclude_supplier_terms
+  - uk.s3.po.per_entity_responsibility
+  weight: 1.0
+  required: false

--- a/contract_review_app/legal_rules/coverage_zones.py
+++ b/contract_review_app/legal_rules/coverage_zones.py
@@ -1,0 +1,502 @@
+"""Zone metadata and curation hints for the coverage map."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, FrozenSet, Mapping, Tuple
+
+
+@dataclass(frozen=True)
+class ZoneSeed:
+    """Declarative seed configuration for a coverage zone."""
+
+    zone_id: str
+    zone_name: str
+    description: str
+    label_hints: Tuple[str, ...]
+    rule_hints: Tuple[str, ...]
+    entity_selectors: Mapping[str, bool]
+    weight: float = 1.0
+    required: bool = False
+    high_importance: bool = False
+
+
+ZONE_SEED_DATA: Tuple[ZoneSeed, ...] = (
+    ZoneSeed(
+        zone_id="payment",
+        zone_name="Payment & Invoicing",
+        description=(
+            "Payment obligations, invoicing mechanics, withholding and set-off "
+            "controls."
+        ),
+        label_hints=(
+            "payment_terms",
+            "payment_security",
+            "late_payment_interest",
+            "service_credits",
+            "set_off",
+            "taxes_vat",
+            "open_book_pricing",
+            "rate_card",
+        ),
+        rule_hints=(
+            "payment",
+            "invoice",
+            "billing",
+            "withhold",
+            "set-off",
+            "credit",
+            "vat",
+        ),
+        entity_selectors={"amounts": True, "durations": True, "law": False, "jurisdiction": False},
+        weight=1.0,
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="term",
+        zone_name="Term & Renewal",
+        description="Contract duration, renewal cycles and suspension windows.",
+        label_hints=("term", "renewal_auto", "suspension", "usage_limits", "survival"),
+        rule_hints=("term", "renewal", "duration", "expiry", "extension"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="termination",
+        zone_name="Termination Rights",
+        description="Termination for breach, convenience, insolvency and related cure steps.",
+        label_hints=(
+            "termination_breach",
+            "termination_convenience",
+            "termination_insolvency",
+            "termination_assistance",
+            "termination_change_of_control",
+        ),
+        rule_hints=("terminate", "termination", "cure", "for cause", "for convenience"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="notices",
+        zone_name="Notices",
+        description="Service of notices, delivery methods and notice periods.",
+        label_hints=("notices", "foi", "lead_times", "escalation", "service_levels_sla"),
+        rule_hints=("notice", "notification", "address", "served", "service"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="governing_law",
+        zone_name="Governing Law",
+        description="Choice of law, statutory references and conflict rules.",
+        label_hints=(
+            "governing_law",
+            "severance",
+            "waiver",
+            "entire_agreement",
+            "third_party_rights",
+            "remedies",
+        ),
+        rule_hints=("law", "governed", "statute", "jurisdiction", "governing"),
+        entity_selectors={"amounts": False, "durations": False, "law": True, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="jurisdiction",
+        zone_name="Jurisdiction & Forum",
+        description="Courts, venues and escalation forums for disputes.",
+        label_hints=("jurisdiction", "dispute_resolution", "arbitration", "mediation", "escalation"),
+        rule_hints=("jurisdiction", "forum", "court", "venue", "seat", "arbitration"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": True},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="dispute_resolution",
+        zone_name="Dispute Resolution",
+        description="Mediation, arbitration and escalation procedures.",
+        label_hints=("dispute_resolution", "arbitration", "mediation", "escalation", "foi"),
+        rule_hints=("dispute", "escalation", "arbitration", "mediation", "adr"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="liability_cap",
+        zone_name="Liability & Caps",
+        description="Limitation of liability, carve outs and capped exposure.",
+        label_hints=(
+            "limitation_of_liability",
+            "liability_cap_amount",
+            "liability_carveouts",
+            "indirect_consequential_exclusion",
+            "liquidated_damages",
+            "deductibles_limits",
+        ),
+        rule_hints=("liability", "cap", "carve", "indirect", "consequential", "liquidated"),
+        entity_selectors={"amounts": True, "durations": False, "law": False, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="indemnity",
+        zone_name="Indemnities",
+        description="Scope of indemnities, defence obligations and exclusions.",
+        label_hints=("indemnity_general", "ip_indemnity", "dp_indemnity", "waiver_of_subrogation", "insurance_requirements"),
+        rule_hints=("indemn", "hold harmless", "defence", "defense", "third party claim"),
+        entity_selectors={"amounts": True, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="confidentiality",
+        zone_name="Confidentiality & Publicity",
+        description="Confidential information handling, permitted disclosures and publicity.",
+        label_hints=(
+            "confidentiality",
+            "nhs_patient_confidentiality",
+            "permitted_disclosures",
+            "return_or_destruction",
+            "announcements_publicity",
+            "transparency_publication",
+        ),
+        rule_hints=("confidential", "nda", "non-disclosure", "publicity", "announcement", "disclosure"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="ip",
+        zone_name="Intellectual Property",
+        description="IP ownership, licensing, infringement indemnities and tooling.",
+        label_hints=("ip_ownership", "license_grant", "ip_indemnity", "open_source", "tooling", "title_retention_rot"),
+        rule_hints=("intellectual", "ip", "license", "licence", "ownership", "infringe", "tooling"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="data_protection",
+        zone_name="Data Protection",
+        description="GDPR roles, processing instructions, breach notification and sub-processing.",
+        label_hints=(
+            "dp_general",
+            "dp_roles",
+            "dp_breach_notification",
+            "dp_security_measures",
+            "dp_subprocessing",
+            "dp_retention_deletion",
+            "dp_records_of_processing",
+            "dp_localisation",
+            "dp_dpia",
+            "dp_dsr",
+        ),
+        rule_hints=("data", "gdpr", "processor", "controller", "breach", "personal data", "processing"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="insurance",
+        zone_name="Insurance Requirements",
+        description="Insurance coverage, certificates, limits and waivers.",
+        label_hints=(
+            "insurance_requirements",
+            "insurance_types_limits",
+            "waiver_of_subrogation",
+            "deductibles_limits",
+            "business_continuity_bcp",
+        ),
+        rule_hints=("insurance", "policy", "coverage", "certificate", "indemnity", "waiver"),
+        entity_selectors={"amounts": True, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="force_majeure",
+        zone_name="Force Majeure",
+        description="Force majeure events, mitigation, suspension rights and continuity planning.",
+        label_hints=(
+            "force_majeure",
+            "business_continuity_bcp",
+            "disaster_recovery",
+            "backup_restore",
+            "suspension",
+            "step_in_rights",
+        ),
+        rule_hints=("force majeure", "fm", "beyond control", "suspension", "continuity"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="taxes",
+        zone_name="Taxes & Withholding",
+        description="Indirect taxes, gross-up mechanics and anti-avoidance obligations.",
+        label_hints=("taxes_vat", "anti_tax_evasion", "price_changes_indexation", "set_off", "payment_terms"),
+        rule_hints=("tax", "vat", "withhold", "gross", "hmrc", "taxation"),
+        entity_selectors={"amounts": True, "durations": False, "law": False, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="assignment",
+        zone_name="Assignment",
+        description="Assignment restrictions, consent requirements and transfers.",
+        label_hints=("assignment", "joa_assignment_consent", "tenancy_assignment_underlet", "third_party_rights", "title_retention_rot"),
+        rule_hints=("assign", "transfer", "assignment", "consent", "delegate"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="subcontracting",
+        zone_name="Subcontracting & Flow-down",
+        description="Subcontract approvals, flow-down obligations and sub-processor controls.",
+        label_hints=("subcontracting", "subprocessor_approval", "dp_subprocessing", "support_maintenance", "staff_vetting"),
+        rule_hints=("subcontract", "sub-contractor", "flow down", "subprocessor", "delegate"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="order_of_precedence",
+        zone_name="Order of Precedence",
+        description="Hierarchy between contract documents and precedence clauses.",
+        label_hints=("entire_agreement", "remedies", "third_party_rights", "waiver", "severance"),
+        rule_hints=("precedence", "order", "hierarchy", "conflict", "govern"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="definitions",
+        zone_name="Definitions",
+        description="Defined terms, parties and interpretation aids.",
+        label_hints=("definitions", "parties", "interpretation", "entire_agreement", "remedies"),
+        rule_hints=("definition", "defined", "capitalised", "interpretation", "means"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="interpretation",
+        zone_name="Interpretation",
+        description="Rules of construction, severability, waiver and entire agreement boilerplate.",
+        label_hints=("interpretation", "entire_agreement", "severance", "waiver", "remedies"),
+        rule_hints=("interpret", "construction", "including", "shall", "boilerplate"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="acceptance",
+        zone_name="Acceptance & Testing",
+        description="Acceptance testing, inspection rights and rejection procedures.",
+        label_hints=("acceptance_testing", "acceptance_it", "quality_control_qc", "warranty_conformity", "service_levels_sla"),
+        rule_hints=("acceptance", "test", "inspection", "criteria", "rejection"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="delivery",
+        zone_name="Delivery & Performance",
+        description="Delivery logistics, risk transfer and packaging obligations.",
+        label_hints=("delivery", "delivery_terms_incoterms", "risk_and_title", "packaging_labelling", "lead_times"),
+        rule_hints=("deliver", "delivery", "shipment", "incoterm", "risk", "title"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="service_levels",
+        zone_name="Service Levels & Credits",
+        description="Service level metrics, uptime, support and service credits.",
+        label_hints=("service_levels_sla", "service_credits", "saas_uptime", "support_maintenance", "quality_control_qc"),
+        rule_hints=("service level", "sla", "uptime", "response", "service credit", "performance"),
+        entity_selectors={"amounts": True, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="price_adjustment",
+        zone_name="Price Adjustments",
+        description="Indexation, benchmarking, open book pricing and most favoured terms.",
+        label_hints=("price_changes_indexation", "open_book_pricing", "rate_card", "most_favoured_customer", "usage_limits"),
+        rule_hints=("price", "index", "benchmark", "open book", "mfn", "rate"),
+        entity_selectors={"amounts": True, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="interest_late",
+        zone_name="Late Payment Interest",
+        description="Interest regimes, statutory remedies and payment enforcement.",
+        label_hints=("late_payment_interest", "payment_terms", "service_credits", "taxes_vat", "set_off"),
+        rule_hints=("late", "interest", "statutory", "late payment", "boe", "8%"),
+        entity_selectors={"amounts": True, "durations": False, "law": False, "jurisdiction": False},
+        required=True,
+        high_importance=True,
+    ),
+    ZoneSeed(
+        zone_id="change_control",
+        zone_name="Change Control",
+        description="Change request procedures, variation mechanics and approvals.",
+        label_hints=("change_control", "change_management_it", "variation", "construction_variations", "construction_programme"),
+        rule_hints=("change", "variation", "request", "cr", "change control"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="audit_records",
+        zone_name="Audit & Records",
+        description="Audit rights, record keeping and back-to-back compliance.",
+        label_hints=("audit_rights", "records_retention", "dp_audit", "dp_records_of_processing", "dp_back_to_back"),
+        rule_hints=("audit", "records", "inspection", "books", "access"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="survival",
+        zone_name="Survival & Exit",
+        description="Clauses surviving termination, exit assistance and post-termination obligations.",
+        label_hints=("survival", "termination_assistance", "records_retention", "return_or_destruction", "dp_retention_deletion"),
+        rule_hints=("survive", "survival", "post termination", "exit", "transition"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="personnel",
+        zone_name="Personnel & Conduct",
+        description="Key personnel, onboarding, vetting and conduct expectations.",
+        label_hints=("staff_vetting", "onboarding_migration", "equality_diversity", "conflicts_of_interest", "modern_slavery", "nhs_safeguarding"),
+        rule_hints=("personnel", "staff", "vet", "background", "conduct", "resources"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="cross_refs",
+        zone_name="Cross References",
+        description="References to other documents, transparency and publication duties.",
+        label_hints=("entire_agreement", "transparency_publication", "foi", "third_party_rights", "remedies"),
+        rule_hints=("reference", "schedule", "appendix", "publication", "transparency"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="warranties",
+        zone_name="Warranties",
+        description="Warranty scope, remedies, IP non-infringement and DOA/RMA processes.",
+        label_hints=("warranty_conformity", "warranty_performance", "warranty_ip_noninfringe", "warranty_doas_rma", "quality_control_qc", "remedies"),
+        rule_hints=("warranty", "warrant", "remedy", "defect", "non conform"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="quality",
+        zone_name="Quality & Standards",
+        description="Quality assurance, inspections, programme management and technical standards.",
+        label_hints=("quality_control_qc", "construction_defects_liability", "construction_programme", "construction_retention", "construction_eot", "construction_variations", "spares_obsolescence"),
+        rule_hints=("quality", "inspection", "programme", "retention", "defect"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="health_safety",
+        zone_name="Health & Safety",
+        description="Health and safety duties, hazardous materials controls and serious incident handling.",
+        label_hints=(
+            "health_and_safety",
+            "hazardous_substances",
+            "nhs_serious_incident",
+            "nhs_safeguarding",
+            "construction_health_safety_cdm",
+        ),
+        rule_hints=("health", "safety", "incident", "hazard", "cdm"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="compliance_abac",
+        zone_name="Compliance & ABAC",
+        description="Anti-bribery, tax evasion, modern slavery and ethical compliance.",
+        label_hints=("anti_bribery", "anti_tax_evasion", "modern_slavery", "equality_diversity", "sanctions_export_controls", "conflicts_of_interest"),
+        rule_hints=("compliance", "anti", "bribery", "corruption", "modern slavery", "ethical"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="change_of_control",
+        zone_name="Change of Control",
+        description="Change of control triggers, operator provisions and joint operating agreement controls.",
+        label_hints=("termination_change_of_control", "joa_operator", "joa_opcom", "joa_marketing", "joa_default_nonconsent", "joa_work_program_budget"),
+        rule_hints=("change of control", "coc", "operator", "joint operating", "default"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="background_ip",
+        zone_name="Background IP",
+        description="Pre-existing IP rights, tooling and retained ownership provisions.",
+        label_hints=("license_grant", "title_retention_rot", "tooling", "joa_work_program_budget", "joa_authorisation_for_expenditure"),
+        rule_hints=("background", "pre-existing", "tooling", "retained", "existing"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="foreground_ip",
+        zone_name="Foreground IP",
+        description="Developed IP ownership, indemnities and allocation in joint ventures.",
+        label_hints=("ip_ownership", "ip_indemnity", "joa_joint_accounting", "joa_marketing", "joa_operator"),
+        rule_hints=("foreground", "developed", "new ip", "joint", "work product"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="records_retention",
+        zone_name="Records & Retention",
+        description="Retention periods, localisation and destruction routines for records.",
+        label_hints=("records_retention", "dp_retention_deletion", "dp_records_of_processing", "return_or_destruction", "dp_localisation"),
+        rule_hints=("retention", "records", "destroy", "deletion", "archive"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="limitation_periods",
+        zone_name="Limitation Periods",
+        description="Limitation periods, carve outs and long-stop dates for claims.",
+        label_hints=("limitation_of_liability", "liability_cap_amount", "liability_carveouts", "liquidated_damages", "remedies"),
+        rule_hints=("limitation", "long stop", "claim", "time bar"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="setoff_withholding",
+        zone_name="Set-off & Withholding",
+        description="Rights to set-off, netting and withholding across accounts.",
+        label_hints=("set_off", "taxes_vat", "payment_terms", "payment_security", "anti_tax_evasion"),
+        rule_hints=("set-off", "setoff", "withhold", "net", "offset"),
+        entity_selectors={"amounts": True, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="export_controls_sanctions",
+        zone_name="Export Controls & Sanctions",
+        description="Sanctions screening, export controls and trade compliance.",
+        label_hints=("sanctions_export_controls", "anti_bribery", "anti_tax_evasion", "modern_slavery", "foi"),
+        rule_hints=("sanction", "export", "trade", "embargo", "ofac"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="escrow_source_code",
+        zone_name="Source Code Escrow",
+        description="Escrow arrangements, release events and contingency tooling.",
+        label_hints=("escrow", "backup_restore", "disaster_recovery", "business_continuity_bcp", "tooling"),
+        rule_hints=("escrow", "source code", "release", "deposit", "escrow agent"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="step_in_rights",
+        zone_name="Step-in Rights",
+        description="Step-in triggers, remediation and continuity of services.",
+        label_hints=("step_in_rights", "nhs_step_in", "business_continuity_bcp", "support_maintenance", "disaster_recovery"),
+        rule_hints=("step in", "remedy", "continuity", "intervene", "direct control"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="novation",
+        zone_name="Novation & Transfer",
+        description="Novation mechanics, consents and successor obligations.",
+        label_hints=("assignment", "joa_assignment_consent", "tenancy_assignment_underlet", "third_party_rights", "termination_change_of_control"),
+        rule_hints=("novation", "transfer", "assign", "successor", "replacement"),
+        entity_selectors={"amounts": False, "durations": False, "law": False, "jurisdiction": False},
+    ),
+    ZoneSeed(
+        zone_id="non_solicit_non_compete",
+        zone_name="Non-solicit & Non-compete",
+        description="Non-solicitation, restrictive covenants and safeguarding obligations.",
+        label_hints=("non_solicitation", "staff_vetting", "equality_diversity", "conflicts_of_interest", "nhs_safeguarding"),
+        rule_hints=("non solicit", "non-compete", "restraint", "poach", "restrictive"),
+        entity_selectors={"amounts": False, "durations": True, "law": False, "jurisdiction": False},
+    ),
+)
+
+
+ZONE_LABEL_ALLOWLIST: Dict[str, FrozenSet[str]] = {}
+ZONE_LABEL_BLACKLIST: Dict[str, FrozenSet[str]] = {}
+ZONE_RULE_BLACKLIST: Dict[str, FrozenSet[str]] = {}
+
+SERVICE_LABEL_IDS: FrozenSet[str] = frozenset()
+
+HIGH_IMPORTANCE_ZONES: FrozenSet[str] = frozenset(
+    seed.zone_id for seed in ZONE_SEED_DATA if seed.high_importance
+)
+
+ZONE_ENTITY_MATRIX: Dict[str, Dict[str, bool]] = {
+    seed.zone_id: dict(seed.entity_selectors) for seed in ZONE_SEED_DATA
+}
+

--- a/docs/coverage_map.md
+++ b/docs/coverage_map.md
@@ -13,7 +13,7 @@ zones:
     zone_name: "Payment & Invoicing"
     description: "Optional human readable text"
     label_selectors:
-      any: ["payment"]      # at least one required
+      any: ["payment_terms", "payment_security", "late_payment_interest", ...]
       all: []                # optional set of labels that must all match
       none: []               # optional labels that prevent a match
     entity_selectors:
@@ -21,15 +21,108 @@ zones:
       durations: false
       law: false
       jurisdiction: false
-    rule_ids_opt: ["pay_late_interest_v1"]  # optional related rules
+    rule_ids_opt: ["pay_late_interest_v1", ...]  # optional related rules
     weight: 1.0             # reserved for future weighting logic
-    required: true          # reserved for validation/UX rules
+    required: true          # zones we expect to always evaluate
 ```
 
 All label selectors are normalised with the same tokeniser used for L0 features.
 Aliases such as `governed_by` for `governing_law` are expanded automatically.
 
-## Loader
+## Zone catalogue
+
+The current catalogue contains 45 zones curated in
+[`coverage_zones.py`](../contract_review_app/legal_rules/coverage_zones.py).
+Each entry below lists the zone id, its intent and representative L0 labels used as selectors.
+
+- **payment — Payment & Invoicing**: payment_terms, payment_security, late_payment_interest, service_credits, set_off, taxes_vat, open_book_pricing, rate_card
+- **term — Term & Renewal**: term, renewal_auto, suspension, usage_limits, survival
+- **termination — Termination Rights**: termination_breach, termination_convenience, termination_insolvency, termination_assistance, termination_change_of_control
+- **notices — Notices**: notices, foi, lead_times, escalation, service_levels_sla
+- **governing_law — Governing Law**: governing_law, severance, waiver, entire_agreement, third_party_rights, remedies
+- **jurisdiction — Jurisdiction & Forum**: jurisdiction, dispute_resolution, arbitration, mediation, escalation
+- **dispute_resolution — Dispute Resolution**: dispute_resolution, arbitration, mediation, escalation, foi
+- **liability_cap — Liability & Caps**: limitation_of_liability, liability_cap_amount, liability_carveouts, indirect_consequential_exclusion, liquidated_damages, deductibles_limits
+- **indemnity — Indemnities**: indemnity_general, ip_indemnity, dp_indemnity, waiver_of_subrogation, insurance_requirements
+- **confidentiality — Confidentiality & Publicity**: confidentiality, nhs_patient_confidentiality, permitted_disclosures, return_or_destruction, announcements_publicity, transparency_publication
+- **ip — Intellectual Property**: ip_ownership, license_grant, ip_indemnity, open_source, tooling, title_retention_rot
+- **data_protection — Data Protection**: dp_general, dp_roles, dp_breach_notification, dp_security_measures, dp_subprocessing, dp_retention_deletion, dp_records_of_processing, dp_localisation, dp_dpia, dp_dsr
+- **insurance — Insurance Requirements**: insurance_requirements, insurance_types_limits, waiver_of_subrogation, deductibles_limits, business_continuity_bcp
+- **force_majeure — Force Majeure**: force_majeure, business_continuity_bcp, disaster_recovery, backup_restore, suspension, step_in_rights
+- **taxes — Taxes & Withholding**: taxes_vat, anti_tax_evasion, price_changes_indexation, set_off, payment_terms
+- **assignment — Assignment**: assignment, joa_assignment_consent, tenancy_assignment_underlet, third_party_rights, title_retention_rot
+- **subcontracting — Subcontracting & Flow-down**: subcontracting, subprocessor_approval, dp_subprocessing, support_maintenance, staff_vetting
+- **order_of_precedence — Order of Precedence**: entire_agreement, remedies, third_party_rights, waiver, severance
+- **definitions — Definitions**: definitions, parties, interpretation, entire_agreement, remedies
+- **interpretation — Interpretation**: interpretation, entire_agreement, severance, waiver, remedies
+- **acceptance — Acceptance & Testing**: acceptance_testing, acceptance_it, quality_control_qc, warranty_conformity, service_levels_sla
+- **delivery — Delivery & Performance**: delivery, delivery_terms_incoterms, risk_and_title, packaging_labelling, lead_times
+- **service_levels — Service Levels & Credits**: service_levels_sla, service_credits, saas_uptime, support_maintenance, quality_control_qc
+- **price_adjustment — Price Adjustments**: price_changes_indexation, open_book_pricing, rate_card, most_favoured_customer, usage_limits
+- **interest_late — Late Payment Interest**: late_payment_interest, payment_terms, service_credits, taxes_vat, set_off
+- **change_control — Change Control**: change_control, change_management_it, variation, construction_variations, construction_programme
+- **audit_records — Audit & Records**: audit_rights, records_retention, dp_audit, dp_records_of_processing, dp_back_to_back
+- **survival — Survival & Exit**: survival, termination_assistance, records_retention, return_or_destruction, dp_retention_deletion
+- **personnel — Personnel & Conduct**: staff_vetting, onboarding_migration, equality_diversity, conflicts_of_interest, modern_slavery, nhs_safeguarding
+- **cross_refs — Cross References**: entire_agreement, transparency_publication, foi, third_party_rights, remedies
+- **warranties — Warranties**: warranty_conformity, warranty_performance, warranty_ip_noninfringe, warranty_doas_rma, quality_control_qc, remedies
+- **quality — Quality & Standards**: quality_control_qc, construction_defects_liability, construction_programme, construction_retention, construction_eot, construction_variations, spares_obsolescence
+- **health_safety — Health & Safety**: health_and_safety, hazardous_substances, nhs_serious_incident, nhs_safeguarding, construction_health_safety_cdm
+- **compliance_abac — Compliance & ABAC**: anti_bribery, anti_tax_evasion, modern_slavery, equality_diversity, sanctions_export_controls, conflicts_of_interest
+- **change_of_control — Change of Control**: termination_change_of_control, joa_operator, joa_opcom, joa_marketing, joa_default_nonconsent, joa_work_program_budget
+- **background_ip — Background IP**: license_grant, title_retention_rot, tooling, joa_work_program_budget, joa_authorisation_for_expenditure
+- **foreground_ip — Foreground IP**: ip_ownership, ip_indemnity, joa_joint_accounting, joa_marketing, joa_operator
+- **records_retention — Records & Retention**: records_retention, dp_retention_deletion, dp_records_of_processing, return_or_destruction, dp_localisation
+- **limitation_periods — Limitation Periods**: limitation_of_liability, liability_cap_amount, liability_carveouts, liquidated_damages, remedies
+- **setoff_withholding — Set-off & Withholding**: set_off, taxes_vat, payment_terms, payment_security, anti_tax_evasion
+- **export_controls_sanctions — Export Controls & Sanctions**: sanctions_export_controls, anti_bribery, anti_tax_evasion, modern_slavery, foi
+- **escrow_source_code — Source Code Escrow**: escrow, backup_restore, disaster_recovery, business_continuity_bcp, tooling
+- **step_in_rights — Step-in Rights**: step_in_rights, nhs_step_in, business_continuity_bcp, support_maintenance, disaster_recovery
+- **novation — Novation & Transfer**: assignment, joa_assignment_consent, tenancy_assignment_underlet, third_party_rights, termination_change_of_control
+- **non_solicit_non_compete — Non-solicit & Non-compete**: non_solicitation, staff_vetting, equality_diversity, conflicts_of_interest, nhs_safeguarding
+
+## Auto-generation workflow
+
+`tools/coverage_seed_from_repo.py` rebuilds the YAML file from repository metadata. The script:
+
+1. Reads the canonical taxonomy (`LABELS_CANON`) and the declarative zone seeds in
+   [`coverage_zones.py`](../contract_review_app/legal_rules/coverage_zones.py).
+2. Matches label hints to existing L0 labels (with optional allow/deny lists) and
+   enumerates rules whose identifiers, clause types or packs align with the rule hints.
+3. Writes `coverage_map.yaml` and reports statistics:
+   - number of zones,
+   - percentage of labels used vs. the taxonomy,
+   - percentage of rules covered, and
+   - the top unused labels so curators can tighten gaps.
+
+Run the tool directly:
+
+```bash
+python tools/coverage_seed_from_repo.py            # write YAML and emit report
+python tools/coverage_seed_from_repo.py --dry-run  # show the generated YAML
+```
+
+The script is deterministic thanks to the curated hints and allow/deny lists. Manual
+adjustments should happen in `coverage_zones.py`, not in the YAML file.
+
+## Lint & thresholds
+
+`tools/coverage_map_lint.py` validates both schema and curation quality. In strict
+mode (`--strict` or `FEATURE_COVERAGE_LINT_STRICT=1`) the following thresholds are
+checked:
+
+- at least 30 zones in the map;
+- ≥80% of YAML rules appear in `rule_ids_opt` for some zone;
+- ≥70% of taxonomy labels (excluding service entries) are referenced by `label_selectors.any`;
+- each high-importance zone (`payment`, `liability_cap`, `confidentiality`, `data_protection`,
+  `governing_law`, `jurisdiction`, `dispute_resolution`, `force_majeure`, `notices`, `taxes`, `ip`)
+  has five or more label selectors; and
+- entity selectors in YAML match the curated matrix from `coverage_zones.py`.
+
+The lint report prints summary metrics and highlights the top unused labels to aid
+future tuning.
+
+## Loader and coverage computation
 
 `coverage_map.load_coverage_map()` reads the YAML file, validates the schema via
 Pydantic and returns a cached structure containing:
@@ -41,8 +134,6 @@ Pydantic and returns a cached structure containing:
 The loader is cached with `functools.lru_cache`. Use
 `coverage_map.invalidate_cache()` to reload the file in development.
 
-## Coverage computation
-
 `coverage_map.build_coverage()` aggregates L0 labels, entities and rule firing
 signals into a compact TRACE block. Inputs:
 
@@ -51,12 +142,9 @@ signals into a compact TRACE block. Inputs:
 - `triggered_rule_ids`: fired YAML rules, and
 - `rule_lookup`: optional map of rule metadata (for validation).
 
-The output is a dictionary compatible with `TRACE.add(..., "coverage", ...)`.
-Details are clamped to 50 zones and three segments per zone to keep TRACE small.
-Raw text snippets are removed during sanitisation.
+The output is compatible with `TRACE.add(..., "coverage", ...)`. Details are
+clamped to 50 zones and three segments per zone to keep TRACE small. Raw text
+snippets are removed during sanitisation.
 
-## Tooling
-
-`tools/coverage_map_lint.py` validates the YAML file and supports a strict mode via
-`--strict` or `FEATURE_COVERAGE_LINT_STRICT=1`. The strict mode asserts that the map
-contains at least 30 zones.
+Integration tests verify that the TRACE payload surfaces meaningful coverage on a
+mix of real contract fixtures and that the aggregation stays performant.

--- a/tests/integration/test_coverage_usefulness.py
+++ b/tests/integration/test_coverage_usefulness.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from math import ceil
+from pathlib import Path
+from typing import Sequence
+
+from tests.integration.test_trace_flag_bootstrap import (
+    _build_client,
+    _cleanup,
+    _headers,
+)
+
+FIXTURES = {
+    "services_combo": [Path("fixtures/contracts/mixed_sample.txt")],
+    "supply_combo": [
+        Path("fixtures/contracts/mixed_sample.txt"),
+        Path("fixtures/soft_no_goods_ins.txt"),
+        Path("fixtures/soft_no_flowdown.txt"),
+    ],
+    "compliance_combo": [
+        Path("fixtures/contracts/mixed_sample.txt"),
+        Path("fixtures/soft_mixed_warns.txt"),
+        Path("fixtures/soft_low_cgl.txt"),
+    ],
+}
+
+
+def _load_text(paths: Sequence[Path]) -> str:
+    return "\n\n".join(path.read_text(encoding="utf-8") for path in paths)
+
+
+def test_coverage_summary_useful():
+    client, modules = _build_client("1")
+    try:
+        for name, paths in FIXTURES.items():
+            text = _load_text(paths)
+            response = client.post("/api/analyze", headers=_headers(), json={"text": text})
+            assert response.status_code == 200, name
+            cid = response.headers.get("x-cid")
+            assert cid, name
+            trace_response = client.get(f"/api/trace/{cid}")
+            assert trace_response.status_code == 200, name
+            trace_body = trace_response.json()
+            coverage = trace_body.get("coverage")
+            assert isinstance(coverage, dict), name
+
+            zones_total = int(coverage.get("zones_total", 0))
+            assert zones_total >= 30, name
+            zones_present = int(coverage.get("zones_present", 0))
+            assert zones_present >= max(1, ceil(zones_total * 0.25)), name
+
+            zones_candidates = int(coverage.get("zones_candidates", 0))
+            zones_fired = int(coverage.get("zones_fired", 0))
+            assert (zones_candidates + zones_fired) >= 8, name
+
+            details = coverage.get("details") or []
+            assert details, name
+            for detail in details:
+                matched = detail.get("matched_labels") or []
+                candidate_rules = detail.get("candidate_rules") or []
+                fired_rules = detail.get("fired_rules") or []
+                missing_rules = detail.get("missing_rules") or []
+                assert (
+                    matched or candidate_rules or fired_rules or missing_rules
+                ), f"zone {detail.get('zone_id')} has no signals"
+    finally:
+        _cleanup(client, modules)

--- a/tests/unit/test_coverage_map_content.py
+++ b/tests/unit/test_coverage_map_content.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from contract_review_app.analysis.labels_taxonomy import LABELS_CANON
+from contract_review_app.legal_rules import coverage_map, loader
+from contract_review_app.legal_rules.coverage_zones import (
+    HIGH_IMPORTANCE_ZONES,
+    ZONE_ENTITY_MATRIX,
+)
+
+
+def _load_map():
+    coverage_map.invalidate_cache()
+    cmap = coverage_map.load_coverage_map()
+    assert cmap is not None, "coverage map failed to load"
+    return cmap
+
+
+def test_high_importance_zones_have_labels_and_entities():
+    cmap = _load_map()
+    zone_lookup = {zone.zone_id: zone for zone in cmap.zones}
+    for zone_id in HIGH_IMPORTANCE_ZONES:
+        assert zone_id in zone_lookup, f"zone '{zone_id}' missing from map"
+        zone = zone_lookup[zone_id]
+        assert len(zone.label_any) >= 5, f"zone '{zone_id}' must have >=5 label selectors"
+        expected_entities = ZONE_ENTITY_MATRIX.get(zone_id)
+        if expected_entities is not None:
+            current = {key: bool(zone.entity_selectors.get(key, False)) for key in expected_entities}
+            expected = {key: bool(value) for key, value in expected_entities.items()}
+            assert (
+                current == expected
+            ), f"zone '{zone_id}' entity selectors mismatch: {current} != {expected}"
+
+
+def test_zone_labels_exist_in_taxonomy():
+    cmap = _load_map()
+    taxonomy_labels = set(LABELS_CANON.keys())
+    alias_whitelist = {
+        alias for aliases in coverage_map.ZONE_ALIASES.values() for alias in aliases
+    }
+    for zone in cmap.zones:
+        selectors = zone.label_any.union(zone.label_all).union(zone.label_none)
+        for label in selectors:
+            if label in alias_whitelist:
+                continue
+            assert (
+                label in taxonomy_labels
+            ), f"label '{label}' from zone '{zone.zone_id}' not in taxonomy"
+
+
+def test_rule_ids_exist():
+    cmap = _load_map()
+    rules = loader.load_rules()
+    rule_ids = {
+        str(rule.get("id") or rule.get("rule_id") or "").strip()
+        for rule in rules
+        if str(rule.get("id") or rule.get("rule_id") or "").strip()
+    }
+    for zone in cmap.zones:
+        for rule_id in zone.rule_ids:
+            assert rule_id in rule_ids, f"zone '{zone.zone_id}' references unknown rule '{rule_id}'"

--- a/tools/coverage_map_lint.py
+++ b/tools/coverage_map_lint.py
@@ -8,10 +8,21 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Mapping
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from contract_review_app.legal_rules import coverage_map
+from contract_review_app.analysis.labels_taxonomy import LABELS_CANON  # noqa: E402
+from contract_review_app.legal_rules import coverage_map, loader  # noqa: E402
+from contract_review_app.legal_rules.coverage_zones import (  # noqa: E402
+    HIGH_IMPORTANCE_ZONES,
+    SERVICE_LABEL_IDS,
+    ZONE_ENTITY_MATRIX,
+)
+
+
+def _bool_map(mapping: Mapping[str, object]) -> dict[str, bool]:
+    return {key: bool(mapping.get(key, False)) for key in sorted(mapping)}
 
 
 def run(strict: bool = False) -> int:
@@ -22,18 +33,82 @@ def run(strict: bool = False) -> int:
         return 1
 
     zones_total = len(cmap.zones)
-    if strict or os.getenv("FEATURE_COVERAGE_LINT_STRICT") == "1":
-        if zones_total < 30:
-            print("Coverage map must contain at least 30 zones", file=sys.stderr)
-            return 1
+    strict_mode = strict or os.getenv("FEATURE_COVERAGE_LINT_STRICT") == "1"
+
+    issues: list[str] = []
+    if zones_total < 30:
+        issues.append("Coverage map must contain at least 30 zones")
+
+    used_labels: set[str] = set()
+
+    for zone in cmap.zones:
+        used_labels.update(zone.label_any)
+        if zone.zone_id in HIGH_IMPORTANCE_ZONES and len(zone.label_any) < 5:
+            issues.append(
+                f"Zone '{zone.zone_id}' must declare at least 5 label selectors"
+            )
+        expected_entities = ZONE_ENTITY_MATRIX.get(zone.zone_id)
+        if expected_entities is not None:
+            current = _bool_map(zone.entity_selectors)
+            expected = _bool_map(expected_entities)
+            if current != expected:
+                issues.append(
+                    f"Zone '{zone.zone_id}' entity selectors {current} != {expected}"
+                )
+        if not (zone.label_any or zone.label_all or zone.label_none):
+            issues.append(f"Zone '{zone.zone_id}' must define at least one selector")
+        if zone.required and not zone.rule_ids:
+            issues.append(f"Zone '{zone.zone_id}' is required but has no rules mapped")
+
+    rules = loader.load_rules()
+    rule_ids = {
+        str(rule.get("id") or rule.get("rule_id") or "").strip()
+        for rule in rules
+        if str(rule.get("id") or rule.get("rule_id") or "").strip()
+    }
+    total_rules = len(rule_ids)
+    covered_rules = {
+        rule_id for rule_id in cmap.rule_index.keys() if rule_id in rule_ids
+    }
+    rule_ratio = len(covered_rules) / total_rules if total_rules else 1.0
+    if rule_ratio < 0.8:
+        issues.append(
+            f"Only {len(covered_rules)} of {total_rules} rules have coverage entries"
+        )
+
+    taxonomy_labels = set(LABELS_CANON.keys()) - set(SERVICE_LABEL_IDS)
+    labels_used = used_labels.intersection(taxonomy_labels)
+    label_ratio = len(labels_used) / len(taxonomy_labels) if taxonomy_labels else 1.0
+    if label_ratio < 0.7:
+        issues.append(
+            f"Only {len(labels_used)} of {len(taxonomy_labels)} taxonomy labels used"
+        )
+
+    unused_labels = sorted(taxonomy_labels - labels_used)
 
     summary = {
         "version": cmap.version,
         "zones_total": zones_total,
-        "labels_indexed": len(cmap.label_index),
-        "rules_indexed": len(cmap.rule_index),
+        "labels_used": len(labels_used),
+        "labels_total": len(taxonomy_labels),
+        "labels_ratio": round(label_ratio, 4),
+        "rules_covered": len(covered_rules),
+        "rules_total": total_rules,
+        "rules_ratio": round(rule_ratio, 4),
     }
     print(json.dumps(summary, indent=2, sort_keys=True))
+
+    if unused_labels:
+        print("\nTop unused labels:")
+        for label in unused_labels[:10]:
+            print(f"  - {label}")
+
+    if issues:
+        print("\nIssues detected:")
+        for item in issues:
+            print(f"  - {item}")
+        if strict_mode:
+            return 1
     return 0
 
 

--- a/tools/coverage_seed_from_repo.py
+++ b/tools/coverage_seed_from_repo.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Seed coverage_map.yaml from the repository taxonomy and rules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Sequence, Set, Tuple
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from contract_review_app.analysis.labels_taxonomy import LABELS_CANON  # noqa: E402
+from contract_review_app.legal_rules import loader  # noqa: E402
+from contract_review_app.legal_rules.coverage_map import (  # noqa: E402
+    COVERAGE_MAP_PATH,
+    _normalize_label,
+)
+from contract_review_app.legal_rules.coverage_zones import (  # noqa: E402
+    HIGH_IMPORTANCE_ZONES,
+    SERVICE_LABEL_IDS,
+    ZONE_LABEL_ALLOWLIST,
+    ZONE_LABEL_BLACKLIST,
+    ZONE_RULE_BLACKLIST,
+    ZONE_SEED_DATA,
+)
+
+
+def _tokenize(value: str | None) -> Set[str]:
+    if not value:
+        return set()
+    normalized = _normalize_label(value)
+    if not normalized:
+        return set()
+    tokens = {normalized}
+    separators = [" ", "-", "/", "\\", ".", ":", ";"]
+    interim = normalized
+    for sep in separators:
+        interim = interim.replace(sep, " ")
+    for part in interim.split():
+        part = part.strip()
+        if part:
+            tokens.add(part)
+    return {token for token in tokens if token}
+
+
+def _build_label_catalog() -> Dict[str, Set[str]]:
+    catalog: Dict[str, Set[str]] = {}
+    for label_id, meta in LABELS_CANON.items():
+        tokens = _tokenize(label_id)
+        for synonym in meta.get("high_priority_synonyms", []) or []:
+            tokens.update(_tokenize(synonym))
+        catalog[label_id] = tokens
+    return catalog
+
+
+def _match_labels(
+    zone_id: str,
+    hints: Sequence[str],
+    catalog: Mapping[str, Set[str]],
+) -> Tuple[Set[str], Set[str]]:
+    matched: Set[str] = set()
+    missing: Set[str] = set()
+    for hint in hints:
+        normalized = _normalize_label(hint)
+        if not normalized:
+            continue
+        local_matches = {
+            label_id
+            for label_id, tokens in catalog.items()
+            if normalized == _normalize_label(label_id) or normalized in tokens
+        }
+        if not local_matches:
+            missing.add(hint)
+            continue
+        matched.update(local_matches)
+    allowlist = ZONE_LABEL_ALLOWLIST.get(zone_id)
+    if allowlist:
+        matched.update(allowlist)
+    blacklist = ZONE_LABEL_BLACKLIST.get(zone_id)
+    if blacklist:
+        matched.difference_update(blacklist)
+    return matched, missing
+
+
+def _build_rule_tokens(rules: Sequence[Mapping[str, object]]) -> Dict[str, Set[str]]:
+    rule_tokens: Dict[str, Set[str]] = {}
+    for rule in rules:
+        rule_id = str(rule.get("id") or rule.get("rule_id") or "").strip()
+        if not rule_id:
+            continue
+        tokens: Set[str] = set()
+        fields: Iterable[object] = (
+            rule.get("title"),
+            rule.get("clause_type"),
+            rule.get("pack"),
+        )
+        for field in fields:
+            if isinstance(field, str):
+                tokens.update(_tokenize(field))
+        requires_clause = rule.get("requires_clause") or []
+        for clause in requires_clause if isinstance(requires_clause, Iterable) else []:
+            if isinstance(clause, str):
+                tokens.update(_tokenize(clause))
+        doc_types = rule.get("doc_types") or []
+        for doc_type in doc_types if isinstance(doc_types, Iterable) else []:
+            if isinstance(doc_type, str):
+                tokens.update(_tokenize(doc_type))
+        rule_tokens[rule_id] = {token for token in tokens if token}
+    return rule_tokens
+
+
+def _match_rules(
+    zone_id: str,
+    hints: Sequence[str],
+    rule_tokens: Mapping[str, Set[str]],
+) -> Tuple[Set[str], Set[str]]:
+    normalized_hints = [_normalize_label(hint) for hint in hints if _normalize_label(hint)]
+    matched: Set[str] = set()
+    empty_hints: Set[str] = set()
+    if not normalized_hints:
+        empty_hints.update(hints)
+    for rule_id, tokens in rule_tokens.items():
+        for hint in normalized_hints:
+            if hint in tokens or any(hint in token or token in hint for token in tokens):
+                matched.add(rule_id)
+                break
+    blacklist = ZONE_RULE_BLACKLIST.get(zone_id)
+    if blacklist:
+        matched.difference_update(blacklist)
+    return matched, empty_hints
+
+
+def _coerce_bool_map(values: Mapping[str, object]) -> Dict[str, bool]:
+    return {key: bool(values.get(key, False)) for key in sorted(values)}
+
+
+def build_seed() -> Tuple[Dict[str, object], Dict[str, object]]:
+    label_catalog = _build_label_catalog()
+    rules = loader.load_rules()
+    rule_tokens = _build_rule_tokens(rules)
+    rule_lookup = {str(rule.get("id") or rule.get("rule_id")): rule for rule in rules}
+
+    zones_payload = []
+    used_labels: Set[str] = set()
+    covered_rules: Set[str] = set()
+    missing_labels_report: Dict[str, Set[str]] = defaultdict(set)
+    missing_rule_hints: Dict[str, Set[str]] = defaultdict(set)
+
+    for seed in ZONE_SEED_DATA:
+        labels_matched, missing = _match_labels(seed.zone_id, seed.label_hints, label_catalog)
+        if missing:
+            missing_labels_report[seed.zone_id].update(missing)
+        rules_matched, empty = _match_rules(seed.zone_id, seed.rule_hints, rule_tokens)
+        if empty:
+            missing_rule_hints[seed.zone_id].update(empty)
+
+        labels_sorted = sorted(labels_matched)
+        rules_sorted = sorted(rules_matched)
+
+        used_labels.update(labels_sorted)
+        covered_rules.update(rules_sorted)
+
+        zone_payload = {
+            "zone_id": seed.zone_id,
+            "zone_name": seed.zone_name,
+            "description": seed.description,
+            "label_selectors": {
+                "any": labels_sorted,
+                "all": [],
+                "none": [],
+            },
+            "entity_selectors": _coerce_bool_map(seed.entity_selectors),
+            "rule_ids_opt": rules_sorted,
+            "weight": seed.weight,
+            "required": bool(seed.required),
+        }
+        zones_payload.append(zone_payload)
+
+    taxonomy_labels = set(LABELS_CANON.keys()) - set(SERVICE_LABEL_IDS)
+    unused_labels = sorted(taxonomy_labels.difference(used_labels))
+
+    metrics = {
+        "zones_total": len(zones_payload),
+        "labels_used": len(used_labels),
+        "labels_total": len(taxonomy_labels),
+        "rules_covered": len(covered_rules),
+        "rules_total": len(rule_lookup),
+        "missing_labels": {k: sorted(v) for k, v in missing_labels_report.items() if v},
+        "missing_rule_hints": {k: sorted(v) for k, v in missing_rule_hints.items() if v},
+        "unused_labels": unused_labels,
+        "high_importance_zones": sorted(HIGH_IMPORTANCE_ZONES),
+    }
+
+    payload = {"version": 1, "zones": zones_payload}
+    return payload, metrics
+
+
+def write_yaml(payload: Mapping[str, object], *, dry_run: bool = False) -> None:
+    if dry_run:
+        print(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True))
+        return
+    COVERAGE_MAP_PATH.write_text(
+        yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def print_report(metrics: Mapping[str, object]) -> None:
+    zones_total = metrics.get("zones_total", 0)
+    labels_used = metrics.get("labels_used", 0)
+    labels_total = metrics.get("labels_total", 1)
+    rules_covered = metrics.get("rules_covered", 0)
+    rules_total = metrics.get("rules_total", 1)
+    label_ratio = labels_used / labels_total if labels_total else 0.0
+    rule_ratio = rules_covered / rules_total if rules_total else 0.0
+
+    summary = {
+        "zones_total": zones_total,
+        "labels_used": labels_used,
+        "labels_total": labels_total,
+        "labels_ratio": round(label_ratio, 4),
+        "rules_covered": rules_covered,
+        "rules_total": rules_total,
+        "rules_ratio": round(rule_ratio, 4),
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    missing_labels = metrics.get("missing_labels") or {}
+    if missing_labels:
+        print("\n[warn] Unmatched label hints:")
+        for zone_id, hints in sorted(missing_labels.items()):
+            print(f"  - {zone_id}: {', '.join(hints)}")
+
+    missing_rule_hints = metrics.get("missing_rule_hints") or {}
+    if missing_rule_hints:
+        print("\n[warn] Rule hints without tokens:")
+        for zone_id, hints in sorted(missing_rule_hints.items()):
+            print(f"  - {zone_id}: {', '.join(hints)}")
+
+    unused_labels = metrics.get("unused_labels") or []
+    if unused_labels:
+        print("\n[info] Top unused labels:")
+        for label in unused_labels[:10]:
+            print(f"  - {label}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Print YAML to stdout instead of writing")
+    args = parser.parse_args()
+
+    payload, metrics = build_seed()
+    write_yaml(payload, dry_run=args.dry_run)
+    print_report(metrics)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- curate 45 coverage zones with declarative seeds and shared metadata
- add a seeding tool that rebuilds coverage_map.yaml and enhance lint thresholds
- document guidelines and add unit/integration tests to guard coverage usefulness

## Testing
- `python tools/coverage_seed_from_repo.py`
- `python tools/coverage_map_lint.py --strict`
- `pytest tests/unit/test_coverage_map_content.py`
- `pytest tests/integration/test_coverage_usefulness.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2eb3edf50832588f7ce09695d3f31