### PR TITLE
Fix timeout tests to align with middleware behavior

### DIFF
--- a/tests/api/test_timeouts_budget.py
+++ b/tests/api/test_timeouts_budget.py
@@ -44,6 +44,7 @@ def test_api_timeout_budget(monkeypatch, api_timeout, request_timeout):
 
     assert response.status_code == 504
     payload = response.json()
-    assert payload.get("type") == "timeout"
+    assert payload.get("status_text") == "timeout"
+    assert payload.get("reason") == "analyze_timeout"
     assert captured["timeout"] == pytest.approx(limits_module.API_TIMEOUT_S)
     assert limits_module.API_TIMEOUT_S < limits_module.REQUEST_TIMEOUT_S


### PR DESCRIPTION
## Summary
- update the analyze timeout test to assert the fields emitted by the timeout middleware
- scope the health timeout monkeypatch to only intercept rule discovery waits so the handler response is asserted

## Testing
- pytest tests/api/test_timeouts_budget.py::test_api_timeout_budget tests/api/test_health_timeout.py::test_health_timeout

------
https://chatgpt.com/codex/tasks/task_e_68d2f1c3d2e88325b32e69ac86d2157e