### PR TITLE
chore(word_addin_dev): align lint and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,11 @@ repos:
       - id: trailing-whitespace
   - repo: local
     hooks:
+      - id: lint-staged
+        name: lint-staged
+        entry: npm --prefix word_addin_dev run lint:staged
+        language: system
+        pass_filenames: false
       - id: eslint
         name: eslint
         entry: npm --prefix word_addin_dev run lint

--- a/word_addin_dev/.eslintrc.cjs
+++ b/word_addin_dev/.eslintrc.cjs
@@ -1,20 +1,25 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
-  ignorePatterns: ['dist', 'taskpane.bundle.js', 'app/assets'],
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  ignorePatterns: ['dist', 'taskpane.bundle.js', 'app/assets', 'app/types'],
   overrides: [
     {
       files: ['app/__tests__/**/*.ts', 'app/src/**/*.spec.ts'],
       rules: {
         '@typescript-eslint/no-explicit-any': 'off',
-        'no-empty': 'off'
-      }
-    }
+        'no-empty': 'off',
+      },
+    },
   ],
   rules: {
     // Allow transitional 'any' in production assets for now; flip to "error" in Step 1
-    '@typescript-eslint/no-explicit-any': 'warn'
-  }
+    '@typescript-eslint/no-explicit-any': 'warn',
+    'prettier/prettier': 'error',
+  },
 };

--- a/word_addin_dev/.prettierignore
+++ b/word_addin_dev/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+.dist
+/dist
+app/assets
+.taskpane.bundle.js
+taskpane.bundle.js
+app/types

--- a/word_addin_dev/.prettierrc.cjs
+++ b/word_addin_dev/.prettierrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'es5',
+  printWidth: 100,
+  bracketSpacing: true,
+  arrowParens: 'avoid',
+};

--- a/word_addin_dev/LINT_HEALTH.md
+++ b/word_addin_dev/LINT_HEALTH.md
@@ -1,0 +1,31 @@
+# Lint Health Report
+
+## Overview
+
+- **ESLint** now extends `plugin:prettier/recommended` to keep linting rules in sync with Prettier and fail on formatting drift.
+- **Prettier** enforces the shared style guide: semicolons, single quotes, two-space indentation, trailing commas where valid in ES5, and a 100-character print width.
+- `lint-staged` runs `eslint --fix --max-warnings=0` followed by `prettier --write` on staged files, ensuring fixes are applied before commit.
+
+## Key Rules
+
+- `@typescript-eslint/no-explicit-any` remains a warning for production assets until migration is complete.
+- `prettier/prettier` is an error so any formatting deviations break the lint run and CI.
+- ESLint ignores generated assets: `dist`, `taskpane.bundle.js`, and `app/assets`.
+
+## Developer Workflow
+
+1. **Auto-fix on commit**: `.pre-commit-config.yaml` now calls `npm --prefix word_addin_dev run lint:staged`. Staged files are auto-fixed and re-staged. The subsequent `npm --prefix word_addin_dev run lint` gate guarantees the full project still passes linting.
+2. **Manual commands**:
+   - `npm --prefix word_addin_dev run lint` – run ESLint with `--max-warnings=0`.
+   - `npm --prefix word_addin_dev run format` – format the project with Prettier.
+   - `npm --prefix word_addin_dev run lint:staged` – execute the `lint-staged` pipeline locally.
+
+## CI Changes
+
+- The CI workflow already calls `npm --prefix word_addin_dev run lint`; with the stricter ESLint+Prettier integration, warnings fail the job. No additional `lint:fix` invocation is required.
+
+## Getting Started
+
+1. Install dependencies once: `npm --prefix word_addin_dev install`.
+2. Activate pre-commit hooks: `python -m pre_commit install` (already part of repository instructions).
+3. Make your changes; staged files are automatically formatted and linted on commit.

--- a/word_addin_dev/MIGRATION.md
+++ b/word_addin_dev/MIGRATION.md
@@ -1,14 +1,17 @@
 # Migration: Add comments on Analyze
 
 ## Toggle
+
 - The Task Pane now includes **Add comments on Analyze** checkbox.
 - Enabled by default. Uncheck to skip automatic comment insertion.
 
 ## Comment prefix
+
 - Comments inserted by Contract AI start with `"[CAI][cid:{CID}][rule:{RULE_ID}]"`.
 - Search for this prefix to locate all generated comments.
 
 ## Limitations
+
 - Only comments are added; document text is not modified.
 - Track Changes are untouched.
 

--- a/word_addin_dev/app/__tests__/analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.flow.spec.ts
@@ -14,12 +14,20 @@ describe('analyze flow', () => {
   });
 
   it('posts flat payload with schema', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
     (globalThis as any).fetch = fetchMock;
     (globalThis as any).window = { dispatchEvent() {} } as any;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
     const { analyze } = await import('../assets/api-client.ts');
-    const payload: AnalyzeRequest = { text: 'hello', language: 'en-GB', mode: 'live', risk: null, schema: null };
+    const payload: AnalyzeRequest = {
+      text: 'hello',
+      language: 'en-GB',
+      mode: 'live',
+      risk: null,
+      schema: null,
+    };
     await analyze({ text: payload.text, mode: payload.mode } as any);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, opts] = fetchMock.mock.calls[0];
@@ -31,7 +39,11 @@ describe('analyze flow', () => {
   it('filters QA findings to high and above', async () => {
     vi.resetModules();
     (globalThis as any).__CAI_TESTING__ = true;
-    (globalThis as any).window = { addEventListener() {}, removeEventListener() {}, location: { search: '' } } as any;
+    (globalThis as any).window = {
+      addEventListener() {},
+      removeEventListener() {},
+      location: { search: '' },
+    } as any;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
     const { filterFindingsByRiskForTests } = await import('../assets/taskpane.ts');
     const findings: AnalyzeFinding[] = [

--- a/word_addin_dev/app/__tests__/analyze.payload.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.payload.spec.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 
 describe('analyze payload wrapper', () => {
   it('sends flat payload with mode only', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
     (globalThis as any).fetch = fetchMock;
     (globalThis as any).window = { dispatchEvent() {} } as any;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;

--- a/word_addin_dev/app/__tests__/analyze.risk.spec.ts
+++ b/word_addin_dev/app/__tests__/analyze.risk.spec.ts
@@ -1,19 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 function makeElement(overrides: any = {}) {
-  return Object.assign({
-    style: { display: '', removeProperty: vi.fn() },
-    classList: { add: vi.fn(), remove: vi.fn(), toggle: vi.fn() },
-    appendChild: vi.fn(),
-    removeChild: vi.fn(),
-    dispatchEvent: vi.fn(),
-    addEventListener: vi.fn(),
-    setAttribute: vi.fn(),
-    removeAttribute: vi.fn(),
-    innerHTML: '',
-    textContent: '',
-    value: '',
-  }, overrides);
+  return Object.assign(
+    {
+      style: { display: '', removeProperty: vi.fn() },
+      classList: { add: vi.fn(), remove: vi.fn(), toggle: vi.fn() },
+      appendChild: vi.fn(),
+      removeChild: vi.fn(),
+      dispatchEvent: vi.fn(),
+      addEventListener: vi.fn(),
+      setAttribute: vi.fn(),
+      removeAttribute: vi.fn(),
+      innerHTML: '',
+      textContent: '',
+      value: '',
+    },
+    overrides
+  );
 }
 
 describe('risk forwarding to analyze', () => {
@@ -33,10 +36,22 @@ describe('risk forwarding to analyze', () => {
   });
 
   it('includes selected critical risk in analyze request body', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, headers: new Headers(), json: async () => ({}) });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 200, headers: new Headers(), json: async () => ({}) });
     (globalThis as any).fetch = fetchMock;
-    (globalThis as any).window = { addEventListener() {}, removeEventListener() {}, dispatchEvent() {}, location: { search: '' } } as any;
-    (globalThis as any).document = { addEventListener() {}, querySelectorAll() { return [] as any; } } as any;
+    (globalThis as any).window = {
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {},
+      location: { search: '' },
+    } as any;
+    (globalThis as any).document = {
+      addEventListener() {},
+      querySelectorAll() {
+        return [] as any;
+      },
+    } as any;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
     const { analyze } = await import('../assets/api-client.ts');
     await analyze({ text: 'hello', risk: 'critical' });
@@ -47,9 +62,7 @@ describe('risk forwarding to analyze', () => {
   });
 
   it('does not drop findings already filtered by the server', async () => {
-    const serverFindings = [
-      { rule_id: 'F1', snippet: 'alpha', severity: 'critical' },
-    ];
+    const serverFindings = [{ rule_id: 'F1', snippet: 'alpha', severity: 'critical' }];
     (globalThis as any).__CAI_TESTING__ = true;
     (globalThis as any).window = {
       addEventListener: vi.fn(),
@@ -71,10 +84,14 @@ describe('risk forwarding to analyze', () => {
       json: { analysis: { findings: serverFindings }, recommendations: [] },
       meta: {},
     } as any);
-    const parseFindingsSpy = vi.spyOn(apiClient, 'parseFindings').mockImplementation(() => serverFindings);
+    const parseFindingsSpy = vi
+      .spyOn(apiClient, 'parseFindings')
+      .mockImplementation(() => serverFindings);
 
     const annotateMod = await import('../assets/annotate.ts');
-    const planAnnotationsSpy = vi.spyOn(annotateMod, 'planAnnotations').mockImplementation((items: any[]) => items.map(f => ({ ...f, raw: f.snippet })) as any);
+    const planAnnotationsSpy = vi
+      .spyOn(annotateMod, 'planAnnotations')
+      .mockImplementation((items: any[]) => items.map(f => ({ ...f, raw: f.snippet })) as any);
     vi.spyOn(annotateMod, 'annotateFindingsIntoWord').mockResolvedValue();
 
     const notifierMod = await import('../assets/notifier');
@@ -137,7 +154,10 @@ describe('risk forwarding to analyze', () => {
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
     (globalThis as any).CustomEvent = class {
       detail: any;
-      constructor(public type: string, init?: any) {
+      constructor(
+        public type: string,
+        init?: any
+      ) {
         this.detail = init?.detail;
       }
     } as any;
@@ -153,6 +173,9 @@ describe('risk forwarding to analyze', () => {
     const planned = planAnnotationsSpy.mock.calls[0][0];
     expect(planned).toHaveLength(serverFindings.length);
     expect(planned.map((f: any) => f.rule_id)).toEqual(serverFindings.map(f => f.rule_id));
-    expect(parseFindingsSpy).toHaveBeenCalledWith({ analysis: { findings: serverFindings }, recommendations: [] });
+    expect(parseFindingsSpy).toHaveBeenCalledWith({
+      analysis: { findings: serverFindings },
+      recommendations: [],
+    });
   });
 });

--- a/word_addin_dev/app/__tests__/annotate.anchor_by_offsets.spec.ts
+++ b/word_addin_dev/app/__tests__/annotate.anchor_by_offsets.spec.ts
@@ -3,10 +3,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 const safeBodySearchMock = vi.fn();
 
 vi.mock('../assets/safeBodySearch.ts', async () => {
-  const actual = await vi.importActual<typeof import('../assets/safeBodySearch.ts')>('../assets/safeBodySearch.ts');
+  const actual = await vi.importActual<typeof import('../assets/safeBodySearch.ts')>(
+    '../assets/safeBodySearch.ts'
+  );
   return {
     ...actual,
-    safeBodySearch: safeBodySearchMock
+    safeBodySearch: safeBodySearchMock,
   };
 });
 
@@ -14,8 +16,8 @@ describe('anchorByOffsets behaviour', () => {
   const makeBody = () => ({
     context: {
       sync: vi.fn(async () => {}),
-      trackedObjects: { add: vi.fn() }
-    }
+      trackedObjects: { add: vi.fn() },
+    },
   });
 
   beforeEach(() => {
@@ -42,7 +44,7 @@ describe('anchorByOffsets behaviour', () => {
       end: 50,
       nth: 0,
       searchOptions: { matchCase: false, matchWholeWord: false },
-      onMethod
+      onMethod,
     });
 
     expect(range).toBe(target);
@@ -74,7 +76,7 @@ describe('anchorByOffsets behaviour', () => {
       nth: 0,
       searchOptions: { matchCase: false, matchWholeWord: false },
       normalizedCandidates: ['foo bar'],
-      onMethod
+      onMethod,
     });
 
     expect(range).toBe(normalizedRange);

--- a/word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts
+++ b/word_addin_dev/app/__tests__/annotate.flow.offsets.spec.ts
@@ -10,7 +10,7 @@ vi.mock('../assets/anchors', async () => {
     ...actual,
     anchorByOffsets: anchorByOffsetsMock,
     findAnchors: anchorsMock,
-    searchNth: searchNthMock
+    searchNth: searchNthMock,
   };
 });
 
@@ -32,7 +32,12 @@ describe('annotate flow offsets', () => {
 
   it('requests anchors using nth derived from offsets', async () => {
     anchorByOffsetsMock.mockImplementation(async opts => {
-      return (await searchNthMock(opts.body, opts.snippet, opts.nth ?? 0, opts.searchOptions)) as any;
+      return (await searchNthMock(
+        opts.body,
+        opts.snippet,
+        opts.nth ?? 0,
+        opts.searchOptions
+      )) as any;
     });
     const baseText = 'foo bar foo bar foo bar foo bar';
     (globalThis as any).__lastAnalyzed = baseText;
@@ -47,7 +52,7 @@ describe('annotate flow offsets', () => {
     const targetRange = { start, end: start + snippet.length, load: vi.fn() } as any;
     const otherRanges = [
       { start: starts[0], end: starts[0] + snippet.length, load: vi.fn() },
-      { start: starts[1], end: starts[1] + snippet.length, load: vi.fn() }
+      { start: starts[1], end: starts[1] + snippet.length, load: vi.fn() },
     ];
 
     const annotateMod = await import('../assets/annotate');
@@ -64,9 +69,9 @@ describe('annotate flow offsets', () => {
           tag: '',
           title: '',
           color: '',
-          insertText: vi.fn()
+          insertText: vi.fn(),
         };
-      }
+      },
     });
 
     const ranges = [...otherRanges.map(wrapRange), wrapRange(targetRange)];
@@ -84,19 +89,17 @@ describe('annotate flow offsets', () => {
         const ctx = {
           document: {
             body: {
-              context: { sync: vi.fn(async () => {}), trackedObjects: { add: () => {} } }
-            }
+              context: { sync: vi.fn(async () => {}), trackedObjects: { add: () => {} } },
+            },
           },
-          sync: vi.fn(async () => {})
+          sync: vi.fn(async () => {}),
         };
         return await cb(ctx);
-      }
+      },
     };
     (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false } } };
 
-    const findings = [
-      { rule_id: 'r1', snippet, start, end: start + snippet.length }
-    ];
+    const findings = [{ rule_id: 'r1', snippet, start, end: start + snippet.length }];
 
     const inserted = await annotateFindingsIntoWord(findings as any);
     expect(inserted).toBe(1);
@@ -129,9 +132,9 @@ describe('annotate flow offsets', () => {
           tag: '',
           title: '',
           color: '',
-          insertText: vi.fn()
+          insertText: vi.fn(),
         };
-      }
+      },
     });
 
     const preferredRange = makeRange(starts[2]);
@@ -154,19 +157,19 @@ describe('annotate flow offsets', () => {
         const ctx = {
           document: {
             body: {
-              context: { sync: vi.fn(async () => {}), trackedObjects: { add: () => {} } }
-            }
+              context: { sync: vi.fn(async () => {}), trackedObjects: { add: () => {} } },
+            },
           },
-          sync: vi.fn(async () => {})
+          sync: vi.fn(async () => {}),
         };
         return await cb(ctx);
-      }
+      },
     };
 
     (globalThis as any).Office = { context: { requirements: { isSetSupported: () => false } } };
 
     const findings = [
-      { rule_id: 'r1', snippet, start: preferredRange.start, end: preferredRange.end, nth: 2 }
+      { rule_id: 'r1', snippet, start: preferredRange.start, end: preferredRange.end, nth: 2 },
     ];
 
     const inserted = await annotateFindingsIntoWord(findings as any);
@@ -186,7 +189,12 @@ describe('annotate flow offsets', () => {
     const findings = [
       { rule_id: 'r1', snippet: 'alpha', start: 0, end: 5, nth: 0 },
       { rule_id: 'r2', snippet: 'beta', start: 4, end: 8 },
-      { rule_id: 'r3', snippet: 'delta', start: baseText.indexOf('delta'), end: baseText.indexOf('delta') + 'delta'.length }
+      {
+        rule_id: 'r3',
+        snippet: 'delta',
+        start: baseText.indexOf('delta'),
+        end: baseText.indexOf('delta') + 'delta'.length,
+      },
     ];
 
     const plan = planAnnotations(findings as any);

--- a/word_addin_dev/app/__tests__/applyOpsTracked.long.spec.ts
+++ b/word_addin_dev/app/__tests__/applyOpsTracked.long.spec.ts
@@ -1,47 +1,45 @@
-import { describe, it, expect, vi } from 'vitest'
-
-;(globalThis as any).window = globalThis
-;(globalThis as any).document = { readyState: 'complete', addEventListener: vi.fn() }
-;(globalThis as any).Office = { onReady: vi.fn() }
+import { describe, it, expect, vi } from 'vitest';
+(globalThis as any).window = globalThis;
+(globalThis as any).document = { readyState: 'complete', addEventListener: vi.fn() };
+(globalThis as any).Office = { onReady: vi.fn() };
 
 vi.mock('../assets/pending.ts', async () => {
-  const actual = await vi.importActual('../assets/pending.ts')
-  return { ...actual, withBusy: async (fn: any) => await fn() }
-})
+  const actual = await vi.importActual('../assets/pending.ts');
+  return { ...actual, withBusy: async (fn: any) => await fn() };
+});
 
 vi.mock('../assets/annotate.ts', async () => {
-  const actual = await vi.importActual('../assets/annotate.ts')
+  const actual = await vi.importActual('../assets/annotate.ts');
 
-  return { ...actual, COMMENT_PREFIX: '[CAI]', safeInsertComment: vi.fn().mockResolvedValue(true) }
-})
+  return { ...actual, COMMENT_PREFIX: '[CAI]', safeInsertComment: vi.fn().mockResolvedValue(true) };
+});
 
-const innerRange: any = {}
-innerRange.insertText = vi.fn().mockReturnValue(innerRange)
-innerRange.getRange = vi.fn().mockReturnThis()
-innerRange.search = vi.fn().mockReturnValue({ items: [innerRange], load: vi.fn() })
-const innerCollection = { items: [innerRange], load: vi.fn() }
-const fullSearch = vi.fn().mockReturnValue(innerCollection)
+const innerRange: any = {};
+innerRange.insertText = vi.fn().mockReturnValue(innerRange);
+innerRange.getRange = vi.fn().mockReturnThis();
+innerRange.search = vi.fn().mockReturnValue({ items: [innerRange], load: vi.fn() });
+const innerCollection = { items: [innerRange], load: vi.fn() };
+const fullSearch = vi.fn().mockReturnValue(innerCollection);
 
 vi.mock('../assets/safeBodySearch.ts', () => ({
-  safeBodySearch: vi.fn().mockResolvedValue({ items: [{ search: fullSearch }] })
-}))
-
+  safeBodySearch: vi.fn().mockResolvedValue({ items: [{ search: fullSearch }] }),
+}));
 
 describe('applyOpsTracked long replacements', () => {
   it('clamps snippet before searching full range', async () => {
-    const longText = 'x'.repeat(500)
-    ;(globalThis as any).__lastAnalyzed = longText
+    const longText = 'x'.repeat(500);
+    (globalThis as any).__lastAnalyzed = longText;
 
     const run = vi.fn(async (cb: any) => {
-      await cb({ document: { body: {} }, sync: vi.fn() })
-    })
-    ;(globalThis as any).Word = { run }
+      await cb({ document: { body: {} }, sync: vi.fn() });
+    });
+    (globalThis as any).Word = { run };
 
-    const mod = await import('../assets/taskpane.ts')
-    await mod.applyOpsTracked([{ start: 0, end: 500, replacement: 'R', context_before: 'a' }])
+    const mod = await import('../assets/taskpane.ts');
+    await mod.applyOpsTracked([{ start: 0, end: 500, replacement: 'R', context_before: 'a' }]);
 
-      expect(fullSearch).toHaveBeenCalledTimes(2)
-      expect(fullSearch.mock.calls[0][0]).toBe(longText.slice(0, 240))
-      expect(fullSearch.mock.calls[1][0]).toBe(longText.slice(-240))
-    })
-  })
+    expect(fullSearch).toHaveBeenCalledTimes(2);
+    expect(fullSearch.mock.calls[0][0]).toBe(longText.slice(0, 240));
+    expect(fullSearch.mock.calls[1][0]).toBe(longText.slice(-240));
+  });
+});

--- a/word_addin_dev/app/__tests__/bootstrap.once.spec.ts
+++ b/word_addin_dev/app/__tests__/bootstrap.once.spec.ts
@@ -1,13 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('bootstrap once', () => {
-  beforeEach(() => { vi.resetModules(); });
+  beforeEach(() => {
+    vi.resetModules();
+  });
   it('invokes wireUI only once', async () => {
     (globalThis as any).__CAI_TESTING__ = true;
-    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
-    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
-    (globalThis as any).Word = { Revision:{}, Comment:{}, SearchOptions:{}, ContentControl:{} } as any;
-    (globalThis as any).document = { querySelector: () => null, getElementById: () => null, addEventListener: () => {} } as any;
+    (globalThis as any).window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    };
+    (globalThis as any).Office = {
+      context: { requirements: { isSetSupported: () => true } },
+    } as any;
+    (globalThis as any).Word = {
+      Revision: {},
+      Comment: {},
+      SearchOptions: {},
+      ContentControl: {},
+    } as any;
+    (globalThis as any).document = {
+      querySelector: () => null,
+      getElementById: () => null,
+      addEventListener: () => {},
+    } as any;
     const mod = await import('../assets/taskpane.ts');
     mod.invokeBootstrap();
     mod.invokeBootstrap();

--- a/word_addin_dev/app/__tests__/bootstrap.test.ts
+++ b/word_addin_dev/app/__tests__/bootstrap.test.ts
@@ -8,13 +8,18 @@ describe('startPanel bootstrap', () => {
       querySelector: qSpy,
       getElementById: () => null,
       addEventListener: () => {},
-      readyState: 'complete'
+      readyState: 'complete',
     } as any;
     (globalThis as any).localStorage = { getItem: () => '', setItem: () => {} };
     (globalThis as any).fetch = vi.fn(async () => ({ json: async () => ({}) }));
     const mod = await import('../src/panel/index');
     let readyResolve: () => void;
-    const onReady = vi.fn(() => new Promise<void>(res => { readyResolve = res; }));
+    const onReady = vi.fn(
+      () =>
+        new Promise<void>(res => {
+          readyResolve = res;
+        })
+    );
     (globalThis as any).Office = { onReady };
     const p = mod.startPanel();
     expect(onReady).toHaveBeenCalled();

--- a/word_addin_dev/app/__tests__/clear_annotations.test.ts
+++ b/word_addin_dev/app/__tests__/clear_annotations.test.ts
@@ -13,13 +13,16 @@ describe('clearAnnotations', () => {
         const cmts = {
           items: [
             { text: `${COMMENT_PREFIX} one`, delete: () => deleted.push('a') },
-            { text: 'foreign', delete: () => deleted.push('b') }
+            { text: 'foreign', delete: () => deleted.push('b') },
           ],
-          load: () => {}
+          load: () => {},
         };
-        const ctx = { document: { comments: cmts, body: { font: { highlightColor: 'Yellow' } } }, sync: async () => {} };
+        const ctx = {
+          document: { comments: cmts, body: { font: { highlightColor: 'Yellow' } } },
+          sync: async () => {},
+        };
         await cb(ctx);
-      }
+      },
     };
     await mod.clearAnnotations();
     expect(deleted).toEqual(['a']);

--- a/word_addin_dev/app/__tests__/dev.gating.spec.ts
+++ b/word_addin_dev/app/__tests__/dev.gating.spec.ts
@@ -5,20 +5,37 @@ const html = readFileSync(new URL('../../taskpane.html', import.meta.url), 'utf-
 if (!html.includes('id="btnTest"')) throw new Error('btnTest missing from canonical HTML');
 
 const mkDoc = () => {
-  const el: any = { disabled: false, style: { display: '' }, addEventListener: () => {}, classList: { remove: () => {} }, removeAttribute: () => {} };
+  const el: any = {
+    disabled: false,
+    style: { display: '' },
+    addEventListener: () => {},
+    classList: { remove: () => {} },
+    removeAttribute: () => {},
+  };
   return {
-    getElementById: (id: string) => id === 'btnTest' ? el : null,
-    querySelector: (sel: string) => sel === '#btnTest' ? el : null,
+    getElementById: (id: string) => (id === 'btnTest' ? el : null),
+    querySelector: (sel: string) => (sel === '#btnTest' ? el : null),
   } as any;
 };
 
 describe('dev gating', () => {
   beforeEach(() => {
     vi.resetModules();
-    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    };
     (globalThis as any).__CAI_TESTING__ = true;
-    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
-    (globalThis as any).Word = { Revision:{}, Comment:{}, SearchOptions:{}, ContentControl:{} } as any;
+    (globalThis as any).Office = {
+      context: { requirements: { isSetSupported: () => true } },
+    } as any;
+    (globalThis as any).Word = {
+      Revision: {},
+      Comment: {},
+      SearchOptions: {},
+      ContentControl: {},
+    } as any;
   });
 
   it('hides test button in prod', async () => {

--- a/word_addin_dev/app/__tests__/draft.spec.ts
+++ b/word_addin_dev/app/__tests__/draft.spec.ts
@@ -3,8 +3,11 @@ import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 
 const html = readFileSync(
-  new URL('../../../contract_review_app/contract_review_app/static/panel/taskpane.html', import.meta.url),
-  'utf-8',
+  new URL(
+    '../../../contract_review_app/contract_review_app/static/panel/taskpane.html',
+    import.meta.url
+  ),
+  'utf-8'
 );
 
 describe('get draft', () => {
@@ -18,17 +21,27 @@ describe('get draft', () => {
     (globalThis as any).CustomEvent = dom.window.CustomEvent;
     (globalThis as any).localStorage = {
       store: {} as Record<string, string>,
-      getItem(key: string) { return this.store[key] || null; },
-      setItem(key: string, value: string) { this.store[key] = value; }
+      getItem(key: string) {
+        return this.store[key] || null;
+      },
+      setItem(key: string, value: string) {
+        this.store[key] = value;
+      },
     };
-    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
     (globalThis as any).fetch = fetchMock;
     (globalThis as any).Office = {
       onReady: (cb: any) => cb({ host: 'Word' }),
       context: {
         requirements: { isSetSupported: () => true },
         host: 'Word',
-        document: { addHandlerAsync: (_: any, cb: any) => { (globalThis as any).__selHandler = cb; } },
+        document: {
+          addHandlerAsync: (_: any, cb: any) => {
+            (globalThis as any).__selHandler = cb;
+          },
+        },
       },
       EventType: { DocumentSelectionChanged: 'DocumentSelectionChanged' },
     };
@@ -41,19 +54,25 @@ describe('get draft', () => {
     const btn = document.getElementById('btnSuggestEdit') as HTMLButtonElement;
     expect(btn.disabled).toBe(true);
     await onSuggestEdit();
-    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt/draft'));
+    const calls = fetchMock.mock.calls.filter((c: any[]) =>
+      String(c[0]).includes('/api/gpt/draft')
+    );
     expect(calls.length).toBe(0);
   });
 
   it('selection enables and sends request with text', async () => {
-    (globalThis as any).getSelectionText = vi.fn().mockResolvedValue('This is a sample clause with sufficient length.');
+    (globalThis as any).getSelectionText = vi
+      .fn()
+      .mockResolvedValue('This is a sample clause with sufficient length.');
     const { wireUI, getClauseText, onSuggestEdit } = await import('../assets/taskpane.ts');
     wireUI();
     await getClauseText();
     const btn = document.getElementById('btnSuggestEdit') as HTMLButtonElement;
     expect(btn.disabled).toBe(false);
     await onSuggestEdit();
-    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt/draft'));
+    const calls = fetchMock.mock.calls.filter((c: any[]) =>
+      String(c[0]).includes('/api/gpt/draft')
+    );
     expect(calls.length).toBe(1);
     const body = JSON.parse(calls[0][1].body);
     expect(body).toMatchObject({ text: 'This is a sample clause with sufficient length.' });
@@ -61,13 +80,21 @@ describe('get draft', () => {
 
   it('Word API failure warns and skips request', async () => {
     (globalThis as any).getSelectionText = vi.fn().mockRejectedValue(new Error('fail'));
-    vi.mock('../assets/notifier', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
+    vi.mock('../assets/notifier', () => ({
+      notifyWarn: vi.fn(),
+      notifyErr: vi.fn(),
+      notifyOk: vi.fn(),
+    }));
     const { wireUI, onSuggestEdit } = await import('../assets/taskpane');
     const { notifyWarn } = await import('../assets/notifier');
     wireUI();
     await onSuggestEdit();
-    const calls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/gpt/draft'));
+    const calls = fetchMock.mock.calls.filter((c: any[]) =>
+      String(c[0]).includes('/api/gpt/draft')
+    );
     expect(calls.length).toBe(0);
-    expect(notifyWarn).toHaveBeenCalledWith('Please paste the original clause (min 20 chars) or select text in the document.');
+    expect(notifyWarn).toHaveBeenCalledWith(
+      'Please paste the original clause (min 20 chars) or select text in the document.'
+    );
   });
 });

--- a/word_addin_dev/app/__tests__/enable.analyze.spec.ts
+++ b/word_addin_dev/app/__tests__/enable.analyze.spec.ts
@@ -5,7 +5,10 @@ import path from 'node:path';
 
 describe('panel bootstrap flow', () => {
   it('enables analyze after successful health', async () => {
-    const htmlPath = path.resolve(__dirname, '../../../contract_review_app/contract_review_app/static/panel/taskpane.html');
+    const htmlPath = path.resolve(
+      __dirname,
+      '../../../contract_review_app/contract_review_app/static/panel/taskpane.html'
+    );
     const html = fs.readFileSync(htmlPath, 'utf8');
     document.documentElement.innerHTML = html;
 
@@ -16,16 +19,22 @@ describe('panel bootstrap flow', () => {
 
     (globalThis as any).Office = {
       onReady: (cb: any) => cb({ host: 'Word' }),
-      context: { host: 'Word', requirements: { isSetSupported: () => true } }
+      context: { host: 'Word', requirements: { isSetSupported: () => true } },
     } as any;
     (globalThis as any).localStorage = { getItem: () => '', setItem: () => {} };
     (globalThis as any).fetch = vi.fn(async () => ({
       ok: true,
       json: async () => ({ status: 'ok' }),
-      headers: { get: () => null }
+      headers: { get: () => null },
     }));
 
-    await import('file://' + path.resolve(__dirname, '../../../contract_review_app/contract_review_app/static/panel/taskpane.bundle.js'));
+    await import(
+      'file://' +
+        path.resolve(
+          __dirname,
+          '../../../contract_review_app/contract_review_app/static/panel/taskpane.bundle.js'
+        )
+    );
     await new Promise(res => setTimeout(res, 0));
 
     expect(btnWhole.disabled).toBe(false);

--- a/word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts
+++ b/word_addin_dev/app/__tests__/ensure.text.analyze.spec.ts
@@ -3,8 +3,11 @@ import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 
 const html = readFileSync(
-  new URL('../../../contract_review_app/contract_review_app/static/panel/taskpane.html', import.meta.url),
-  'utf-8',
+  new URL(
+    '../../../contract_review_app/contract_review_app/static/panel/taskpane.html',
+    import.meta.url
+  ),
+  'utf-8'
 );
 
 describe('ensure text for analyze', () => {
@@ -18,14 +21,20 @@ describe('ensure text for analyze', () => {
     (globalThis as any).CustomEvent = dom.window.CustomEvent;
     (globalThis as any).localStorage = {
       store: { api_key: 'k', schema_version: '1.4', backendUrl: 'https://127.0.0.1:9443' },
-      getItem(key: string) { return (this.store as any)[key] || null; },
-      setItem(key: string, value: string) { (this.store as any)[key] = value; }
+      getItem(key: string) {
+        return (this.store as any)[key] || null;
+      },
+      setItem(key: string, value: string) {
+        (this.store as any)[key] = value;
+      },
     };
-    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
     (globalThis as any).fetch = fetchMock;
     (globalThis as any).Office = {
       onReady: (cb: any) => cb({ host: 'Word' }),
-      context: { requirements: { isSetSupported: () => true }, host: 'Word' }
+      context: { requirements: { isSetSupported: () => true }, host: 'Word' },
     };
     (globalThis as any).__CAI_TESTING__ = true;
   });
@@ -36,7 +45,9 @@ describe('ensure text for analyze', () => {
     const { onAnalyze } = await import('../assets/taskpane.ts');
     await onAnalyze();
     expect(getWholeDocText).toHaveBeenCalledOnce();
-    const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
+    const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) =>
+      String(c[0]).includes('/api/analyze')
+    );
     expect(analyzeCalls.length).toBe(1);
     const opts = analyzeCalls[0][1];
     const body = JSON.parse(opts.body);
@@ -48,12 +59,18 @@ describe('ensure text for analyze', () => {
   it('warns when document empty', async () => {
     const getWholeDocText = vi.fn().mockResolvedValue('');
     (globalThis as any).getWholeDocText = getWholeDocText;
-    vi.mock('../assets/notifier', () => ({ notifyWarn: vi.fn(), notifyErr: vi.fn(), notifyOk: vi.fn() }));
+    vi.mock('../assets/notifier', () => ({
+      notifyWarn: vi.fn(),
+      notifyErr: vi.fn(),
+      notifyOk: vi.fn(),
+    }));
     const { onAnalyze } = await import('../assets/taskpane');
     const { notifyWarn } = await import('../assets/notifier');
     await onAnalyze();
     expect(getWholeDocText).toHaveBeenCalledOnce();
-    const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
+    const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) =>
+      String(c[0]).includes('/api/analyze')
+    );
     expect(analyzeCalls.length).toBe(0);
     expect(notifyWarn).toHaveBeenCalledWith('Document is empty');
   });

--- a/word_addin_dev/app/__tests__/health.negatives.spec.ts
+++ b/word_addin_dev/app/__tests__/health.negatives.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('checkHealth negatives', () => {
-  beforeEach(() => { vi.resetModules(); });
+  beforeEach(() => {
+    vi.resetModules();
+  });
 
   it('handles non-ok response', async () => {
     (globalThis as any).window = globalThis;

--- a/word_addin_dev/app/__tests__/health.positive.spec.ts
+++ b/word_addin_dev/app/__tests__/health.positive.spec.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('health positive', () => {
-  beforeEach(() => { vi.resetModules(); });
+  beforeEach(() => {
+    vi.resetModules();
+  });
 
   it('returns ok', async () => {
     (globalThis as any).window = globalThis;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
     (globalThis as any).fetch = fetchMock;
     const { checkHealth } = await import('../assets/health.ts');
     const res = await checkHealth({ backend: 'http://x' });

--- a/word_addin_dev/app/__tests__/insertDraftText.spec.ts
+++ b/word_addin_dev/app/__tests__/insertDraftText.spec.ts
@@ -1,56 +1,62 @@
-import { describe, it, expect, vi } from 'vitest'
-import { insertDraftText } from '../assets/insert'
+import { describe, it, expect, vi } from 'vitest';
+import { insertDraftText } from '../assets/insert';
 
 describe('insertDraftText', () => {
   it('skips empty text', async () => {
-    const run = vi.fn()
-    ;(globalThis as any).Word = { run }
-    await insertDraftText('', 'live')
-    expect(run).not.toHaveBeenCalled()
-  })
+    const run = vi.fn();
+    (globalThis as any).Word = { run };
+    await insertDraftText('', 'live');
+    expect(run).not.toHaveBeenCalled();
+  });
 
   it('calls Word.run once', async () => {
     const run = vi.fn(async (cb: any) => {
-      const sel = { isEmpty: true, load: vi.fn(), insertText: vi.fn().mockReturnValue({}) }
-      const rangeEnd = { insertText: vi.fn().mockReturnValue({}) }
-      const doc = { getSelection: () => sel, body: { getRange: () => rangeEnd }, comments: { add: vi.fn() } }
-      await cb({ document: doc, sync: vi.fn() })
-    })
-    ;(globalThis as any).Word = { run, InsertLocation: { replace: 'Replace' } }
-    await insertDraftText('hello', 'live')
-    expect(run).toHaveBeenCalledTimes(1)
-  })
+      const sel = { isEmpty: true, load: vi.fn(), insertText: vi.fn().mockReturnValue({}) };
+      const rangeEnd = { insertText: vi.fn().mockReturnValue({}) };
+      const doc = {
+        getSelection: () => sel,
+        body: { getRange: () => rangeEnd },
+        comments: { add: vi.fn() },
+      };
+      await cb({ document: doc, sync: vi.fn() });
+    });
+    (globalThis as any).Word = { run, InsertLocation: { replace: 'Replace' } };
+    await insertDraftText('hello', 'live');
+    expect(run).toHaveBeenCalledTimes(1);
+  });
 
   it('inserts draft_text without replacing whole paragraph', async () => {
-    const draft = 'draft_text'
+    const draft = 'draft_text';
     const range: any = {
       isEmpty: false,
       load: vi.fn(),
       text: 'orig',
       insertText: vi.fn((txt: string) => {
-        range.text = txt
-        return {}
+        range.text = txt;
+        return {};
       }),
-    }
-    const body = { getRange: vi.fn() }
-    const doc = { getSelection: () => range, body, comments: { add: vi.fn() } }
+    };
+    const body = { getRange: vi.fn() };
+    const doc = { getSelection: () => range, body, comments: { add: vi.fn() } };
     const run = vi.fn(async (cb: any) => {
-      await cb({ document: doc, sync: vi.fn() })
-    })
-    ;(globalThis as any).Word = { run, InsertLocation: { replace: 'Replace' } }
-    await insertDraftText(draft, 'live')
-    expect(range.insertText).toHaveBeenCalledWith(draft, 'Replace')
-    expect(body.getRange).not.toHaveBeenCalled()
-    expect(range.text).toBe(draft)
-  })
+      await cb({ document: doc, sync: vi.fn() });
+    });
+    (globalThis as any).Word = { run, InsertLocation: { replace: 'Replace' } };
+    await insertDraftText(draft, 'live');
+    expect(range.insertText).toHaveBeenCalledWith(draft, 'Replace');
+    expect(body.getRange).not.toHaveBeenCalled();
+    expect(range.text).toBe(draft);
+  });
 
   it('logs debug info and rethrows', async () => {
-    const err: any = { code: 'X', message: 'boom', debugInfo: { errorLocation: 'loc' } }
-    const run = vi.fn(async () => { throw err })
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    ;(globalThis as any).Word = { run }
-    await expect(insertDraftText('hi', 'live')).rejects.toBe(err)
-    expect(spy).toHaveBeenCalledWith('insertDraftText error', err.code, err.message, err.debugInfo)
-    spy.mockRestore()
-  })
-})
+    const err: any = { code: 'X', message: 'boom', debugInfo: { errorLocation: 'loc' } };
+    const run = vi.fn(async () => {
+      throw err;
+    });
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (globalThis as any).Word = { run };
+    await expect(insertDraftText('hi', 'live')).rejects.toBe(err);
+    expect(spy).toHaveBeenCalledWith('insertDraftText error', err.code, err.message, err.debugInfo);
+    spy.mockRestore();
+  });
+});

--- a/word_addin_dev/app/__tests__/insertIntoWord.test.ts
+++ b/word_addin_dev/app/__tests__/insertIntoWord.test.ts
@@ -5,8 +5,14 @@ describe('onInsertIntoWord', () => {
     (globalThis as any).__CAI_TESTING__ = true;
     const add = vi.fn();
     const sel = { isEmpty: false, load: vi.fn(), insertText: vi.fn().mockReturnValue({}) };
-    const doc = { getSelection: () => sel, body: { getRange: () => ({}) }, comments: { add } } as any;
-    const run = vi.fn(async (cb: any) => { await cb({ document: doc, sync: vi.fn() }); });
+    const doc = {
+      getSelection: () => sel,
+      body: { getRange: () => ({}) },
+      comments: { add },
+    } as any;
+    const run = vi.fn(async (cb: any) => {
+      await cb({ document: doc, sync: vi.fn() });
+    });
     (globalThis as any).Word = { run, InsertLocation: { replace: 'Replace' } };
     (globalThis as any).document = { querySelector: () => ({ value: 'draft' }) } as any;
     const mod = await import('../src/panel/index');

--- a/word_addin_dev/app/__tests__/large.analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/large.analyze.flow.spec.ts
@@ -5,14 +5,27 @@ describe('large analyze flow', () => {
     vi.useFakeTimers();
     const timers: number[] = [];
     const origSet = setTimeout;
-    (globalThis as any).setTimeout = ((fn: any, ms: number) => { timers.push(ms); return origSet(fn, ms); }) as any;
+    (globalThis as any).setTimeout = ((fn: any, ms: number) => {
+      timers.push(ms);
+      return origSet(fn, ms);
+    }) as any;
     const origClear = clearTimeout;
     (globalThis as any).clearTimeout = (id: any) => origClear(id);
-    (globalThis as any).window = { dispatchEvent: () => {}, addEventListener: () => {}, location: { search: '' } } as any;
+    (globalThis as any).window = {
+      dispatchEvent: () => {},
+      addEventListener: () => {},
+      location: { search: '' },
+    } as any;
     (globalThis as any).location = (globalThis as any).window.location;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
-    (globalThis as any).fetch = vi.fn(() =>
-      new Promise(res => setTimeout(() => res({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 }), 12000))
+    (globalThis as any).fetch = vi.fn(
+      () =>
+        new Promise(res =>
+          setTimeout(
+            () => res({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 }),
+            12000
+          )
+        )
     );
     const { postJson } = await import('../assets/api-client.ts');
     const p = postJson('/api/analyze', { text: 'a'.repeat(400 * 1024) });

--- a/word_addin_dev/app/__tests__/loading.indicator.spec.ts
+++ b/word_addin_dev/app/__tests__/loading.indicator.spec.ts
@@ -2,13 +2,15 @@ import { describe, it, expect, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 
 function setupDom() {
-  const dom = new JSDOM('<div id="loading-book" class="cai-book hidden"></div>', { url: 'https://127.0.0.1' });
+  const dom = new JSDOM('<div id="loading-book" class="cai-book hidden"></div>', {
+    url: 'https://127.0.0.1',
+  });
   (globalThis as any).window = dom.window as any;
   (globalThis as any).document = dom.window.document as any;
   (globalThis as any).CustomEvent = dom.window.CustomEvent;
   dom.window.addEventListener('cai:busy', (e: any) => {
     const el = dom.window.document.getElementById('loading-book');
-    const busy = !!(e?.detail?.busy);
+    const busy = !!e?.detail?.busy;
     if (busy) el?.classList.remove('hidden');
     else el?.classList.add('hidden');
   });
@@ -20,50 +22,72 @@ describe('loading indicator', () => {
     vi.resetModules();
     const dom = setupDom();
     const { withBusy } = await import('../assets/pending.ts');
-    const p = withBusy(async () => { await new Promise(r => setTimeout(r, 50)); });
+    const p = withBusy(async () => {
+      await new Promise(r => setTimeout(r, 50));
+    });
     await Promise.resolve();
-    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(false);
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      false
+    );
     await p;
-    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      true
+    );
   });
 
   it('aggregates concurrent operations', async () => {
     vi.resetModules();
     const dom = setupDom();
     const { withBusy } = await import('../assets/pending.ts');
-    const wait = (ms:number) => new Promise(r => setTimeout(r, ms));
+    const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
     const p1 = withBusy(() => wait(20));
     const p2 = withBusy(() => wait(40));
     await Promise.resolve();
-    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(false);
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      false
+    );
     await p1;
-    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(false);
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      false
+    );
     await p2;
-    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      true
+    );
   });
 
   it('hides after rejected operation', async () => {
     vi.resetModules();
     const dom = setupDom();
     const { withBusy } = await import('../assets/pending.ts');
-    await withBusy(async () => { throw new Error('x'); }).catch(() => {});
-    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+    await withBusy(async () => {
+      throw new Error('x');
+    }).catch(() => {});
+    expect(dom.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      true
+    );
   });
 
   it('isolates per window', async () => {
-    const wait = (ms:number) => new Promise(r => setTimeout(r, ms));
+    const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
 
     vi.resetModules();
     const dom1 = setupDom();
     const { withBusy: withBusy1 } = await import('../assets/pending.ts');
     await withBusy1(() => wait(20));
-    expect(dom1.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+    expect(dom1.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      true
+    );
 
     vi.resetModules();
     const dom2 = setupDom();
     const { withBusy: withBusy2 } = await import('../assets/pending.ts');
-    expect(dom1.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+    expect(dom1.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      true
+    );
     await withBusy2(() => wait(20));
-    expect(dom2.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(true);
+    expect(dom2.window.document.getElementById('loading-book')?.classList.contains('hidden')).toBe(
+      true
+    );
   });
 });

--- a/word_addin_dev/app/__tests__/logging.test.ts
+++ b/word_addin_dev/app/__tests__/logging.test.ts
@@ -8,7 +8,7 @@ describe('extended error logging', () => {
     (globalThis as any).window = globalThis;
     (globalThis as any).localStorage = {
       getItem: () => null,
-      setItem: () => {}
+      setItem: () => {},
     };
     const stubEl = {
       addEventListener: () => {},
@@ -17,13 +17,13 @@ describe('extended error logging', () => {
       setAttribute: () => {},
       removeAttribute: () => {},
       innerHTML: '',
-      textContent: ''
+      textContent: '',
     };
     (globalThis as any).document = {
       readyState: 'complete',
       addEventListener: () => {},
       querySelector: () => stubEl,
-      body: { dataset: {}, querySelectorAll: () => ({ forEach: () => {} }) }
+      body: { dataset: {}, querySelectorAll: () => ({ forEach: () => {} }) },
     };
     (globalThis as any).__CAI_TESTING__ = true;
   });

--- a/word_addin_dev/app/__tests__/no-text.blocks-analyze.spec.ts
+++ b/word_addin_dev/app/__tests__/no-text.blocks-analyze.spec.ts
@@ -3,7 +3,10 @@ import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 
 const html = readFileSync(
-  new URL('../../../contract_review_app/contract_review_app/static/panel/taskpane.html', import.meta.url),
+  new URL(
+    '../../../contract_review_app/contract_review_app/static/panel/taskpane.html',
+    import.meta.url
+  ),
   'utf-8'
 );
 
@@ -18,21 +21,31 @@ describe('no text blocks analyze', () => {
     (globalThis as any).CustomEvent = dom.window.CustomEvent;
     (globalThis as any).localStorage = {
       store: { api_key: 'k', schema_version: '1.4', backendUrl: 'https://127.0.0.1:9443' },
-      getItem(key: string) { return (this.store as any)[key] || null; },
-      setItem(key: string, value: string) { (this.store as any)[key] = value; }
+      getItem(key: string) {
+        return (this.store as any)[key] || null;
+      },
+      setItem(key: string, value: string) {
+        (this.store as any)[key] = value;
+      },
     };
-    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
     (globalThis as any).fetch = fetchMock;
     (globalThis as any).Office = {
       onReady: (cb: any) => cb({ host: 'Word' }),
-      context: { requirements: { isSetSupported: () => true }, host: 'Word' }
+      context: { requirements: { isSetSupported: () => true }, host: 'Word' },
     };
     (globalThis as any).Word = {
-      Revision: {}, Comment: {}, SearchOptions: {}, ContentControl: {},
-      run: (fn: any) => fn({
-        document: { body: { text: '', load: () => {} } },
-        sync: async () => {}
-      })
+      Revision: {},
+      Comment: {},
+      SearchOptions: {},
+      ContentControl: {},
+      run: (fn: any) =>
+        fn({
+          document: { body: { text: '', load: () => {} } },
+          sync: async () => {},
+        }),
     };
     (globalThis as any).__CAI_TESTING__ = true;
   });
@@ -53,7 +66,9 @@ describe('no text blocks analyze', () => {
     btnAnalyze.disabled = false;
     btnAnalyze.click();
 
-    const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
+    const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) =>
+      String(c[0]).includes('/api/analyze')
+    );
     expect(analyzeCalls.length).toBe(0);
   });
 });

--- a/word_addin_dev/app/__tests__/normalize.full.spec.ts
+++ b/word_addin_dev/app/__tests__/normalize.full.spec.ts
@@ -33,7 +33,7 @@ describe('normalizeTextFull', () => {
       ' “Quote” — dash ',
       'A\u00A0B\u200B C',
       'Line1\rLine2',
-      'Zero\u200DWidth'
+      'Zero\u200DWidth',
     ];
     for (const sample of samples) {
       const result = normalizeTextFull(sample);

--- a/word_addin_dev/app/__tests__/panel.dom.contract.spec.ts
+++ b/word_addin_dev/app/__tests__/panel.dom.contract.spec.ts
@@ -5,7 +5,10 @@ const schema = JSON.parse(
   readFileSync(new URL('../panel_dom.schema.json', import.meta.url), 'utf-8')
 );
 const html = readFileSync(
-  new URL('../../../contract_review_app/contract_review_app/static/panel/taskpane.html', import.meta.url),
+  new URL(
+    '../../../contract_review_app/contract_review_app/static/panel/taskpane.html',
+    import.meta.url
+  ),
   'utf-8'
 );
 

--- a/word_addin_dev/app/__tests__/postJson.timeout.spec.ts
+++ b/word_addin_dev/app/__tests__/postJson.timeout.spec.ts
@@ -5,20 +5,37 @@ describe('postJson timeout/retry', () => {
     vi.useFakeTimers();
     const timers: number[] = [];
     const origSet = setTimeout;
-    (globalThis as any).setTimeout = ((fn: any, ms: number) => { timers.push(ms); return origSet(fn, ms); }) as any;
+    (globalThis as any).setTimeout = ((fn: any, ms: number) => {
+      timers.push(ms);
+      return origSet(fn, ms);
+    }) as any;
     const origClear = clearTimeout;
     (globalThis as any).clearTimeout = (id: any) => origClear(id);
-    (globalThis as any).window = { dispatchEvent: () => {}, addEventListener: () => {}, location: { search: '' } } as any;
+    (globalThis as any).window = {
+      dispatchEvent: () => {},
+      addEventListener: () => {},
+      location: { search: '' },
+    } as any;
     (globalThis as any).location = (globalThis as any).window.location;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
     const logs: string[] = [];
-    vi.spyOn(console, 'log').mockImplementation((...a: any[]) => { logs.push(a.join(' ')); });
+    vi.spyOn(console, 'log').mockImplementation((...a: any[]) => {
+      logs.push(a.join(' '));
+    });
     const fetchMock = vi
       .fn()
-      .mockImplementationOnce((_u, opts: any) => new Promise((_res, rej) => {
-        opts.signal.addEventListener('abort', () => rej(new DOMException('x', 'AbortError')));
-      }))
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
+      .mockImplementationOnce(
+        (_u, opts: any) =>
+          new Promise((_res, rej) => {
+            opts.signal.addEventListener('abort', () => rej(new DOMException('x', 'AbortError')));
+          })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+        headers: new Headers(),
+        status: 200,
+      });
     (globalThis as any).fetch = fetchMock;
     const { postJson } = await import('../assets/api-client.ts');
     const p = postJson('/api/analyze', { text: 'hi' });
@@ -36,7 +53,10 @@ describe('postJson timeout/retry', () => {
     vi.useFakeTimers();
     const timers: number[] = [];
     const origSet = setTimeout;
-    (globalThis as any).setTimeout = ((fn: any, ms: number) => { timers.push(ms); return origSet(fn, ms); }) as any;
+    (globalThis as any).setTimeout = ((fn: any, ms: number) => {
+      timers.push(ms);
+      return origSet(fn, ms);
+    }) as any;
     const origClear2 = clearTimeout;
     (globalThis as any).clearTimeout = (id: any) => origClear2(id);
     const store: Record<string, string> = {
@@ -46,7 +66,9 @@ describe('postJson timeout/retry', () => {
     };
     (globalThis as any).localStorage = {
       getItem: (k: string) => store[k] || null,
-      setItem: (k: string, v: string) => { store[k] = v; },
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
     } as any;
     (globalThis as any).window = {
       dispatchEvent: () => {},
@@ -56,13 +78,24 @@ describe('postJson timeout/retry', () => {
     (globalThis as any).location = (globalThis as any).window.location;
     const fetchMock = vi
       .fn()
-      .mockImplementationOnce((_u, opts: any) => new Promise((_res, rej) => {
-        opts.signal.addEventListener('abort', () => rej(new DOMException('x', 'AbortError')));
-      }))
-      .mockImplementationOnce((_u, opts: any) => new Promise((_res, rej) => {
-        opts.signal.addEventListener('abort', () => rej(new DOMException('x', 'AbortError')));
-      }))
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
+      .mockImplementationOnce(
+        (_u, opts: any) =>
+          new Promise((_res, rej) => {
+            opts.signal.addEventListener('abort', () => rej(new DOMException('x', 'AbortError')));
+          })
+      )
+      .mockImplementationOnce(
+        (_u, opts: any) =>
+          new Promise((_res, rej) => {
+            opts.signal.addEventListener('abort', () => rej(new DOMException('x', 'AbortError')));
+          })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+        headers: new Headers(),
+        status: 200,
+      });
     (globalThis as any).fetch = fetchMock;
     const { postJson } = await import('../assets/api-client.ts');
     const p = postJson('/api/analyze', { text: 'hi' });

--- a/word_addin_dev/app/__tests__/props/normalized_equivalence.spec.ts
+++ b/word_addin_dev/app/__tests__/props/normalized_equivalence.spec.ts
@@ -57,7 +57,7 @@ describe('normalizeIntakeText', () => {
     "'": ["'", '’', '‘', '‚', '‛'],
     '-': ['-', '—', '–', '−', '‒'],
     ' ': [' ', '\u00A0'],
-    '\n': ['\n', '\r', '\r\n']
+    '\n': ['\n', '\r', '\r\n'],
   };
 
   const randomReplace = (ch: string): string => {
@@ -75,7 +75,9 @@ describe('normalizeIntakeText', () => {
       }
       mutated = mutated.replace('clause', 'clause\nline');
       const newlineVariants = ['\n', '\r', '\r\n'];
-      const newline = newlineVariants[Math.floor(Math.random() * newlineVariants.length)].replace('\\n', '\n').replace('\\r', '\r');
+      const newline = newlineVariants[Math.floor(Math.random() * newlineVariants.length)]
+        .replace('\\n', '\n')
+        .replace('\\r', '\r');
       mutated = mutated.replace('\n', newline);
       const normalized = normalizeIntakeText(mutated);
       expect(normalized).toBe('Alpha - "beta\'s" clause\nline');
@@ -86,7 +88,7 @@ describe('normalizeIntakeText', () => {
     const cases: Array<[string, string]> = [
       ['A\u200Bgreement — “Quote”\u00A0', 'Agreement - "Quote"'],
       ['Cafe\u0301', 'Café'],
-      [' Foo\t\tBar ', 'Foo Bar']
+      [' Foo\t\tBar ', 'Foo Bar'],
     ];
     for (const [input, expected] of cases) {
       expect(normalizeIntakeText(input)).toBe(expected);

--- a/word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts
+++ b/word_addin_dev/app/__tests__/qa.recheck.navigation.spec.ts
@@ -3,8 +3,11 @@ import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 
 const html = readFileSync(
-  new URL('../../../contract_review_app/contract_review_app/static/panel/taskpane.html', import.meta.url),
-  'utf-8',
+  new URL(
+    '../../../contract_review_app/contract_review_app/static/panel/taskpane.html',
+    import.meta.url
+  ),
+  'utf-8'
 );
 
 describe('qa recheck navigation', () => {
@@ -21,11 +24,21 @@ describe('qa recheck navigation', () => {
       context: {
         requirements: { isSetSupported: () => true },
         host: 'Word',
-        document: { addHandlerAsync: (_: any, cb: any) => { (globalThis as any).__selHandler = cb; } },
+        document: {
+          addHandlerAsync: (_: any, cb: any) => {
+            (globalThis as any).__selHandler = cb;
+          },
+        },
       },
       EventType: { DocumentSelectionChanged: 'DocumentSelectionChanged' },
     };
-    (globalThis as any).Word = { run: async () => {}, SearchOptions: {}, Comment: {}, Revision: {}, ContentControl: {} };
+    (globalThis as any).Word = {
+      run: async () => {},
+      SearchOptions: {},
+      Comment: {},
+      Revision: {},
+      ContentControl: {},
+    };
     (globalThis as any).__CAI_TESTING__ = true;
   });
 
@@ -73,7 +86,11 @@ describe('qa recheck navigation', () => {
     await postJSON('/api/qa-recheck', { document_id: 'doc1', rules: {}, risk: expectedRisk });
     resultsEl.dispatchEvent(new CustomEvent('ca.qa', { detail: qaResp }));
 
-    expect(postJSON).toHaveBeenCalledWith('/api/qa-recheck', { document_id: 'doc1', rules: {}, risk: expectedRisk });
+    expect(postJSON).toHaveBeenCalledWith('/api/qa-recheck', {
+      document_id: 'doc1',
+      rules: {},
+      risk: expectedRisk,
+    });
 
     const items = (window as any).__findings;
     expect(items).toEqual(qaResp.analysis.findings);

--- a/word_addin_dev/app/__tests__/render.ch.spec.ts
+++ b/word_addin_dev/app/__tests__/render.ch.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest';
 
 function createElementFactory(elements: Record<string, any>) {
   return function createElement(tag: string) {
@@ -8,83 +8,83 @@ function createElementFactory(elements: Record<string, any>) {
       style: {},
       appendChild(child: any) {
         if (child === undefined || child === null) {
-          return child
+          return child;
         }
-        this.children.push(child)
+        this.children.push(child);
         if (typeof child === 'object') {
-          child.parentElement = this
+          child.parentElement = this;
         }
-        return child
+        return child;
       },
       removeChild(child: any) {
-        this.children = this.children.filter((node: any) => node !== child)
+        this.children = this.children.filter((node: any) => node !== child);
         if (child && typeof child === 'object') {
-          child.parentElement = null
+          child.parentElement = null;
         }
-        return child
+        return child;
       },
       setAttribute(name: string, value: any) {
-        ;(this as any)[name] = value
+        (this as any)[name] = value;
       },
-    }
+    };
 
-    let textContent = ''
+    let textContent = '';
     Object.defineProperty(el, 'textContent', {
       get() {
-        return textContent
+        return textContent;
       },
       set(val) {
-        textContent = String(val ?? '')
+        textContent = String(val ?? '');
       },
-    })
+    });
 
     Object.defineProperty(el, 'innerHTML', {
       get() {
-        return textContent
+        return textContent;
       },
-      set(_val) {
-        textContent = ''
-        el.children = []
+      set() {
+        textContent = '';
+        el.children = [];
       },
-    })
+    });
 
     Object.defineProperty(el, 'id', {
       get() {
-        return (this as any)._id
+        return (this as any)._id;
       },
       set(val) {
-        ;(this as any)._id = val
+        (this as any)._id = val;
         if (val) {
-          elements[val] = el
+          elements[val] = el;
         }
       },
-    })
+    });
 
-    return el
-  }
+    return el;
+  };
 }
 
 function collectText(node: any): string {
-  if (!node) return ''
-  let text = node.textContent || ''
+  if (!node) return '';
+  let text = node.textContent || '';
   if (Array.isArray(node.children) && node.children.length) {
     for (const child of node.children) {
-      text += collectText(child)
+      text += collectText(child);
     }
   }
-  return text
+  return text;
 }
 
 function findAnchor(node: any): any {
-  if (!node) return undefined
-  if (node.tagName === 'A') return node
+  if (!node) return undefined;
+  if (node.tagName === 'A') return node;
   if (Array.isArray(node.children)) {
     for (const child of node.children) {
-      const found = findAnchor(child)
-      if (found) return found
+      const found = findAnchor(child);
+      if (found) return found;
     }
   }
-  return undefined
+  return undefined;
 }
 
 describe('Companies House rendering', () => {
@@ -93,40 +93,54 @@ describe('Companies House rendering', () => {
       clauseTypeOut: { textContent: '' },
       resFindingsCount: { textContent: '' },
       visibleHiddenOut: { textContent: '' },
-      findingsList: { innerHTML: '', children: [] as any[], appendChild(el: any) { this.children.push(el); return el } },
-      recommendationsList: { innerHTML: '', children: [] as any[], appendChild(el: any) { this.children.push(el); return el } },
+      findingsList: {
+        innerHTML: '',
+        children: [] as any[],
+        appendChild(el: any) {
+          this.children.push(el);
+          return el;
+        },
+      },
+      recommendationsList: {
+        innerHTML: '',
+        children: [] as any[],
+        appendChild(el: any) {
+          this.children.push(el);
+          return el;
+        },
+      },
       findingsBlock: { style: { display: 'none' } },
       recommendationsBlock: { style: { display: 'none' } },
-    }
+    };
 
-    const createElement = createElementFactory(elements)
-    const resultsBlock = createElement('div')
-    resultsBlock.style.display = 'none'
+    const createElement = createElementFactory(elements);
+    const resultsBlock = createElement('div');
+    resultsBlock.style.display = 'none';
     resultsBlock.style.removeProperty = function (prop: string) {
-      delete (this as any)[prop]
-    }
-    resultsBlock.id = 'resultsBlock'
+      delete (this as any)[prop];
+    };
+    resultsBlock.id = 'resultsBlock';
 
     const docStub: any = {
       getElementById(id: string) {
-        return elements[id] || null
+        return elements[id] || null;
       },
       createElement,
-    }
-    elements.resultsBlock = resultsBlock
+    };
+    elements.resultsBlock = resultsBlock;
 
-    const originalDocument = (globalThis as any).document
-    const originalWindow = (globalThis as any).window
-    const originalLocalStorage = (globalThis as any).localStorage
-    const originalTesting = (globalThis as any).__CAI_TESTING__
+    const originalDocument = (globalThis as any).document;
+    const originalWindow = (globalThis as any).window;
+    const originalLocalStorage = (globalThis as any).localStorage;
+    const originalTesting = (globalThis as any).__CAI_TESTING__;
 
     try {
-      ;(globalThis as any).document = docStub
-      ;(globalThis as any).window = globalThis as any
-      ;(globalThis as any).localStorage = { getItem: () => null, setItem: () => {} }
-      ;(globalThis as any).__CAI_TESTING__ = true
+      (globalThis as any).document = docStub;
+      (globalThis as any).window = globalThis as any;
+      (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} };
+      (globalThis as any).__CAI_TESTING__ = true;
 
-      const mod = await import('../assets/taskpane')
+      const mod = await import('../assets/taskpane');
 
       const payload = {
         summary: {
@@ -158,52 +172,53 @@ describe('Companies House rendering', () => {
                 sic_codes: ['62020'],
                 links: {
                   self: 'https://api.company-information.service.gov.uk/company/12345678',
-                  officers: 'https://api.company-information.service.gov.uk/company/12345678/officers',
+                  officers:
+                    'https://api.company-information.service.gov.uk/company/12345678/officers',
                 },
               },
             },
           ],
         },
-      }
+      };
 
-      mod.renderAnalysisSummary(payload)
+      mod.renderAnalysisSummary(payload);
 
-      const chBlock = elements.companiesHouseBlock
-      expect(chBlock).toBeTruthy()
-      expect(resultsBlock.children.includes(chBlock)).toBe(true)
+      const chBlock = elements.companiesHouseBlock;
+      expect(chBlock).toBeTruthy();
+      expect(resultsBlock.children.includes(chBlock)).toBe(true);
 
-      const entry = chBlock.children[1]
-      expect(entry).toBeTruthy()
-      const header = entry.children[0]
-      expect(header.children[0].textContent).toBe('Match')
+      const entry = chBlock.children[1];
+      expect(entry).toBeTruthy();
+      const header = entry.children[0];
+      expect(header.children[0].textContent).toBe('Match');
 
-      const text = collectText(chBlock)
-      expect(text).toContain('Company number: 12345678')
-      expect(text).toContain('Status: active')
+      const text = collectText(chBlock);
+      expect(text).toContain('Company number: 12345678');
+      expect(text).toContain('Status: active');
 
-      const link = findAnchor(chBlock)
-      expect(link?.href).toContain('/company/12345678')
+      const link = findAnchor(chBlock);
+      expect(link?.href).toContain('/company/12345678');
     } finally {
       if (originalDocument === undefined) {
-        delete (globalThis as any).document
+        delete (globalThis as any).document;
       } else {
-        ;(globalThis as any).document = originalDocument
+        (globalThis as any).document = originalDocument;
       }
       if (originalWindow === undefined) {
-        delete (globalThis as any).window
+        delete (globalThis as any).window;
       } else {
-        ;(globalThis as any).window = originalWindow
+        (globalThis as any).window = originalWindow;
       }
       if (originalLocalStorage === undefined) {
-        delete (globalThis as any).localStorage
+        delete (globalThis as any).localStorage;
       } else {
-        ;(globalThis as any).localStorage = originalLocalStorage
+        (globalThis as any).localStorage = originalLocalStorage;
       }
       if (originalTesting === undefined) {
-        delete (globalThis as any).__CAI_TESTING__
+        delete (globalThis as any).__CAI_TESTING__;
       } else {
-        ;(globalThis as any).__CAI_TESTING__ = originalTesting
+        (globalThis as any).__CAI_TESTING__ = originalTesting;
       }
     }
-  })
-})
+  });
+});

--- a/word_addin_dev/app/__tests__/render.trace.spec.ts
+++ b/word_addin_dev/app/__tests__/render.trace.spec.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest';
 
 function matchesSelector(el: any, selector: string): boolean {
-  if (!el) return false
+  if (!el) return false;
   if (selector === '.muted') {
-    const cls = typeof el.className === 'string' ? el.className : ''
-    return cls.split(/\s+/).includes('muted')
+    const cls = typeof el.className === 'string' ? el.className : '';
+    return cls.split(/\s+/).includes('muted');
   }
-  const roleMatch = selector.match(/^\[data-role="(.+)"\]$/)
+  const roleMatch = selector.match(/^\[data-role="(.+)"\]$/);
   if (roleMatch) {
-    return el.dataset?.role === roleMatch[1]
+    return el.dataset?.role === roleMatch[1];
   }
-  return false
+  return false;
 }
 
 function createElementFactory(elements: Record<string, any>) {
@@ -24,161 +24,161 @@ function createElementFactory(elements: Record<string, any>) {
       parentElement: null as any,
       appendChild(child: any) {
         if (child === undefined || child === null) {
-          return child
+          return child;
         }
         if (typeof child === 'string') {
-          const textNode = { nodeType: 3, textContent: String(child) }
-          this.children.push(textNode)
-          return textNode
+          const textNode = { nodeType: 3, textContent: String(child) };
+          this.children.push(textNode);
+          return textNode;
         }
-        this.children.push(child)
+        this.children.push(child);
         if (typeof child === 'object') {
-          child.parentElement = this
+          child.parentElement = this;
         }
-        return child
+        return child;
       },
       removeChild(child: any) {
-        this.children = this.children.filter((node: any) => node !== child)
+        this.children = this.children.filter((node: any) => node !== child);
         if (child && typeof child === 'object') {
-          child.parentElement = null
+          child.parentElement = null;
         }
-        return child
+        return child;
       },
       append(...nodes: any[]) {
         for (const node of nodes) {
-          if (node === undefined || node === null) continue
+          if (node === undefined || node === null) continue;
           if (typeof node === 'string') {
-            const textNode = { nodeType: 3, textContent: String(node) }
-            this.children.push(textNode)
-            continue
+            const textNode = { nodeType: 3, textContent: String(node) };
+            this.children.push(textNode);
+            continue;
           }
-          this.appendChild(node)
+          this.appendChild(node);
         }
       },
       replaceChildren(...nodes: any[]) {
-        this.children = []
-        this.append(...nodes)
+        this.children = [];
+        this.append(...nodes);
       },
       querySelector(selector: string) {
         if (matchesSelector(this, selector)) {
-          return this
+          return this;
         }
         for (const child of this.children) {
           if (child && typeof child === 'object' && typeof child.querySelector === 'function') {
-            const found = child.querySelector(selector)
-            if (found) return found
+            const found = child.querySelector(selector);
+            if (found) return found;
           }
         }
-        return null
+        return null;
       },
       setAttribute(name: string, value: any) {
-        ;(this as any)[name] = value
+        (this as any)[name] = value;
       },
       addEventListener() {
         // noop for tests
       },
-    }
+    };
 
-    let textContent = ''
+    let textContent = '';
     Object.defineProperty(el, 'textContent', {
       get() {
-        if (textContent) return textContent
-        let acc = ''
+        if (textContent) return textContent;
+        let acc = '';
         for (const child of el.children) {
           if (child && typeof child === 'object') {
-            acc += child.textContent || ''
+            acc += child.textContent || '';
           } else if (typeof child === 'string') {
-            acc += child
+            acc += child;
           }
         }
-        return acc
+        return acc;
       },
       set(val) {
-        textContent = String(val ?? '')
-        el.children = []
+        textContent = String(val ?? '');
+        el.children = [];
       },
-    })
+    });
 
     Object.defineProperty(el, 'innerHTML', {
       get() {
-        return textContent
+        return textContent;
       },
-      set(_val) {
-        textContent = ''
-        el.children = []
+      set() {
+        textContent = '';
+        el.children = [];
       },
-    })
+    });
 
     Object.defineProperty(el, 'id', {
       get() {
-        return (this as any)._id
+        return (this as any)._id;
       },
       set(val) {
-        ;(this as any)._id = val
+        (this as any)._id = val;
         if (val) {
-          elements[val] = el
+          elements[val] = el;
         }
       },
-    })
+    });
 
-    return el
-  }
+    return el;
+  };
 }
 
 function findAnchor(node: any): any {
-  if (!node) return null
-  if (node.tagName === 'A') return node
+  if (!node) return null;
+  if (node.tagName === 'A') return node;
   if (Array.isArray(node.children)) {
     for (const child of node.children) {
-      const found = findAnchor(child)
-      if (found) return found
+      const found = findAnchor(child);
+      if (found) return found;
     }
   }
-  return null
+  return null;
 }
 
 describe('renderResults trace link', () => {
   it('renders trace link when cid is provided', async () => {
-    const elements: Record<string, any> = {}
-    const createElement = createElementFactory(elements)
+    const elements: Record<string, any> = {};
+    const createElement = createElementFactory(elements);
 
-    const clauseTypeOut = createElement('span')
-    clauseTypeOut.dataset.role = 'clause-type'
-    elements.resClauseType = clauseTypeOut
+    const clauseTypeOut = createElement('span');
+    clauseTypeOut.dataset.role = 'clause-type';
+    elements.resClauseType = clauseTypeOut;
 
-    const findingsList = createElement('ol')
-    findingsList.dataset.role = 'findings'
-    elements.findingsList = findingsList
+    const findingsList = createElement('ol');
+    findingsList.dataset.role = 'findings';
+    elements.findingsList = findingsList;
 
-    const findingsBlock = createElement('div')
-    findingsBlock.id = 'findingsBlock'
-    findingsBlock.style = { display: 'none' }
-    elements.findingsBlock = findingsBlock
+    const findingsBlock = createElement('div');
+    findingsBlock.id = 'findingsBlock';
+    findingsBlock.style = { display: 'none' };
+    elements.findingsBlock = findingsBlock;
 
-    const recommendationsList = createElement('ol')
-    recommendationsList.dataset.role = 'recommendations'
-    elements.recommendationsList = recommendationsList
+    const recommendationsList = createElement('ol');
+    recommendationsList.dataset.role = 'recommendations';
+    elements.recommendationsList = recommendationsList;
 
-    const recommendationsBlock = createElement('div')
-    recommendationsBlock.id = 'recommendationsBlock'
-    recommendationsBlock.style = { display: 'none' }
-    elements.recommendationsBlock = recommendationsBlock
+    const recommendationsBlock = createElement('div');
+    recommendationsBlock.id = 'recommendationsBlock';
+    recommendationsBlock.style = { display: 'none' };
+    elements.recommendationsBlock = recommendationsBlock;
 
-    const findingsCount = createElement('span')
-    findingsCount.dataset.role = 'findings-count'
-    elements.resFindingsCount = findingsCount
+    const findingsCount = createElement('span');
+    findingsCount.dataset.role = 'findings-count';
+    elements.resFindingsCount = findingsCount;
 
-    const rawJson = createElement('pre')
-    rawJson.dataset.role = 'raw-json'
-    elements.rawJson = rawJson
+    const rawJson = createElement('pre');
+    rawJson.dataset.role = 'raw-json';
+    elements.rawJson = rawJson;
 
-    const resultsBlock = createElement('section')
-    resultsBlock.id = 'resultsBlock'
-    const header = createElement('div')
-    header.className = 'muted'
-    header.textContent = 'Results'
-    resultsBlock.appendChild(header)
-    elements.resultsBlock = resultsBlock
+    const resultsBlock = createElement('section');
+    resultsBlock.id = 'resultsBlock';
+    const header = createElement('div');
+    header.className = 'muted';
+    header.textContent = 'Results';
+    resultsBlock.appendChild(header);
+    elements.resultsBlock = resultsBlock;
 
     const roleMap: Record<string, any> = {
       'clause-type': clauseTypeOut,
@@ -186,75 +186,75 @@ describe('renderResults trace link', () => {
       'findings-count': findingsCount,
       'raw-json': rawJson,
       recommendations: recommendationsList,
-    }
+    };
 
-    const originalDocument = (globalThis as any).document
-    const originalWindow = (globalThis as any).window
-    const originalLocalStorage = (globalThis as any).localStorage
-    const originalTesting = (globalThis as any).__CAI_TESTING__
+    const originalDocument = (globalThis as any).document;
+    const originalWindow = (globalThis as any).window;
+    const originalLocalStorage = (globalThis as any).localStorage;
+    const originalTesting = (globalThis as any).__CAI_TESTING__;
 
     try {
-      ;(globalThis as any).document = {
+      (globalThis as any).document = {
         getElementById(id: string) {
-          return elements[id] || null
+          return elements[id] || null;
         },
         querySelector(selector: string) {
-          const roleMatch = selector.match(/^\[data-role="(.+)"\]$/)
+          const roleMatch = selector.match(/^\[data-role="(.+)"\]$/);
           if (roleMatch) {
-            return roleMap[roleMatch[1]] || null
+            return roleMap[roleMatch[1]] || null;
           }
-          return null
+          return null;
         },
         createElement,
-      } as any
-      ;(globalThis as any).window = globalThis as any
-      ;(globalThis as any).localStorage = {
+      } as any;
+      (globalThis as any).window = globalThis as any;
+      (globalThis as any).localStorage = {
         getItem(key: string) {
           if (key === 'backend.url' || key === 'backendUrl') {
-            return 'https://backend.test'
+            return 'https://backend.test';
           }
-          return null
+          return null;
         },
         setItem() {},
-      }
-      ;(globalThis as any).__CAI_TESTING__ = true
+      };
+      (globalThis as any).__CAI_TESTING__ = true;
 
-      const mod = await import('../assets/taskpane')
+      const mod = await import('../assets/taskpane');
       mod.renderResults({
         meta: { cid: 'cid-123' },
         findings: [],
         recommendations: [],
-      })
+      });
 
-      const traceContainer = header.querySelector('[data-role="trace-link"]')
-      expect(traceContainer).toBeTruthy()
-      expect(traceContainer?.style.display).toBe('')
+      const traceContainer = header.querySelector('[data-role="trace-link"]');
+      expect(traceContainer).toBeTruthy();
+      expect(traceContainer?.style.display).toBe('');
 
-      const anchor = findAnchor(traceContainer)
-      expect(anchor).toBeTruthy()
-      expect(anchor?.href).toBe('https://backend.test/api/trace/cid-123')
-      expect(anchor?.textContent).toBe('/api/trace/cid-123')
+      const anchor = findAnchor(traceContainer);
+      expect(anchor).toBeTruthy();
+      expect(anchor?.href).toBe('https://backend.test/api/trace/cid-123');
+      expect(anchor?.textContent).toBe('/api/trace/cid-123');
     } finally {
       if (originalDocument === undefined) {
-        delete (globalThis as any).document
+        delete (globalThis as any).document;
       } else {
-        ;(globalThis as any).document = originalDocument
+        (globalThis as any).document = originalDocument;
       }
       if (originalWindow === undefined) {
-        delete (globalThis as any).window
+        delete (globalThis as any).window;
       } else {
-        ;(globalThis as any).window = originalWindow
+        (globalThis as any).window = originalWindow;
       }
       if (originalLocalStorage === undefined) {
-        delete (globalThis as any).localStorage
+        delete (globalThis as any).localStorage;
       } else {
-        ;(globalThis as any).localStorage = originalLocalStorage
+        (globalThis as any).localStorage = originalLocalStorage;
       }
       if (originalTesting === undefined) {
-        delete (globalThis as any).__CAI_TESTING__
+        delete (globalThis as any).__CAI_TESTING__;
       } else {
-        ;(globalThis as any).__CAI_TESTING__ = originalTesting
+        (globalThis as any).__CAI_TESTING__ = originalTesting;
       }
     }
-  })
-})
+  });
+});

--- a/word_addin_dev/app/__tests__/renderAnalysisSummary.spec.ts
+++ b/word_addin_dev/app/__tests__/renderAnalysisSummary.spec.ts
@@ -1,51 +1,97 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest';
 
 describe('renderAnalysisSummary', () => {
   it('handles minimal response', async () => {
     const elements: Record<string, any> = {
       clauseTypeOut: { textContent: '' },
       visibleHiddenOut: { textContent: '' },
-      findingsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
-      recommendationsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
+      findingsList: {
+        innerHTML: '',
+        children: [] as any[],
+        appendChild(el: any) {
+          this.children.push(el);
+        },
+      },
+      recommendationsList: {
+        innerHTML: '',
+        children: [] as any[],
+        appendChild(el: any) {
+          this.children.push(el);
+        },
+      },
       findingsBlock: { style: { display: 'none' } },
       recommendationsBlock: { style: { display: 'none' } },
-      resultsBlock: { style: { display: 'none', removeProperty(prop: string){ delete (this as any)[prop] } } }
-    }
-    ;(globalThis as any).document = {
-      getElementById(id: string){ return elements[id] || null },
-      createElement(){ return { textContent: '' } as any }
-    } as any
-    ;(globalThis as any).window = globalThis as any
-    ;(globalThis as any).localStorage = { getItem: () => null, setItem: () => {} }
-    ;(globalThis as any).__CAI_TESTING__ = true
-    const mod = await import('../assets/taskpane')
-    mod.renderAnalysisSummary({ findings: [], recommendations: [] })
-    expect(elements.clauseTypeOut.textContent).toBe('—')
-    expect(elements.visibleHiddenOut.textContent).toBe('0 / 0')
-    expect(elements.findingsList.children.length).toBe(0)
-    expect(elements.recommendationsList.children.length).toBe(0)
-    expect(elements.resultsBlock.style.display).toBeUndefined()
-  })
+      resultsBlock: {
+        style: {
+          display: 'none',
+          removeProperty(prop: string) {
+            delete (this as any)[prop];
+          },
+        },
+      },
+    };
+    (globalThis as any).document = {
+      getElementById(id: string) {
+        return elements[id] || null;
+      },
+      createElement() {
+        return { textContent: '' } as any;
+      },
+    } as any;
+    (globalThis as any).window = globalThis as any;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    const mod = await import('../assets/taskpane');
+    mod.renderAnalysisSummary({ findings: [], recommendations: [] });
+    expect(elements.clauseTypeOut.textContent).toBe('—');
+    expect(elements.visibleHiddenOut.textContent).toBe('0 / 0');
+    expect(elements.findingsList.children.length).toBe(0);
+    expect(elements.recommendationsList.children.length).toBe(0);
+    expect(elements.resultsBlock.style.display).toBeUndefined();
+  });
 
   it('ignores non-array findings', async () => {
     const elements: Record<string, any> = {
       clauseTypeOut: { textContent: '' },
       visibleHiddenOut: { textContent: '' },
-      findingsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
-      recommendationsList: { innerHTML: '', children: [] as any[], appendChild(el: any){ this.children.push(el) } },
+      findingsList: {
+        innerHTML: '',
+        children: [] as any[],
+        appendChild(el: any) {
+          this.children.push(el);
+        },
+      },
+      recommendationsList: {
+        innerHTML: '',
+        children: [] as any[],
+        appendChild(el: any) {
+          this.children.push(el);
+        },
+      },
       findingsBlock: { style: { display: 'none' } },
       recommendationsBlock: { style: { display: 'none' } },
-      resultsBlock: { style: { display: 'none', removeProperty(prop: string){ delete (this as any)[prop] } } }
-    }
-    ;(globalThis as any).document = {
-      getElementById(id: string){ return elements[id] || null },
-      createElement(){ return { textContent: '' } as any }
-    } as any
-    ;(globalThis as any).window = globalThis as any
-    ;(globalThis as any).localStorage = { getItem: () => null, setItem: () => {} }
-    ;(globalThis as any).__CAI_TESTING__ = true
-    const mod = await import('../assets/taskpane')
-    expect(() => mod.renderAnalysisSummary({ findings: 'bad' as any })).not.toThrow()
-    expect(elements.findingsList.children.length).toBe(0)
-  })
-})
+      resultsBlock: {
+        style: {
+          display: 'none',
+          removeProperty(prop: string) {
+            delete (this as any)[prop];
+          },
+        },
+      },
+    };
+    (globalThis as any).document = {
+      getElementById(id: string) {
+        return elements[id] || null;
+      },
+      createElement() {
+        return { textContent: '' } as any;
+      },
+    } as any;
+    (globalThis as any).window = globalThis as any;
+    (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} };
+    (globalThis as any).__CAI_TESTING__ = true;
+    const mod = await import('../assets/taskpane');
+    expect(() => mod.renderAnalysisSummary({ findings: 'bad' as any })).not.toThrow();
+    expect(elements.findingsList.children.length).toBe(0);
+  });
+});

--- a/word_addin_dev/app/__tests__/requirement.sets.spec.ts
+++ b/word_addin_dev/app/__tests__/requirement.sets.spec.ts
@@ -2,23 +2,38 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const mkDoc = (ids: string[]) => {
   const elements: Record<string, any> = {};
-  ids.forEach(id => elements[id] = { disabled: false, style: { display: '' }, addEventListener: () => {}, classList: { remove: () => {} }, removeAttribute: () => {} });
+  ids.forEach(
+    id =>
+      (elements[id] = {
+        disabled: false,
+        style: { display: '' },
+        addEventListener: () => {},
+        classList: { remove: () => {} },
+        removeAttribute: () => {},
+      })
+  );
   return {
     getElementById: (id: string) => elements[id] || null,
-    querySelector: (sel: string) => elements[sel.replace('#','')] || null,
+    querySelector: (sel: string) => elements[sel.replace('#', '')] || null,
   } as any;
 };
 
 describe('requirement sets support', () => {
   beforeEach(() => {
     vi.resetModules();
-    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    };
     (globalThis as any).__CAI_TESTING__ = true;
-    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
+    (globalThis as any).Office = {
+      context: { requirements: { isSetSupported: () => true } },
+    } as any;
   });
 
   it('disables revisions buttons when revisions unsupported', async () => {
-    (globalThis as any).document = mkDoc(['btnApplyTracked','btnAcceptAll','btnRejectAll']);
+    (globalThis as any).document = mkDoc(['btnApplyTracked', 'btnAcceptAll', 'btnRejectAll']);
     (globalThis as any).Word = { Comment: {}, SearchOptions: {}, ContentControl: {} } as any;
     const { wireUI } = await import('../assets/taskpane.ts');
     wireUI();
@@ -36,7 +51,7 @@ describe('requirement sets support', () => {
   });
 
   it('disables search navigation when search unsupported', async () => {
-    (globalThis as any).document = mkDoc(['btnPrevIssue','btnNextIssue','btnQARecheck']);
+    (globalThis as any).document = mkDoc(['btnPrevIssue', 'btnNextIssue', 'btnQARecheck']);
     (globalThis as any).Word = { Revision: {}, Comment: {}, ContentControl: {} } as any;
     const { wireUI } = await import('../assets/taskpane.ts');
     wireUI();

--- a/word_addin_dev/app/__tests__/riskThreshold.read.spec.ts
+++ b/word_addin_dev/app/__tests__/riskThreshold.read.spec.ts
@@ -1,30 +1,44 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 describe('risk threshold read', () => {
-  beforeEach(() => { vi.resetModules(); });
+  beforeEach(() => {
+    vi.resetModules();
+  });
 
   it('reads selectRiskThreshold', async () => {
-    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    };
     (globalThis as any).__CAI_TESTING__ = true;
     (globalThis as any).document = {
-      getElementById: (id: string) => id === 'selectRiskThreshold' ? { value: 'high' } : null,
+      getElementById: (id: string) => (id === 'selectRiskThreshold' ? { value: 'high' } : null),
     } as any;
     const mod = await import('../assets/taskpane.ts');
     expect(mod.getRiskThreshold()).toBe('high');
   });
 
   it('passes through critical risk option', async () => {
-    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    };
     (globalThis as any).__CAI_TESTING__ = true;
     (globalThis as any).document = {
-      getElementById: (id: string) => id === 'selectRiskThreshold' ? { value: 'critical' } : null,
+      getElementById: (id: string) => (id === 'selectRiskThreshold' ? { value: 'critical' } : null),
     } as any;
     const mod = await import('../assets/taskpane.ts');
     expect(mod.getRiskThreshold()).toBe('critical');
   });
 
   it('defaults to medium when missing', async () => {
-    (globalThis as any).window = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => {} };
+    (globalThis as any).window = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    };
     (globalThis as any).__CAI_TESTING__ = true;
     (globalThis as any).document = { getElementById: () => null } as any;
     const mod = await import('../assets/taskpane.ts');

--- a/word_addin_dev/app/__tests__/safeBodySearch.spec.ts
+++ b/word_addin_dev/app/__tests__/safeBodySearch.spec.ts
@@ -5,7 +5,11 @@ describe('safeBodySearch', () => {
   it('returns empty items when search keeps failing', async () => {
     const body: any = {
       context: { sync: vi.fn() },
-      search: vi.fn().mockImplementation(() => { const err: any = new Error('fail'); err.code = 'SearchStringInvalidOrTooLong'; throw err; })
+      search: vi.fn().mockImplementation(() => {
+        const err: any = new Error('fail');
+        err.code = 'SearchStringInvalidOrTooLong';
+        throw err;
+      }),
     };
     const res = await safeBodySearch(body, 'x'.repeat(500), {});
     expect(res.items.length).toBe(0);
@@ -13,14 +17,21 @@ describe('safeBodySearch', () => {
   });
 
   it('returns result when search succeeds after truncation', async () => {
-    const inner = { text: 'a'.repeat(500), search: vi.fn().mockReturnValue({ items: [1], load: vi.fn() }) };
+    const inner = {
+      text: 'a'.repeat(500),
+      search: vi.fn().mockReturnValue({ items: [1], load: vi.fn() }),
+    };
     const scope = { paragraphs: { getFirst: vi.fn().mockReturnValue(inner) } };
     const body: any = {
       context: { sync: vi.fn() },
       search: vi.fn().mockImplementation((txt: string) => {
-        if (txt.length > 200) { const err: any = new Error('fail'); err.code = 'SearchStringInvalidOrTooLong'; throw err; }
+        if (txt.length > 200) {
+          const err: any = new Error('fail');
+          err.code = 'SearchStringInvalidOrTooLong';
+          throw err;
+        }
         return { items: [scope], load: vi.fn() };
-      })
+      }),
     };
     const res = await safeBodySearch(body, 'a'.repeat(500), {});
     expect(res.items[0]).toBe(1);

--- a/word_addin_dev/app/__tests__/startup.selftest.spec.ts
+++ b/word_addin_dev/app/__tests__/startup.selftest.spec.ts
@@ -2,19 +2,37 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const baseEnv = () => {
   (globalThis as any).window = globalThis;
-  (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true }, host: 'Word' } } as any;
-  (globalThis as any).Word = { Revision:{}, Comment:{}, SearchOptions:{}, ContentControl:{} } as any;
+  (globalThis as any).Office = {
+    context: { requirements: { isSetSupported: () => true }, host: 'Word' },
+  } as any;
+  (globalThis as any).Word = {
+    Revision: {},
+    Comment: {},
+    SearchOptions: {},
+    ContentControl: {},
+  } as any;
   (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
   (globalThis as any).__CAI_TESTING__ = true;
 };
 
 describe('startup selftest', () => {
-  beforeEach(() => { vi.resetModules(); });
+  beforeEach(() => {
+    vi.resetModules();
+  });
 
   it('fails when id missing', async () => {
     baseEnv();
-    (globalThis as any).document = { getElementById: (id:string) => id==='btnAnalyze'? { setAttribute: () => {}, textContent: ''}: null, querySelector: () => null } as any;
-    (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    (globalThis as any).document = {
+      getElementById: (id: string) =>
+        id === 'btnAnalyze' ? { setAttribute: () => {}, textContent: '' } : null,
+      querySelector: () => null,
+    } as any;
+    (globalThis as any).fetch = async () => ({
+      ok: true,
+      json: async () => ({}),
+      headers: new Headers(),
+      status: 200,
+    });
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
     const { runStartupSelftest } = await import('../assets/startup.selftest.ts');
     const res = await runStartupSelftest('https://x');
@@ -24,7 +42,10 @@ describe('startup selftest', () => {
 
   it('fails when health fails', async () => {
     baseEnv();
-    (globalThis as any).document = { getElementById: () => ({ setAttribute: () => {}, textContent: '' }) , querySelector: () => null } as any;
+    (globalThis as any).document = {
+      getElementById: () => ({ setAttribute: () => {}, textContent: '' }),
+      querySelector: () => null,
+    } as any;
     (globalThis as any).fetch = vi.fn().mockRejectedValue(new Error('fail'));
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
     const { runStartupSelftest } = await import('../assets/startup.selftest.ts');
@@ -35,12 +56,24 @@ describe('startup selftest', () => {
 
   it('passes on happy path', async () => {
     baseEnv();
-    (globalThis as any).document = { getElementById: () => ({ setAttribute: () => {}, textContent: '' }) , querySelector: () => null } as any;
-    (globalThis as any).fetch = async () => ({ ok: true, json: async () => ({}) , headers: new Headers(), status:200 });
+    (globalThis as any).document = {
+      getElementById: () => ({ setAttribute: () => {}, textContent: '' }),
+      querySelector: () => null,
+    } as any;
+    (globalThis as any).fetch = async () => ({
+      ok: true,
+      json: async () => ({}),
+      headers: new Headers(),
+      status: 200,
+    });
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
     const { runStartupSelftest } = await import('../assets/startup.selftest.ts');
     const res = await runStartupSelftest('https://x');
     expect(res.ok).toBe(true);
-    expect(log).toHaveBeenCalledWith(expect.stringMatching(/^Startup OK \| build=.*\| host=Word \| req=1\.4 \| features=\{.*\} \| backend=https:\/\/x$/));
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^Startup OK \| build=.*\| host=Word \| req=1\.4 \| features=\{.*\} \| backend=https:\/\/x$/
+      )
+    );
   });
 });

--- a/word_addin_dev/app/__tests__/unload.spec.ts
+++ b/word_addin_dev/app/__tests__/unload.spec.ts
@@ -4,8 +4,12 @@ function mkEnv(ls: Record<string, string> = {}) {
   const handlers: Record<string, ((ev: any) => void)[]> = {};
   const docHandlers: Record<string, ((ev: any) => void)[]> = {};
   const win: any = {
-    addEventListener: (n: string, f: any) => { (handlers[n] ||= []).push(f); },
-    dispatchEvent: (ev: Event) => { (handlers[ev.type] || []).forEach(fn => fn(ev)); },
+    addEventListener: (n: string, f: any) => {
+      (handlers[n] ||= []).push(f);
+    },
+    dispatchEvent: (ev: Event) => {
+      (handlers[ev.type] || []).forEach(fn => fn(ev));
+    },
     location: { search: '' },
   };
   const prog = { className: 'progress', style: { display: 'block' } };
@@ -13,8 +17,12 @@ function mkEnv(ls: Record<string, string> = {}) {
     getElementById: (id: string) => (id === 'progress' ? prog : null),
     querySelector: () => null,
     querySelectorAll: (sel: string) => (sel === '.progress' ? [prog] : []),
-    addEventListener: (n: string, f: any) => { (docHandlers[n] ||= []).push(f); },
-    dispatchEvent: (ev: Event) => { (docHandlers[ev.type] || []).forEach(fn => fn(ev)); },
+    addEventListener: (n: string, f: any) => {
+      (docHandlers[n] ||= []).push(f);
+    },
+    dispatchEvent: (ev: Event) => {
+      (docHandlers[ev.type] || []).forEach(fn => fn(ev));
+    },
     visibilityState: 'visible',
     hidden: false,
   };
@@ -22,19 +30,27 @@ function mkEnv(ls: Record<string, string> = {}) {
   (globalThis as any).fetch = (_: any, opts: any = {}) =>
     new Promise((_res, rej) => {
       const sig = opts.signal;
-      if (sig) sig.addEventListener('abort', () => {
-        aborted = true;
-        rej(new DOMException('aborted', 'AbortError'));
-      });
+      if (sig)
+        sig.addEventListener('abort', () => {
+          aborted = true;
+          rej(new DOMException('aborted', 'AbortError'));
+        });
     });
   (globalThis as any).window = win;
   (globalThis as any).document = doc;
   (globalThis as any).localStorage = {
     getItem: (k: string) => (k in ls ? ls[k] : null),
-    setItem: (k: string, v: string) => { ls[k] = v; },
+    setItem: (k: string, v: string) => {
+      ls[k] = v;
+    },
   } as any;
   (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } } as any;
-  (globalThis as any).Word = { Revision: {}, Comment: {}, SearchOptions: {}, ContentControl: {} } as any;
+  (globalThis as any).Word = {
+    Revision: {},
+    Comment: {},
+    SearchOptions: {},
+    ContentControl: {},
+  } as any;
   (globalThis as any).__CAI_TESTING__ = true;
   return { win, doc, wasAborted: () => aborted };
 }

--- a/word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts
+++ b/word_addin_dev/app/__tests__/usewholedoc.analyze.flow.spec.ts
@@ -3,7 +3,10 @@ import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 
 const html = readFileSync(
-  new URL('../../../contract_review_app/contract_review_app/static/panel/taskpane.html', import.meta.url),
+  new URL(
+    '../../../contract_review_app/contract_review_app/static/panel/taskpane.html',
+    import.meta.url
+  ),
   'utf-8'
 );
 
@@ -18,21 +21,31 @@ describe('use whole doc + analyze flow', () => {
     (globalThis as any).CustomEvent = dom.window.CustomEvent;
     (globalThis as any).localStorage = {
       store: { api_key: 'k', schema_version: '1.4', backendUrl: 'https://127.0.0.1:9443' },
-      getItem(key: string) { return (this.store as any)[key] || null; },
-      setItem(key: string, value: string) { (this.store as any)[key] = value; }
+      getItem(key: string) {
+        return (this.store as any)[key] || null;
+      },
+      setItem(key: string, value: string) {
+        (this.store as any)[key] = value;
+      },
     };
-    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status:200 });
+    fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 });
     (globalThis as any).fetch = fetchMock;
     (globalThis as any).Office = {
       onReady: (cb: any) => cb({ host: 'Word' }),
-      context: { requirements: { isSetSupported: () => true }, host: 'Word' }
+      context: { requirements: { isSetSupported: () => true }, host: 'Word' },
     };
     (globalThis as any).Word = {
-      Revision: {}, Comment: {}, SearchOptions: {}, ContentControl: {},
-      run: (fn: any) => fn({
-        document: { body: { text: 'TEST BODY', load: () => {} } },
-        sync: async () => {}
-      })
+      Revision: {},
+      Comment: {},
+      SearchOptions: {},
+      ContentControl: {},
+      run: (fn: any) =>
+        fn({
+          document: { body: { text: 'TEST BODY', load: () => {} } },
+          sync: async () => {},
+        }),
     };
     (globalThis as any).__CAI_TESTING__ = true;
   });
@@ -52,8 +65,14 @@ describe('use whole doc + analyze flow', () => {
 
     const btnAnalyze = document.getElementById('btnAnalyze') as HTMLButtonElement;
     btnAnalyze.disabled = false;
-    fetchMock.mockImplementationOnce(() =>
-      new Promise(res => setTimeout(() => res({ ok: true, json: async () => ({}), headers: new Headers(), status:200 }), 50))
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise(res =>
+          setTimeout(
+            () => res({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 }),
+            50
+          )
+        )
     );
     btnAnalyze.click();
     const book = document.getElementById('loading-book') as HTMLElement;
@@ -62,7 +81,9 @@ describe('use whole doc + analyze flow', () => {
     await vi.advanceTimersByTimeAsync(60);
     await Promise.resolve();
     expect(book.classList.contains('hidden')).toBe(true);
-    const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) => String(c[0]).includes('/api/analyze'));
+    const analyzeCalls = fetchMock.mock.calls.filter((c: any[]) =>
+      String(c[0]).includes('/api/analyze')
+    );
     expect(analyzeCalls.length).toBe(1);
     const opts = analyzeCalls[0][1];
     const body = JSON.parse(opts.body);

--- a/word_addin_dev/app/__tests__/usewholedoc.analyze.large.spec.ts
+++ b/word_addin_dev/app/__tests__/usewholedoc.analyze.large.spec.ts
@@ -6,8 +6,14 @@ describe('analyze large logging', () => {
     (globalThis as any).window = { dispatchEvent: () => {}, addEventListener: () => {} } as any;
     (globalThis as any).localStorage = { getItem: () => null, setItem: () => {} } as any;
     const longText = 'A'.repeat(120000);
-    const fetchMock = vi.fn(() =>
-      new Promise(res => setTimeout(() => res({ ok:true, json: async()=>({}), headers:new Headers(), status:200 }), 12000))
+    const fetchMock = vi.fn(
+      () =>
+        new Promise(res =>
+          setTimeout(
+            () => res({ ok: true, json: async () => ({}), headers: new Headers(), status: 200 }),
+            12000
+          )
+        )
     );
     (globalThis as any).fetch = fetchMock;
     const { postJson } = await import('../assets/api-client.ts');

--- a/word_addin_dev/app/__tests__/wordq.test.ts
+++ b/word_addin_dev/app/__tests__/wordq.test.ts
@@ -6,17 +6,16 @@ const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
 describe('wordQ', () => {
   it('runs jobs sequentially', async () => {
     const order: string[] = [];
-    const job = (label: string, ms: number) => wordQ.run(async () => {
-      order.push('start-' + label);
-      await delay(ms);
-      order.push('end-' + label);
-    });
+    const job = (label: string, ms: number) =>
+      wordQ.run(async () => {
+        order.push('start-' + label);
+        await delay(ms);
+        order.push('end-' + label);
+      });
     const p1 = job('a', 20);
     const p2 = job('b', 10);
     const p3 = job('c', 0);
     await Promise.all([p1, p2, p3]);
-    expect(order).toEqual([
-      'start-a','end-a','start-b','end-b','start-c','end-c'
-    ]);
+    expect(order).toEqual(['start-a', 'end-a', 'start-b', 'end-b', 'start-c', 'end-c']);
   });
 });

--- a/word_addin_dev/app/panel_dom.schema.json
+++ b/word_addin_dev/app/panel_dom.schema.json
@@ -1,8 +1,13 @@
 {
   "_comment": "Любая панельная HTML-страница обязана содержать эти id",
   "required_ids": [
-    "btnUseWholeDoc", "btnAnalyze",
-    "originalText", "results", "busyBar", "loading-book",
-    "officeBadge", "connBadge"
+    "btnUseWholeDoc",
+    "btnAnalyze",
+    "originalText",
+    "results",
+    "busyBar",
+    "loading-book",
+    "officeBadge",
+    "connBadge"
   ]
 }

--- a/word_addin_dev/app/selftest.js
+++ b/word_addin_dev/app/selftest.js
@@ -2,45 +2,54 @@
 // Expected API schema version: 1.4
 
 // ---------------------- helpers ----------------------
-const LS_KEY = "panel:backendUrl";
-const API_KEY_STORAGE = "api_key";
-const SCHEMA_STORAGE = "schema_version";
-const DRAFT_PATH = "/api/gpt-draft";
-const SAMPLE = "Governing law: England and Wales.";
+const LS_KEY = 'panel:backendUrl';
+const API_KEY_STORAGE = 'api_key';
+const SCHEMA_STORAGE = 'schema_version';
+const DRAFT_PATH = '/api/gpt-draft';
+const SAMPLE = 'Governing law: England and Wales.';
 let clientCid = genCid();
-let lastCid = ""; // from response headers
+let lastCid = ''; // from response headers
 
-function showMeta(meta){
-  const prov = document.getElementById("llmProv");
-  const model = document.getElementById("llmModel");
-  prov.textContent = (meta && meta.provider) || "—";
-  model.textContent = (meta && meta.model) || "—";
-  const modeEl = document.getElementById("llmLatency");
+function showMeta(meta) {
+  const prov = document.getElementById('llmProv');
+  const model = document.getElementById('llmModel');
+  prov.textContent = (meta && meta.provider) || '—';
+  model.textContent = (meta && meta.model) || '—';
+  const modeEl = document.getElementById('llmLatency');
   if (modeEl && meta && meta.mode) {
     modeEl.textContent = meta.mode;
-    modeEl.className = meta.mode === "mock" ? "ok" : "";
+    modeEl.className = meta.mode === 'mock' ? 'ok' : '';
   }
-  const badge = document.getElementById("llmBadge");
-  if (badge) badge.style.display = (meta && meta.mode === "mock") ? "inline-block" : "none";
+  const badge = document.getElementById('llmBadge');
+  if (badge) badge.style.display = meta && meta.mode === 'mock' ? 'inline-block' : 'none';
 }
 
 function pickDocType(summary) {
   summary = summary || {};
   let list = [];
   if (Array.isArray(summary.doc_types)) list = summary.doc_types;
-  else if (summary.document && Array.isArray(summary.document.doc_types)) list = summary.document.doc_types;
+  else if (summary.document && Array.isArray(summary.document.doc_types))
+    list = summary.document.doc_types;
   // legacy: summary.doc_type = { top:{type,score}, confidence, candidates[] }
   if (!list.length && summary.doc_type && (summary.doc_type.top || summary.doc_type.candidates)) {
     const top = summary.doc_type.top || {};
-    const conf = (typeof summary.doc_type.confidence === 'number')
-      ? summary.doc_type.confidence
-      : (typeof top.score === 'number' ? top.score : null);
+    const conf =
+      typeof summary.doc_type.confidence === 'number'
+        ? summary.doc_type.confidence
+        : typeof top.score === 'number'
+          ? top.score
+          : null;
     return { name: top.type || top.name || null, confidence: conf };
   }
   let best = null;
   if (list && list.length) {
     best = list.reduce((acc, cur) => {
-      const c = typeof cur.confidence === 'number' ? cur.confidence : (typeof cur.score === 'number' ? cur.score : 0);
+      const c =
+        typeof cur.confidence === 'number'
+          ? cur.confidence
+          : typeof cur.score === 'number'
+            ? cur.score
+            : 0;
       const n = cur.name || cur.type || cur.slug || cur.id || null;
       if (!acc || c > acc.confidence) return { name: n, confidence: c };
       return acc;
@@ -48,87 +57,113 @@ function pickDocType(summary) {
   } else {
     let n2 = summary.type || (summary.document && summary.document.type) || null;
     let c2 = summary.type_confidence;
-    if (c2 == null && summary.document && summary.document.type_confidence != null) c2 = summary.document.type_confidence;
-    if (typeof c2 === 'string') { const f = parseFloat(c2); c2 = isNaN(f) ? null : f; }
+    if (c2 == null && summary.document && summary.document.type_confidence != null)
+      c2 = summary.document.type_confidence;
+    if (typeof c2 === 'string') {
+      const f = parseFloat(c2);
+      c2 = isNaN(f) ? null : f;
+    }
     best = { name: n2, confidence: c2 };
   }
   return best || { name: null, confidence: null };
 }
 
-function genCid(){ return "cid-" + Math.random().toString(16).slice(2) + "-" + Date.now().toString(16); }
+function genCid() {
+  return 'cid-' + Math.random().toString(16).slice(2) + '-' + Date.now().toString(16);
+}
 
-function normBase(u){
-  if (!u) return "";
+function normBase(u) {
+  if (!u) return '';
   let s = String(u).trim();
-  if (s.startsWith("//")) s = "https:" + s;
-  if (!/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(s)) s = "https://" + s;
-  s = s.replace(/^http:\/\/127\.0\.0\.1(:9443)(\/|$)/, "https://127.0.0.1$1$2");
-  return s.replace(/\/+$/, "");
+  if (s.startsWith('//')) s = 'https:' + s;
+  if (!/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(s)) s = 'https://' + s;
+  s = s.replace(/^http:\/\/127\.0\.0\.1(:9443)(\/|$)/, 'https://127.0.0.1$1$2');
+  return s.replace(/\/+$/, '');
 }
-function joinUrl(base, path){
-  if (!base) throw new Error("backend base URL is empty");
-  if (!path.startsWith("/")) path = "/" + path;
-  return base.replace(/\/+$/, "") + path;
+function joinUrl(base, path) {
+  if (!base) throw new Error('backend base URL is empty');
+  if (!path.startsWith('/')) path = '/' + path;
+  return base.replace(/\/+$/, '') + path;
 }
-function saveBase(){ try{ const v=document.getElementById("backendInput").value.trim(); localStorage.setItem(LS_KEY, v); localStorage.setItem("backendUrl", v); }catch{} }
-function loadBase(){
-  let v = localStorage.getItem(LS_KEY) || document.getElementById("backendInput").value || "https://127.0.0.1:9443";
+function saveBase() {
+  try {
+    const v = document.getElementById('backendInput').value.trim();
+    localStorage.setItem(LS_KEY, v);
+    localStorage.setItem('backendUrl', v);
+  } catch {}
+}
+function loadBase() {
+  let v =
+    localStorage.getItem(LS_KEY) ||
+    document.getElementById('backendInput').value ||
+    'https://127.0.0.1:9443';
   v = normBase(v);
-  document.getElementById("backendInput").value = v || "https://127.0.0.1:9443";
-  try{ localStorage.setItem("backendUrl", v); }catch{}
+  document.getElementById('backendInput').value = v || 'https://127.0.0.1:9443';
+  try {
+    localStorage.setItem('backendUrl', v);
+  } catch {}
   return v;
 }
 
-function saveApiKey(){
-  try{
-    const v=document.getElementById("apiKeyInput").value.trim();
+function saveApiKey() {
+  try {
+    const v = document.getElementById('apiKeyInput').value.trim();
     localStorage.setItem(API_KEY_STORAGE, v);
     CAI.Store?.setApiKey?.(v);
-  }catch{}
+  } catch {}
 }
-function loadApiKey(){
-  let v="";
-  try{ v = localStorage.getItem(API_KEY_STORAGE) || ""; }catch{}
-  const el = document.getElementById("apiKeyInput");
-  if(el) el.value = v;
+function loadApiKey() {
+  let v = '';
+  try {
+    v = localStorage.getItem(API_KEY_STORAGE) || '';
+  } catch {}
+  const el = document.getElementById('apiKeyInput');
+  if (el) el.value = v;
   return v;
 }
-function saveSchemaVersion(){
-  try{
-    const v=document.getElementById("schemaInput").value.trim();
+function saveSchemaVersion() {
+  try {
+    const v = document.getElementById('schemaInput').value.trim();
     localStorage.setItem(SCHEMA_STORAGE, v);
     CAI.Store?.setSchemaVersion?.(v);
-  }catch{}
+  } catch {}
 }
-function loadSchemaVersion(){
-  let v="";
-  try{ v = localStorage.getItem(SCHEMA_STORAGE) || ""; }catch{}
-  const el = document.getElementById("schemaInput");
-  if(el) el.value = v;
-  try{ CAI.Store?.setSchemaVersion?.(v); }catch{}
+function loadSchemaVersion() {
+  let v = '';
+  try {
+    v = localStorage.getItem(SCHEMA_STORAGE) || '';
+  } catch {}
+  const el = document.getElementById('schemaInput');
+  if (el) el.value = v;
+  try {
+    CAI.Store?.setSchemaVersion?.(v);
+  } catch {}
   return v;
 }
-function setCidLabels(){
-  document.getElementById("cidLbl").textContent = clientCid;
-  document.getElementById("lastCidLbl").textContent = lastCid || "(none yet)";
+function setCidLabels() {
+  document.getElementById('cidLbl').textContent = clientCid;
+  document.getElementById('lastCidLbl').textContent = lastCid || '(none yet)';
 }
-function checkHeaders(){
+function checkHeaders() {
   loadApiKey();
   loadSchemaVersion();
 }
-function setJSON(elId, obj){
+function setJSON(elId, obj) {
   const el = document.getElementById(elId);
-  try { el.textContent = JSON.stringify(obj, null, 2); }
-  catch { el.textContent = String(obj); }
+  try {
+    el.textContent = JSON.stringify(obj, null, 2);
+  } catch {
+    el.textContent = String(obj);
+  }
 }
-function setStatusRow(rowId, {code, xcid, xcache, xschema, latencyMs, ok, error_code, detail}){
+function setStatusRow(rowId, { code, xcid, xcache, xschema, latencyMs, ok, error_code, detail }) {
   const tr = document.getElementById(rowId);
   const cells = tr.getElementsByTagName('td');
-  const latencyText = (latencyMs != null ? `${latencyMs} ms` : (xcid ? "" : ""));
-  cells[1].textContent = code ?? "";
-  cells[2].textContent = xcid ?? "";
-  cells[3].textContent = xcache ?? "";
-  cells[4].textContent = xschema ?? "";
+  const latencyText = latencyMs != null ? `${latencyMs} ms` : xcid ? '' : '';
+  cells[1].textContent = code ?? '';
+  cells[2].textContent = xcid ?? '';
+  cells[3].textContent = xcache ?? '';
+  cells[4].textContent = xschema ?? '';
   cells[5].textContent = latencyText;
   if (ok) {
     cells[6].innerHTML = '<span class="ok">ok</span>';
@@ -138,61 +173,64 @@ function setStatusRow(rowId, {code, xcid, xcache, xschema, latencyMs, ok, error_
   }
 }
 
-function showResp(r){
-  const el = document.getElementById("resp");
-  if(!r.ok){
-    try{ el.textContent = `HTTP ${r.code}\n` + JSON.stringify(r.body, null, 2); }
-    catch{ el.textContent = `HTTP ${r.code}`; }
+function showResp(r) {
+  const el = document.getElementById('resp');
+  if (!r.ok) {
+    try {
+      el.textContent = `HTTP ${r.code}\n` + JSON.stringify(r.body, null, 2);
+    } catch {
+      el.textContent = `HTTP ${r.code}`;
+    }
     return;
   }
-  if(r.body && r.body.status && r.body.status !== "ok"){
+  if (r.body && r.body.status && r.body.status !== 'ok') {
     el.textContent = `API error: ${r.body.detail || r.body.error_code || ''}`;
     return;
   }
-  setJSON("resp", r.body);
+  setJSON('resp', r.body);
 }
 
-function onClick(id, handler){
+function onClick(id, handler) {
   var el = document.getElementById(id);
   if (!el) return;
   el.addEventListener('click', handler);
 }
 
-async function fetchJSON(path){
-  const base = normBase(document.getElementById("backendInput").value);
+async function fetchJSON(path) {
+  const base = normBase(document.getElementById('backendInput').value);
   const url = joinUrl(base, path);
-  const resp = await fetch(url, { method:"GET" });
+  const resp = await fetch(url, { method: 'GET' });
   return await resp.json();
 }
 
-async function loadOpenAPI(){
-  try{
+async function loadOpenAPI() {
+  try {
     const spec = await fetchJSON('/openapi.json');
     return spec.paths || {};
-  }catch{
+  } catch {
     return {};
   }
 }
 
 const TESTS = [];
 
-function buildRowsFromOpenAPI(paths){
+function buildRowsFromOpenAPI(paths) {
   const btns = document.getElementById('testsBtns');
   const tbody = document.getElementById('statusBody');
-  if(!btns || !tbody) return;
+  if (!btns || !tbody) return;
   const slugMap = {
-    '/health':'health',
-    '/api/analyze':'analyze',
-    '/api/summary':'summary',
-    '/api/gpt-draft':'draft',
-    '/api/suggest_edits':'suggest',
-    '/api/qa-recheck':'qa',
-    '/api/calloff/validate':'calloff',
-    '/api/trace/{cid}':'trace',
-    '/api/citation/resolve':'citation-resolve'
+    '/health': 'health',
+    '/api/analyze': 'analyze',
+    '/api/summary': 'summary',
+    '/api/gpt-draft': 'draft',
+    '/api/suggest_edits': 'suggest',
+    '/api/qa-recheck': 'qa',
+    '/api/calloff/validate': 'calloff',
+    '/api/trace/{cid}': 'trace',
+    '/api/citation/resolve': 'citation-resolve',
   };
   const labelMap = {
-    '/api/citation/resolve':'Resolve citations'
+    '/api/citation/resolve': 'Resolve citations',
   };
   const special = {
     '/health': testHealth,
@@ -203,49 +241,57 @@ function buildRowsFromOpenAPI(paths){
     '/api/qa-recheck': testQA,
     '/api/calloff/validate': testCalloff,
     '/api/trace/{cid}': testTrace,
-    '/api/citation/resolve': testCitationResolve
+    '/api/citation/resolve': testCitationResolve,
   };
-  for (const [p, methods] of Object.entries(paths)){
-    if(!p.startsWith('/api/') && p !== '/health') continue;
-    for (const m of Object.keys(methods)){
+  for (const [p, methods] of Object.entries(paths)) {
+    if (!p.startsWith('/api/') && p !== '/health') continue;
+    for (const m of Object.keys(methods)) {
       const method = m.toUpperCase();
-      if(method !== 'GET' && method !== 'POST') continue;
-      const slug = slugMap[p] || p.replace(/^\/api\//,'').replace(/[{}]/g,'').replace(/\//g,'-');
+      if (method !== 'GET' && method !== 'POST') continue;
+      const slug =
+        slugMap[p] ||
+        p
+          .replace(/^\/api\//, '')
+          .replace(/[{}]/g, '')
+          .replace(/\//g, '-');
       const rowId = `row-${slug}`;
       const btnId = `btn-${slug}`;
       const label = labelMap[p] || `${method} ${p}`;
       btns.insertAdjacentHTML('beforeend', `<button id="${btnId}">${label}</button>`);
       const rowHtml = `<tr id="${rowId}"><td>${label}</td><td></td><td></td><td></td><td></td><td></td><td></td></tr>`;
       tbody.insertAdjacentHTML('beforeend', rowHtml);
-      const fn = special[p] || (() => runGeneric({method, path:p, rowId}));
+      const fn = special[p] || (() => runGeneric({ method, path: p, rowId }));
       onClick(btnId, fn);
-      TESTS.push({rowId, fn});
+      TESTS.push({ rowId, fn });
     }
   }
 }
 
-async function callEndpoint({name, method, path, body, dynamicPathFn}) {
-  const base = normBase(document.getElementById("backendInput").value);
-  if (!base) { console.log("Please enter backend URL"); return { error:true }; }
+async function callEndpoint({ name, method, path, body, dynamicPathFn }) {
+  const base = normBase(document.getElementById('backendInput').value);
+  if (!base) {
+    console.log('Please enter backend URL');
+    return { error: true };
+  }
 
   const origBase1 = localStorage.getItem(LS_KEY);
-  const origBase2 = localStorage.getItem("backendUrl");
+  const origBase2 = localStorage.getItem('backendUrl');
   try {
     localStorage.setItem(LS_KEY, base);
-    localStorage.setItem("backendUrl", base);
+    localStorage.setItem('backendUrl', base);
   } catch {}
 
   const origKey = localStorage.getItem(API_KEY_STORAGE);
   const origSchema = localStorage.getItem(SCHEMA_STORAGE);
-  if (path !== "/health") {
+  if (path !== '/health') {
     try {
-      let k = document.getElementById("apiKeyInput").value.trim();
-      let s = document.getElementById("schemaInput").value.trim();
+      let k = document.getElementById('apiKeyInput').value.trim();
+      let s = document.getElementById('schemaInput').value.trim();
       if (!k) {
-        k = origKey || "";
+        k = origKey || '';
       }
       if (!s) {
-        s = origSchema || "";
+        s = origSchema || '';
       }
       if (k) {
         localStorage.setItem(API_KEY_STORAGE, k);
@@ -260,33 +306,53 @@ async function callEndpoint({name, method, path, body, dynamicPathFn}) {
 
   let r;
   const rel = dynamicPathFn ? dynamicPathFn() : path;
-  if (method === "GET") {
+  if (method === 'GET') {
     const url = joinUrl(base, rel);
-    const http = await fetch(url, { method:"GET" });
+    const http = await fetch(url, { method: 'GET' });
     const json = await http.json().catch(() => ({}));
     r = { http, json, headers: http.headers };
-  } else if (method === "POST") {
+  } else if (method === 'POST') {
     r = await postJson(rel, body || {});
   } else {
-    return { ok:false, error_code:"CLIENT", detail:"Unsupported method" };
+    return { ok: false, error_code: 'CLIENT', detail: 'Unsupported method' };
   }
 
-  if (origBase1 == null) { localStorage.removeItem(LS_KEY); } else { localStorage.setItem(LS_KEY, origBase1); }
-  if (origBase2 == null) { localStorage.removeItem("backendUrl"); } else { localStorage.setItem("backendUrl", origBase2); }
-  if (path !== "/health") {
-    if (origKey == null) { localStorage.removeItem(API_KEY_STORAGE); } else { localStorage.setItem(API_KEY_STORAGE, origKey); }
-    if (origSchema == null) { localStorage.removeItem(SCHEMA_STORAGE); } else { localStorage.setItem(SCHEMA_STORAGE, origSchema); }
+  if (origBase1 == null) {
+    localStorage.removeItem(LS_KEY);
+  } else {
+    localStorage.setItem(LS_KEY, origBase1);
+  }
+  if (origBase2 == null) {
+    localStorage.removeItem('backendUrl');
+  } else {
+    localStorage.setItem('backendUrl', origBase2);
+  }
+  if (path !== '/health') {
+    if (origKey == null) {
+      localStorage.removeItem(API_KEY_STORAGE);
+    } else {
+      localStorage.setItem(API_KEY_STORAGE, origKey);
+    }
+    if (origSchema == null) {
+      localStorage.removeItem(SCHEMA_STORAGE);
+    } else {
+      localStorage.setItem(SCHEMA_STORAGE, origSchema);
+    }
   }
 
-  const hdr = r.headers || { get: () => "" };
-  const cid = hdr.get("x-cid") || "";
-  const cache = hdr.get("x-cache") || "";
-  const schema = hdr.get("x-schema-version") || "";
-  const latency = Number(hdr.get("x-latency-ms")) || null;
+  const hdr = r.headers || { get: () => '' };
+  const cid = hdr.get('x-cid') || '';
+  const cache = hdr.get('x-cache') || '';
+  const schema = hdr.get('x-schema-version') || '';
+  const latency = Number(hdr.get('x-latency-ms')) || null;
   if (cid) lastCid = cid;
-  if (schema) { try { CAI.Store?.setSchemaVersion?.(schema); } catch {} }
+  if (schema) {
+    try {
+      CAI.Store?.setSchemaVersion?.(schema);
+    } catch {}
+  }
   setCidLabels();
-  const ok = r.http ? (r.http.ok && r.json && r.json.status === "ok") : false;
+  const ok = r.http ? r.http.ok && r.json && r.json.status === 'ok' : false;
   return {
     url: path,
     code: r.http ? r.http.status : null,
@@ -296,141 +362,173 @@ async function callEndpoint({name, method, path, body, dynamicPathFn}) {
     xschema: schema,
     latencyMs: latency,
     ok,
-    error_code: r.json && r.json.error_code ? r.json.error_code : "",
-    detail: r.json && r.json.detail ? r.json.detail : ""
+    error_code: r.json && r.json.error_code ? r.json.error_code : '',
+    detail: r.json && r.json.detail ? r.json.detail : '',
   };
 }
 
-function resolveDynamicPath(p){
-  return p.includes('{cid}') ? p.replace('{cid}', encodeURIComponent(lastCid || clientCid || '')) : p;
+function resolveDynamicPath(p) {
+  return p.includes('{cid}')
+    ? p.replace('{cid}', encodeURIComponent(lastCid || clientCid || ''))
+    : p;
 }
 
-async function runGeneric({method, path, rowId}){
-  const r = await callEndpoint({ name:path, method, path, dynamicPathFn: () => resolveDynamicPath(path) });
+async function runGeneric({ method, path, rowId }) {
+  const r = await callEndpoint({
+    name: path,
+    method,
+    path,
+    dynamicPathFn: () => resolveDynamicPath(path),
+  });
   setStatusRow(rowId, r);
-  if(path.includes('/trace')) setJSON('trace', r.body); else showResp(r);
+  if (path.includes('/trace')) setJSON('trace', r.body);
+  else showResp(r);
   showMeta(r.body && (r.body.meta || r.body.llm || {}));
   return r;
 }
 
-async function pingLLM(){
-  const latEl = document.getElementById("llmLatency");
-  latEl.textContent = "…";
-  latEl.className = "";
+async function pingLLM() {
+  const latEl = document.getElementById('llmLatency');
+  latEl.textContent = '…';
+  latEl.className = '';
   try {
-    const resp = await CAI.API.get("/api/llm/ping");
+    const resp = await CAI.API.get('/api/llm/ping');
     const meta = resp.meta || resp.json.llm || {};
     if (meta.provider || meta.model || meta.mode) showMeta(meta);
-    const ms = meta.latencyMs || Number(resp.resp.headers?.get("x-latency-ms")) || 0;
-    latEl.textContent = ms + "ms";
-    latEl.className = resp.ok ? "ok" : "err";
+    const ms = meta.latencyMs || Number(resp.resp.headers?.get('x-latency-ms')) || 0;
+    latEl.textContent = ms + 'ms';
+    latEl.className = resp.ok ? 'ok' : 'err';
     showResp({ ok: resp.ok, code: resp.resp.status, body: resp.json });
   } catch (e) {
-    latEl.textContent = "ERR";
-    latEl.className = "err";
+    latEl.textContent = 'ERR';
+    latEl.className = 'err';
   }
 }
 
 // ---------------------- individual tests ----------------------
-async function testHealth(){
-  const r = await callEndpoint({ name:"health", method:"GET", path:"/health" });
-  setStatusRow("row-health", r);
+async function testHealth() {
+  const r = await callEndpoint({ name: 'health', method: 'GET', path: '/health' });
+  setStatusRow('row-health', r);
   showResp(r);
   if (r.body) {
     showMeta(r.body.meta || r.body.llm || {});
   }
   return r;
 }
-function getSampleText(){
+function getSampleText() {
   return SAMPLE;
 }
 
-async function testAnalyze(){
+async function testAnalyze() {
   const r = await callEndpoint({
-    name:"analyze", method:"POST", path:"/api/analyze",
-    body:{ text: SAMPLE }
+    name: 'analyze',
+    method: 'POST',
+    path: '/api/analyze',
+    body: { text: SAMPLE },
   });
-  setStatusRow("row-analyze", r);
+  setStatusRow('row-analyze', r);
   showResp(r);
-  showMeta(r.body && r.body.meta || {});
+  showMeta((r.body && r.body.meta) || {});
   return r;
 }
-async function testSummary(){
+async function testSummary() {
   const r = await callEndpoint({
-    name:"summary", method:"POST", path:"/api/summary",
-    body:{ cid: lastCid }
+    name: 'summary',
+    method: 'POST',
+    path: '/api/summary',
+    body: { cid: lastCid },
   });
-  setStatusRow("row-summary", r);
-  if(!r.ok || (r.body && r.body.status !== "ok")){
+  setStatusRow('row-summary', r);
+  if (!r.ok || (r.body && r.body.status !== 'ok')) {
     showResp(r);
     return r;
   }
-  const el = document.getElementById("resp");
+  const el = document.getElementById('resp');
   try {
     const s = JSON.stringify(r.body, null, 2)
-      .replace(/"schema_version"\s*:\s*"([^"]+)"/,'<span class="ok">"schema_version": "$1"</span>')
-      .replace(/"type"\s*:\s*"([^"]+)"/,'<span class="ok">"type": "$1"</span>')
-      .replace(/"has_cap"\s*:\s*(true|false)/,'<span class="ok">"has_cap": $1</span>')
-      .replace(/"has_conditions"\s*:\s*(true|false)/,'<span class="ok">"has_conditions": $1</span>')
-      .replace(/"has_warranties"\s*:\s*(true|false)/,'<span class="ok">"has_warranties": $1</span>');
+      .replace(/"schema_version"\s*:\s*"([^"]+)"/, '<span class="ok">"schema_version": "$1"</span>')
+      .replace(/"type"\s*:\s*"([^"]+)"/, '<span class="ok">"type": "$1"</span>')
+      .replace(/"has_cap"\s*:\s*(true|false)/, '<span class="ok">"has_cap": $1</span>')
+      .replace(
+        /"has_conditions"\s*:\s*(true|false)/,
+        '<span class="ok">"has_conditions": $1</span>'
+      )
+      .replace(
+        /"has_warranties"\s*:\s*(true|false)/,
+        '<span class="ok">"has_warranties": $1</span>'
+      );
     el.innerHTML = s;
   } catch {
-    setJSON("resp", r.body);
+    setJSON('resp', r.body);
   }
-  const snapEl = document.getElementById("docSnap");
-  const summary = r.body && (r.body.summary || r.body) || null;
+  const snapEl = document.getElementById('docSnap');
+  const summary = (r.body && (r.body.summary || r.body)) || null;
   const docType = pickDocType(summary || {});
   const typeEl = document.querySelector('[data-snap-type]');
   const confEl = document.querySelector('[data-snap-type-confidence]');
   if (typeEl) typeEl.textContent = docType.name ?? '—';
-  if (confEl) confEl.textContent =
-    docType.confidence != null ? Math.round(docType.confidence * 100) + '%' : '—';
+  if (confEl)
+    confEl.textContent =
+      docType.confidence != null ? Math.round(docType.confidence * 100) + '%' : '—';
   if (summary) {
-    try { snapEl.textContent = JSON.stringify(summary, null, 2); }
-    catch { snapEl.textContent = String(summary); }
+    try {
+      snapEl.textContent = JSON.stringify(summary, null, 2);
+    } catch {
+      snapEl.textContent = String(summary);
+    }
   } else {
-    snapEl.textContent = "";
+    snapEl.textContent = '';
   }
   return r;
 }
 
-async function testDraft(){
+async function testDraft() {
   const r = await callEndpoint({
-    name:"draft", method:"POST", path:DRAFT_PATH,
-    body:{ cid: lastCid, clause: SAMPLE, mode: "friendly" }
+    name: 'draft',
+    method: 'POST',
+    path: DRAFT_PATH,
+    body: { cid: lastCid, clause: SAMPLE, mode: 'friendly' },
   });
-  const ok = r.ok && r.body && r.body.status === "ok";
-  setStatusRow("row-draft", Object.assign({}, r, { ok: !!ok }));
+  const ok = r.ok && r.body && r.body.status === 'ok';
+  setStatusRow('row-draft', Object.assign({}, r, { ok: !!ok }));
   showResp(r);
-  showMeta(r.body && r.body.meta || {});
-  const badge = document.getElementById("llmBadge");
+  showMeta((r.body && r.body.meta) || {});
+  const badge = document.getElementById('llmBadge');
   const meta = r.body && r.body.meta ? r.body.meta : {};
-  if (meta.mode === "mock") { badge.style.display = "inline-block"; } else { badge.style.display = "none"; }
+  if (meta.mode === 'mock') {
+    badge.style.display = 'inline-block';
+  } else {
+    badge.style.display = 'none';
+  }
   return r;
 }
-async function testSuggest(){
+async function testSuggest() {
   const r = await callEndpoint({
-    name:"suggest", method:"POST", path:"/api/suggest_edits",
-    body:{ text: SAMPLE, clause_type: "termination" }
+    name: 'suggest',
+    method: 'POST',
+    path: '/api/suggest_edits',
+    body: { text: SAMPLE, clause_type: 'termination' },
   });
-  setStatusRow("row-suggest", r);
+  setStatusRow('row-suggest', r);
   showResp(r);
-  showMeta(r.body && r.body.meta || {});
+  showMeta((r.body && r.body.meta) || {});
   return r;
 }
-async function testQA(){
+async function testQA() {
   const r = await callEndpoint({
-    name:"qa", method:"POST", path:"/api/qa-recheck",
-    body:{ text: SAMPLE, applied_changes:[] }
+    name: 'qa',
+    method: 'POST',
+    path: '/api/qa-recheck',
+    body: { text: SAMPLE, applied_changes: [] },
   });
-  setStatusRow("row-qa", r);
+  setStatusRow('row-qa', r);
   showResp(r);
-  showMeta(r.body && r.body.meta || {});
+  showMeta((r.body && r.body.meta) || {});
   return r;
 }
-async function testCitationResolve(){
+async function testCitationResolve() {
   const fn = window.postCitationResolve || postCitationResolve;
-  const { http, json, headers } = await fn({ citations:[{ instrument: 'Act', section: '1' }] });
+  const { http, json, headers } = await fn({ citations: [{ instrument: 'Act', section: '1' }] });
   const meta = metaFromResponse({ headers, json, status: http.status });
   setStatusRow('row-citation-resolve', {
     code: http.status,
@@ -438,59 +536,71 @@ async function testCitationResolve(){
     xcache: meta.xcache,
     xschema: meta.schema,
     latencyMs: meta.latencyMs,
-    ok: http.ok
+    ok: http.ok,
   });
   showResp({ ok: http.ok, code: http.status, body: json });
   showMeta(json && (json.meta || json.llm || {}));
   return { http, json, headers };
 }
-async function testCalloff(){
+async function testCalloff() {
   const r = await callEndpoint({
-    name:"calloff", method:"POST", path:"/api/calloff/validate",
-    body:{
-      term:"",
-      description:"[●]",
-      price:"",
-      currency:"",
-      vat:"",
-      delivery_point:"",
-      representatives:"",
-      notices:"",
-      po_number:""
-    }
+    name: 'calloff',
+    method: 'POST',
+    path: '/api/calloff/validate',
+    body: {
+      term: '',
+      description: '[●]',
+      price: '',
+      currency: '',
+      vat: '',
+      delivery_point: '',
+      representatives: '',
+      notices: '',
+      po_number: '',
+    },
   });
-  setStatusRow("row-calloff", r);
-  if(!r.ok || (r.body && r.body.status !== "ok")){
+  setStatusRow('row-calloff', r);
+  if (!r.ok || (r.body && r.body.status !== 'ok')) {
     showResp(r);
     return r;
   }
-  const issues = (r.body && r.body.issues) ? r.body.issues.length : 0;
-  const tr = document.getElementById("row-calloff");
+  const issues = r.body && r.body.issues ? r.body.issues.length : 0;
+  const tr = document.getElementById('row-calloff');
   const cells = tr.getElementsByTagName('td');
-  cells[6].innerHTML = r.ok ? `<span class="ok">ok / issues ${issues}</span>` : '<span class="err">error</span>';
-  setJSON("resp", r.body);
+  cells[6].innerHTML = r.ok
+    ? `<span class="ok">ok / issues ${issues}</span>`
+    : '<span class="err">error</span>';
+  setJSON('resp', r.body);
   return r;
 }
-async function testTrace(){
-  const cid = lastCid || clientCid || "cid-dummy";
+async function testTrace() {
+  const cid = lastCid || clientCid || 'cid-dummy';
   const r = await callEndpoint({
-    name:"trace", method:"GET",
-    dynamicPathFn: () => `/api/trace/${encodeURIComponent(cid)}`
+    name: 'trace',
+    method: 'GET',
+    dynamicPathFn: () => `/api/trace/${encodeURIComponent(cid)}`,
   });
-  setStatusRow("row-trace", r);
-  setJSON("trace", r.body);
+  setStatusRow('row-trace', r);
+  setJSON('trace', r.body);
   return r;
 }
 
-async function runAll(){
+async function runAll() {
   saveApiKey();
   saveSchemaVersion();
   for (const t of TESTS) {
-    setStatusRow(t.rowId, {code:"",xcid:"",xcache:"",xschema:"",latencyMs:null,ok:false});
+    setStatusRow(t.rowId, {
+      code: '',
+      xcid: '',
+      xcache: '',
+      xschema: '',
+      latencyMs: null,
+      ok: false,
+    });
   }
-  document.getElementById("resp").textContent = "";
-  document.getElementById("docSnap").textContent = "";
-  document.getElementById("trace").textContent = "";
+  document.getElementById('resp').textContent = '';
+  document.getElementById('docSnap').textContent = '';
+  document.getElementById('trace').textContent = '';
   clientCid = genCid();
   setCidLabels();
   for (const t of TESTS) {
@@ -499,13 +609,21 @@ async function runAll(){
 }
 
 // ---------------------- init & events ----------------------
-onClick("saveBtn", () => { saveBase(); console.log("Saved"); });
-onClick("runAllBtn", runAll);
-onClick("pingBtn", pingLLM);
-onClick("saveKeyBtn", () => { saveApiKey(); saveSchemaVersion(); checkHeaders(); console.log("Saved headers"); });
+onClick('saveBtn', () => {
+  saveBase();
+  console.log('Saved');
+});
+onClick('runAllBtn', runAll);
+onClick('pingBtn', pingLLM);
+onClick('saveKeyBtn', () => {
+  saveApiKey();
+  saveSchemaVersion();
+  checkHeaders();
+  console.log('Saved headers');
+});
 
 // Load defaults on first paint
-window.addEventListener("DOMContentLoaded", async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   loadBase();
   loadApiKey();
   const storedSchema = loadSchemaVersion();
@@ -521,7 +639,8 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     const serverSchema =
       (resp.headers && resp.headers.get && resp.headers.get('x-schema-version')) ||
-      (resp.json && resp.json.schema) || '';
+      (resp.json && resp.json.schema) ||
+      '';
     if (serverSchema) {
       if (storedSchema !== serverSchema) {
         const el = document.getElementById('schemaInput');
@@ -541,6 +660,9 @@ window.addEventListener("DOMContentLoaded", async () => {
     }
   } catch {
     const latEl = document.getElementById('llmLatency');
-    if (latEl) { latEl.textContent = 'ERR'; latEl.className = 'err'; }
+    if (latEl) {
+      latEl.textContent = 'ERR';
+      latEl.className = 'err';
+    }
   }
 });

--- a/word_addin_dev/app/src/panel/analyze.flow.spec.ts
+++ b/word_addin_dev/app/src/panel/analyze.flow.spec.ts
@@ -27,40 +27,51 @@ describe('analyze flow', () => {
 
 describe('dev bootstrap', () => {
   it('auto sets headers and enables analyze', async () => {
-    vi.resetModules()
-    const store: Record<string, string> = {}
-    ;(globalThis as any).localStorage = {
+    vi.resetModules();
+    const store: Record<string, string> = {};
+    (globalThis as any).localStorage = {
       getItem: (k: string) => store[k] || '',
-      setItem: (k: string, v: string) => { store[k] = v }
-    }
-    const analyzeBtn = { disabled: true }
-    ;(globalThis as any).document = {
-      getElementById: (id: string) => {
-        if (id === 'backendUrl') return { value: 'https://base' }
-        if (id === 'btnAnalyze') return analyzeBtn
-        return null
+      setItem: (k: string, v: string) => {
+        store[k] = v;
       },
-      querySelector: (sel: string) => (sel === '#btnAnalyze' ? analyzeBtn : null)
-    }
-    ;(globalThis as any).location = { hostname: '127.0.0.1' }
-    ;(globalThis as any).fetch = async (url: string) => {
+    };
+    const analyzeBtn = { disabled: true };
+    (globalThis as any).document = {
+      getElementById: (id: string) => {
+        if (id === 'backendUrl') return { value: 'https://base' };
+        if (id === 'btnAnalyze') return analyzeBtn;
+        return null;
+      },
+      querySelector: (sel: string) => (sel === '#btnAnalyze' ? analyzeBtn : null),
+    };
+    (globalThis as any).location = { hostname: '127.0.0.1' };
+    (globalThis as any).fetch = async (url: string) => {
       if (url === 'https://base/health') {
         return {
           json: async () => ({ status: 'ok', schema: '1.5' }),
-          headers: { get: (h: string) => (h === 'x-schema-version' ? '1.5' : null) }
-        } as any
+          headers: { get: (h: string) => (h === 'x-schema-version' ? '1.5' : null) },
+        } as any;
       }
-      return { status: 200, json: async () => ({}) } as any
-    }
-    ;(globalThis as any).Word = { run: async (fn: any) => fn({ document: { body: { load: () => {}, text: '' }, getSelection: () => ({ load: () => {}, text: '' }) }, sync: async () => {} }) }
-    ;(globalThis as any).Office = { onReady: () => Promise.resolve() };
+      return { status: 200, json: async () => ({}) } as any;
+    };
+    (globalThis as any).Word = {
+      run: async (fn: any) =>
+        fn({
+          document: {
+            body: { load: () => {}, text: '' },
+            getSelection: () => ({ load: () => {}, text: '' }),
+          },
+          sync: async () => {},
+        }),
+    };
+    (globalThis as any).Office = { onReady: () => Promise.resolve() };
 
     (globalThis as any).__CAI_TESTING__ = true;
-    const mod = await import('./index')
-    await mod.startPanel()
+    const mod = await import('./index');
+    await mod.startPanel();
 
-    expect(store['api_key']).toBe('local-test-key-123')
-    expect(store['schema_version']).toBe('1.4')
-    expect(analyzeBtn.disabled).toBe(false)
-  })
-})
+    expect(store['api_key']).toBe('local-test-key-123');
+    expect(store['schema_version']).toBe('1.4');
+    expect(analyzeBtn.disabled).toBe(false);
+  });
+});

--- a/word_addin_dev/app/src/panel/index.ts
+++ b/word_addin_dev/app/src/panel/index.ts
@@ -13,7 +13,9 @@ export {
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string) =>
   document.querySelector(sel) as T | null;
-const show = (el: HTMLElement | null) => { if (el) el.hidden = false; };
+const show = (el: HTMLElement | null) => {
+  if (el) el.hidden = false;
+};
 
 export function wireDom() {
   $<HTMLButtonElement>('#btnInsertIntoWord')?.addEventListener('click', onInsertIntoWord);
@@ -25,7 +27,10 @@ export function onDraftReady() {
 
 export async function onInsertIntoWord() {
   const txt = ($<HTMLTextAreaElement>('#txtDraft')?.value ?? '').trim();
-  if (!txt) { notifyWarn('No draft text'); return; }
+  if (!txt) {
+    notifyWarn('No draft text');
+    return;
+  }
   await insertDraftText(txt, 'live');
 }
 
@@ -44,7 +49,9 @@ export async function startPanel() {
 
 if (!(globalThis as { __CAI_TESTING__?: boolean }).__CAI_TESTING__) {
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => { void startPanel(); });
+    document.addEventListener('DOMContentLoaded', () => {
+      void startPanel();
+    });
   } else {
     void startPanel();
   }

--- a/word_addin_dev/app/src/panel/state.spec.ts
+++ b/word_addin_dev/app/src/panel/state.spec.ts
@@ -2,20 +2,21 @@ import { describe, it, expect, vi } from 'vitest';
 import { PanelState, nextFinding, prevFinding, addCommentAtRange } from './state';
 
 vi.mock('../assets/safeBodySearch.ts', () => ({
-  safeBodySearch: vi.fn(async () => ({ items: [{ select: vi.fn(), font: {} }] }))
+  safeBodySearch: vi.fn(async () => ({ items: [{ select: vi.fn(), font: {} }] })),
 }));
 
 vi.mock('../assets/api-client.ts', () => ({
-  postJSON: vi.fn(async () => ({ plainText: '', ops: [] }))
+  postJSON: vi.fn(async () => ({ plainText: '', ops: [] })),
 }));
-const safeInsertMock = vi.fn()
+const safeInsertMock = vi
+  .fn()
   .mockResolvedValueOnce({ ok: false, err: new Error('fail') })
   .mockResolvedValue({ ok: true });
 
 vi.mock('../assets/annotate.ts', () => ({
   safeInsertComment: (...args: any[]) => safeInsertMock(...args),
   COMMENT_PREFIX: '[CAI]',
-  fallbackAnnotateWithContentControl: vi.fn()
+  fallbackAnnotateWithContentControl: vi.fn(),
 }));
 
 describe('navigation', () => {
@@ -24,10 +25,10 @@ describe('navigation', () => {
       mode: 'friendly',
       items: [
         { id: 'a', anchor: 'one' },
-        { id: 'b', anchor: 'two' }
+        { id: 'b', anchor: 'two' },
       ],
       cachedDrafts: new Map(),
-      correlationId: 'cid'
+      correlationId: 'cid',
     };
     const doc = { body: {} } as any;
     await nextFinding(state, doc);
@@ -43,7 +44,7 @@ describe('addCommentAtRange', () => {
   it('falls back to paragraph comment on error', async () => {
     const p: any = {};
     const range: any = {
-      paragraphs: { getFirst: () => p }
+      paragraphs: { getFirst: () => p },
     };
     await addCommentAtRange(range, 'hi');
     expect(safeInsertMock).toHaveBeenNthCalledWith(1, range, 'hi');

--- a/word_addin_dev/app/src/panel/state.ts
+++ b/word_addin_dev/app/src/panel/state.ts
@@ -1,7 +1,10 @@
-
 import { safeBodySearch } from '../assets/safeBodySearch.ts';
 import { postJSON } from '../assets/api-client.ts';
-import { safeInsertComment, COMMENT_PREFIX, fallbackAnnotateWithContentControl } from '../assets/annotate.ts';
+import {
+  safeInsertComment,
+  COMMENT_PREFIX,
+  fallbackAnnotateWithContentControl,
+} from '../assets/annotate.ts';
 
 export interface Finding {
   id: string;
@@ -35,15 +38,14 @@ export type PanelState = {
 export async function addCommentAtRange(range: Word.Range, text: string) {
   let res = await safeInsertComment(range, text);
   if (!res.ok) {
-
     try {
       const p = range.paragraphs.getFirst();
       res = await safeInsertComment(p as unknown as Word.Range, text);
       if (!res.ok) {
-        await fallbackAnnotateWithContentControl(range, text.replace(COMMENT_PREFIX, "").trim());
+        await fallbackAnnotateWithContentControl(range, text.replace(COMMENT_PREFIX, '').trim());
       }
     } catch {
-      await fallbackAnnotateWithContentControl(range, text.replace(COMMENT_PREFIX, "").trim());
+      await fallbackAnnotateWithContentControl(range, text.replace(COMMENT_PREFIX, '').trim());
     }
   }
 }
@@ -57,12 +59,14 @@ async function focusRange(body: Word.Body, anchor: string) {
   const res = await safeBodySearch(body, anchor, searchOpts);
   const range = res?.items?.[0];
 
-    if (range) {
-      try {
-        range.select();
-        if (range.font) range.font.highlightColor = '#ffff00';
-      } catch { /* ignore */ }
+  if (range) {
+    try {
+      range.select();
+      if (range.font) range.font.highlightColor = '#ffff00';
+    } catch {
+      /* ignore */
     }
+  }
 }
 
 async function move(state: PanelState, dir: -1 | 1, doc: Word.Document) {
@@ -100,10 +104,15 @@ export async function applyDraft(state: PanelState, id: string, draft: Draft, do
     prevTracking = !!docObj.trackRevisions;
     docObj.trackRevisions = true;
     await doc.context.sync?.();
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 
   for (const op of draft.ops) {
-    const res = await safeBodySearch(doc.body, op.anchor, { matchCase: false, matchWholeWord: false });
+    const res = await safeBodySearch(doc.body, op.anchor, {
+      matchCase: false,
+      matchWholeWord: false,
+    });
     const range = res?.items?.[0];
     if (!range) continue;
     if (op.replace) {
@@ -118,14 +127,18 @@ export async function applyDraft(state: PanelState, id: string, draft: Draft, do
   try {
     docObj.trackRevisions = prevTracking;
     await doc.context.sync?.();
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 
   try {
     const raw = localStorage.getItem('cai_history') || '[]';
     const hist = JSON.parse(raw);
     hist.push({ id, ts: Date.now(), ops: draft.ops });
     localStorage.setItem('cai_history', JSON.stringify(hist));
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 }
 
 export function rejectFinding(state: PanelState, id: string) {

--- a/word_addin_dev/app/src/panel/taskpane.html
+++ b/word_addin_dev/app/src/panel/taskpane.html
@@ -1,16 +1,16 @@
 <!doctype html>
 <html>
-<head>
-  <meta charset="utf-8"/>
-  <title>Contract AI Panel</title>
-</head>
-<body>
-  <button id="btnInsertIntoWord" class="btn" hidden>Insert result into Word</button>
-  <textarea id="txtDraft"></textarea>
-  <script type="module" src="taskpane.bundle.js?b=build-20250921-085759"></script>
-  <script nomodule>
-    document.body.innerHTML = '<div style="padding:12px;color:#f66">Your runtime is too old for ES modules. Please update your browser.</div>';
-  </script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Contract AI Panel</title>
+  </head>
+  <body>
+    <button id="btnInsertIntoWord" class="btn" hidden>Insert result into Word</button>
+    <textarea id="txtDraft"></textarea>
+    <script type="module" src="taskpane.bundle.js?b=build-20250921-085759"></script>
+    <script nomodule>
+      document.body.innerHTML =
+        '<div style="padding:12px;color:#f66">Your runtime is too old for ES modules. Please update your browser.</div>';
+    </script>
+  </body>
 </html>
-

--- a/word_addin_dev/package-lock.json
+++ b/word_addin_dev/package-lock.json
@@ -13,7 +13,11 @@
         "@typescript-eslint/parser": "^8.0.0",
         "diff-match-patch": "^1.0.5",
         "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.2.1",
         "jsdom": "^24.0.0",
+        "lint-staged": "^15.2.10",
+        "prettier": "^3.3.3",
         "typescript": "^5.0.0",
         "vite": "^7.1.1",
         "vitest": "^0.34.6"
@@ -808,6 +812,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.50.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.1.tgz",
@@ -1551,6 +1568,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
+      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1737,6 +1770,39 @@
         "node": "*"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1757,6 +1823,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1768,6 +1841,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -1948,6 +2031,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -1959,6 +2049,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -2122,6 +2225,50 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
+      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -2240,12 +2387,50 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -2415,6 +2600,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -2462,6 +2660,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {
@@ -2652,6 +2863,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -2741,6 +2962,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2780,6 +3014,19 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2887,6 +3134,78 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
@@ -2922,6 +3241,101 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -2959,6 +3373,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3005,6 +3426,32 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -3086,6 +3533,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.22",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
@@ -3101,6 +3577,22 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -3275,6 +3767,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -3331,6 +3836,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -3437,6 +3971,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3447,6 +4014,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -3600,6 +4174,49 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3624,6 +4241,63 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3635,6 +4309,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-indent": {
@@ -3695,6 +4382,22 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/synckit": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -5219,6 +5922,66 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5264,6 +6027,19 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/word_addin_dev/package.json
+++ b/word_addin_dev/package.json
@@ -6,6 +6,8 @@
     "build": "vite build && node tools/copy-bundle.cjs",
     "test": "vitest run",
     "lint": "eslint app --ext .ts --max-warnings=0",
+    "format": "prettier --write .",
+    "lint:staged": "lint-staged",
     "test:ci": "vitest run -c vitest.config.ci.ts"
   },
   "devDependencies": {
@@ -17,7 +19,20 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@testing-library/jest-dom": "^6.4.2",
     "jsdom": "^24.0.0",
-    "diff-match-patch": "^1.0.5"
+    "diff-match-patch": "^1.0.5",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "lint-staged": "^15.2.10",
+    "prettier": "^3.3.3"
+  },
+  "lint-staged": {
+    "**/*.{ts,tsx}": [
+      "eslint --fix --max-warnings=0",
+      "prettier --write"
+    ],
+    "**/*.{js,jsx,cjs,mjs,json,md,css,scss,html}": [
+      "prettier --write"
+    ]
   },
   "engines": {
     "node": ">=20 <21",

--- a/word_addin_dev/panel_selftest.html
+++ b/word_addin_dev/panel_selftest.html
@@ -1,138 +1,283 @@
 <!-- word_addin_dev/panel_selftest.html -->
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <title>Contract AI — Panel Self-Test (Doctor)</title>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <style>
-    :root{
-      --bg:#0f1318; --panel:#0b0f14; --muted:#9ca3af; --text:#e5e7eb; --border:#1f2937; --border2:#374151;
-      --mono: ui-monospace,SFMono-Regular,Consolas,Menlo,monospace;
-      --ui: system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;
-      --ok:#10b981; --err:#f87171; --ink:#d1d5db;
-    }
-    html,body{ height:100%; }
-    body { background:var(--bg); color:var(--text); font-family:var(--ui); margin:0; }
-    .wrap { max-width:1100px; margin:28px auto; padding:0 16px; }
-    h1 { font-size:22px; margin:0 0 12px; display:flex; align-items:center; gap:10px; }
-    .muted { color:var(--muted); font-weight:500; }
-    .badge { display:inline-block; padding:3px 8px; border-radius:999px; border:1px solid var(--border2); color:var(--muted); font-size:12px; }
-    .row { display:flex; gap:10px; align-items:center; margin-bottom:12px; flex-wrap:wrap; }
-    input[type=text]{ width:420px; background:#111827; color:var(--text); border:1px solid var(--border2); border-radius:6px; padding:8px 10px; }
-    button { background:#111827; color:var(--text); border:1px solid var(--border2); border-radius:6px; padding:8px 10px; cursor:pointer; }
-    button:hover { background:#0b1220; }
-    .card { background:var(--panel); border:1px solid var(--border); border-radius:8px; padding:12px; margin-top:14px; }
-    .card h3 { margin:0 0 8px; font-size:14px; color:var(--muted);}
-    .pre { white-space:pre-wrap; word-break:break-word; font-family:var(--mono); font-size:12px;
-           background:#0a0d12; border:1px solid var(--border); border-radius:6px; padding:8px; color:var(--ink); min-height:48px;}
-    .mono{ font-family:var(--mono); }
-    table { width:100%; border-collapse:collapse; font-size:13px; }
-    th, td { border-bottom:1px solid var(--border); padding:6px 8px; text-align:left; }
-    th { color:var(--muted); font-weight:600; }
-    tr:last-child td { border-bottom:none; }
-    .ok { color:var(--ok); }
-    .err{ color:var(--err); }
-    .pill{ display:inline-block; padding:2px 6px; border-radius:999px; border:1px solid var(--border2); font-size:12px; }
-    .btns { display:flex; flex-wrap:wrap; gap:8px; }
-    .small { font-size:12px; color:var(--muted); }
-    .snapshot-row { display:flex; gap:8px; font-size:13px; }
-    .snapshot-row > div:first-child { width:100px; color:var(--muted); }
-  </style>
-</head>
-<body>
-  <div class="wrap">
-    <h1>Contract AI — <span class="muted">Panel Self-Test</span> <span class="badge">Doctor</span> <span class="badge mono" id="buildToken">build-20250921-085759</span></h1>
+  <head>
+    <meta charset="utf-8" />
+    <title>Contract AI — Panel Self-Test (Doctor)</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        --bg: #0f1318;
+        --panel: #0b0f14;
+        --muted: #9ca3af;
+        --text: #e5e7eb;
+        --border: #1f2937;
+        --border2: #374151;
+        --mono: ui-monospace, SFMono-Regular, Consolas, Menlo, monospace;
+        --ui: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Helvetica, Arial, sans-serif;
+        --ok: #10b981;
+        --err: #f87171;
+        --ink: #d1d5db;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font-family: var(--ui);
+        margin: 0;
+      }
+      .wrap {
+        max-width: 1100px;
+        margin: 28px auto;
+        padding: 0 16px;
+      }
+      h1 {
+        font-size: 22px;
+        margin: 0 0 12px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .muted {
+        color: var(--muted);
+        font-weight: 500;
+      }
+      .badge {
+        display: inline-block;
+        padding: 3px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--border2);
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        margin-bottom: 12px;
+        flex-wrap: wrap;
+      }
+      input[type='text'] {
+        width: 420px;
+        background: #111827;
+        color: var(--text);
+        border: 1px solid var(--border2);
+        border-radius: 6px;
+        padding: 8px 10px;
+      }
+      button {
+        background: #111827;
+        color: var(--text);
+        border: 1px solid var(--border2);
+        border-radius: 6px;
+        padding: 8px 10px;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #0b1220;
+      }
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 12px;
+        margin-top: 14px;
+      }
+      .card h3 {
+        margin: 0 0 8px;
+        font-size: 14px;
+        color: var(--muted);
+      }
+      .pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-family: var(--mono);
+        font-size: 12px;
+        background: #0a0d12;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 8px;
+        color: var(--ink);
+        min-height: 48px;
+      }
+      .mono {
+        font-family: var(--mono);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+      }
+      th,
+      td {
+        border-bottom: 1px solid var(--border);
+        padding: 6px 8px;
+        text-align: left;
+      }
+      th {
+        color: var(--muted);
+        font-weight: 600;
+      }
+      tr:last-child td {
+        border-bottom: none;
+      }
+      .ok {
+        color: var(--ok);
+      }
+      .err {
+        color: var(--err);
+      }
+      .pill {
+        display: inline-block;
+        padding: 2px 6px;
+        border-radius: 999px;
+        border: 1px solid var(--border2);
+        font-size: 12px;
+      }
+      .btns {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .small {
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .snapshot-row {
+        display: flex;
+        gap: 8px;
+        font-size: 13px;
+      }
+      .snapshot-row > div:first-child {
+        width: 100px;
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>
+        Contract AI — <span class="muted">Panel Self-Test</span> <span class="badge">Doctor</span>
+        <span class="badge mono" id="buildToken">build-20250921-085759</span>
+      </h1>
 
-  <div class="row">
-    <label for="backendInput">Backend URL:</label>
-    <input id="backendInput" type="text" value="https://127.0.0.1:9443" class="mono" />
-    <button id="saveBtn">Save</button>
-    <label for="apiKeyInput">API Key (x-api-key, optional):</label>
-    <input id="apiKeyInput" type="text" class="mono" style="width:140px" placeholder="optional" />
-    <label for="schemaInput">Schema (x-schema-version):</label>
-    <input id="schemaInput" type="text" class="mono" style="width:80px" placeholder="1.4" />
-    <button id="saveKeyBtn">Save Headers</button>
-    <button id="runAllBtn">Run All</button>
-    <button id="pingBtn">Ping LLM</button>
-    <span class="small">Saved in localStorage. Headers optional in DEV.</span>
-    <span id="schemaWarn" class="small err" style="display:none;"></span>
-  </div>
-
-  <div class="row">
-    <textarea id="testText" placeholder="Sample text" style="flex:1; min-height:60px;">Governing law: England and Wales.</textarea>
-  </div>
-
-  <div class="row" id="llmInfo">LLM: <span id="llmProv">—</span> / <span id="llmModel">—</span> / <span id="llmLatency">—</span> <span id="llmBadge" class="badge" style="display:none;background:#facc15;color:#000;">MOCK</span></div>
-
-    <div class="card">
-      <h3>Tests</h3>
-      <div class="btns" id="testsBtns" style="margin-bottom:8px;"></div>
-      <div class="small">CID used for requests: <span id="cidLbl" class="mono pill"></span></div>
-      <div class="small">Last response CID (from headers): <span id="lastCidLbl" class="mono pill"></span></div>
-      <div style="overflow:auto;">
-        <table id="statusTbl">
-          <thead>
-            <tr>
-              <th style="width:160px;">Test</th>
-              <th>HTTP</th>
-              <th>x-cid</th>
-              <th>x-cache</th>
-              <th>x-schema-version</th>
-              <th>latency</th>
-              <th>status</th>
-            </tr>
-          </thead>
-          <tbody id="statusBody"></tbody>
-        </table>
+      <div class="row">
+        <label for="backendInput">Backend URL:</label>
+        <input id="backendInput" type="text" value="https://127.0.0.1:9443" class="mono" />
+        <button id="saveBtn">Save</button>
+        <label for="apiKeyInput">API Key (x-api-key, optional):</label>
+        <input
+          id="apiKeyInput"
+          type="text"
+          class="mono"
+          style="width: 140px"
+          placeholder="optional"
+        />
+        <label for="schemaInput">Schema (x-schema-version):</label>
+        <input id="schemaInput" type="text" class="mono" style="width: 80px" placeholder="1.4" />
+        <button id="saveKeyBtn">Save Headers</button>
+        <button id="runAllBtn">Run All</button>
+        <button id="pingBtn">Ping LLM</button>
+        <span class="small">Saved in localStorage. Headers optional in DEV.</span>
+        <span id="schemaWarn" class="small err" style="display: none"></span>
       </div>
-    </div>
 
-    <div class="card">
-      <h3>Last Response JSON</h3>
-      <div id="resp" class="pre"></div>
-    </div>
-
-    <div class="card">
-      <h3>Document Snapshot</h3>
-      <div class="snapshot-row">
-        <div>Type:</div><div data-snap-type>—</div>
+      <div class="row">
+        <textarea id="testText" placeholder="Sample text" style="flex: 1; min-height: 60px">
+Governing law: England and Wales.</textarea
+        >
       </div>
-      <div class="snapshot-row">
-        <div>Confidence:</div><div data-snap-type-confidence>—</div>
+
+      <div class="row" id="llmInfo">
+        LLM: <span id="llmProv">—</span> / <span id="llmModel">—</span> /
+        <span id="llmLatency">—</span>
+        <span id="llmBadge" class="badge" style="display: none; background: #facc15; color: #000"
+          >MOCK</span
+        >
       </div>
-      <div id="docSnap" class="pre"></div>
+
+      <div class="card">
+        <h3>Tests</h3>
+        <div class="btns" id="testsBtns" style="margin-bottom: 8px"></div>
+        <div class="small">CID used for requests: <span id="cidLbl" class="mono pill"></span></div>
+        <div class="small">
+          Last response CID (from headers): <span id="lastCidLbl" class="mono pill"></span>
+        </div>
+        <div style="overflow: auto">
+          <table id="statusTbl">
+            <thead>
+              <tr>
+                <th style="width: 160px">Test</th>
+                <th>HTTP</th>
+                <th>x-cid</th>
+                <th>x-cache</th>
+                <th>x-schema-version</th>
+                <th>latency</th>
+                <th>status</th>
+              </tr>
+            </thead>
+            <tbody id="statusBody"></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>Last Response JSON</h3>
+        <div id="resp" class="pre"></div>
+      </div>
+
+      <div class="card">
+        <h3>Document Snapshot</h3>
+        <div class="snapshot-row">
+          <div>Type:</div>
+          <div data-snap-type>—</div>
+        </div>
+        <div class="snapshot-row">
+          <div>Confidence:</div>
+          <div data-snap-type-confidence>—</div>
+        </div>
+        <div id="docSnap" class="pre"></div>
+      </div>
+
+      <div class="card">
+        <h3>Trace Payload</h3>
+        <div id="trace" class="pre"></div>
+      </div>
+
+      <p class="small muted">
+        Tip: For local dev, ensure the backend sends headers: x-cid, x-cache,
+        x-schema-version="1.4".
+      </p>
     </div>
 
-    <div class="card">
-      <h3>Trace Payload</h3>
-      <div id="trace" class="pre"></div>
-    </div>
-
-    <p class="small muted">Tip: For local dev, ensure the backend sends headers: x-cid, x-cache, x-schema-version="1.4".</p>
-  </div>
-
-    <script>window.__DEV_DEFAULT_API_KEY__ = "{{DEFAULT_API_KEY}}";</script>
-  <script type="module">
-    import { bootstrapHeaders } from "./app/assets/bootstrap.js?v=DEV";
-    await bootstrapHeaders();
-    await import("./app/assets/store.js?v=DEV");
-    const existingKey = localStorage.getItem('api_key') || (window.CAI?.Store?.get?.().apiKey);
-    if (existingKey) {
-      const lbl = document.querySelector('label[for="apiKeyInput"]');
-      if (lbl) lbl.style.display = 'none';
-      const inputEl = document.getElementById('apiKeyInput');
-      if (inputEl) inputEl.style.display = 'none';
-    }
-    await import("./app/assets/api-client.js?v=DEV");
-    await import("./app/selftest.js?v=DEV");
-  </script>
-  <script nomodule>
-    document.querySelector('#last_json')?.insertAdjacentHTML(
-      'afterbegin',
-      '<div style=\"color:#f66\">Your runtime is too old for ES modules. Please update Office/Edge.</div>'
-    );
-  </script>
-</body>
+    <script>
+      window.__DEV_DEFAULT_API_KEY__ = '{{DEFAULT_API_KEY}}';
+    </script>
+    <script type="module">
+      import { bootstrapHeaders } from './app/assets/bootstrap.js?v=DEV';
+      await bootstrapHeaders();
+      await import('./app/assets/store.js?v=DEV');
+      const existingKey = localStorage.getItem('api_key') || window.CAI?.Store?.get?.().apiKey;
+      if (existingKey) {
+        const lbl = document.querySelector('label[for="apiKeyInput"]');
+        if (lbl) lbl.style.display = 'none';
+        const inputEl = document.getElementById('apiKeyInput');
+        if (inputEl) inputEl.style.display = 'none';
+      }
+      await import('./app/assets/api-client.js?v=DEV');
+      await import('./app/selftest.js?v=DEV');
+    </script>
+    <script nomodule>
+      document
+        .querySelector('#last_json')
+        ?.insertAdjacentHTML(
+          'afterbegin',
+          '<div style=\"color:#f66\">Your runtime is too old for ES modules. Please update Office/Edge.</div>'
+        );
+    </script>
+  </body>
 </html>

--- a/word_addin_dev/taskpane.html
+++ b/word_addin_dev/taskpane.html
@@ -1,416 +1,621 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta http-equiv="Cache-Control" content="no-store, must-revalidate"/>
-  <meta http-equiv="Pragma" content="no-cache"/>
-  <meta http-equiv="Expires" content="0"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Contract AI - Draft Assistant</title>
-  <link rel="stylesheet" href="./app/assets/notifier.css" />
-  <link rel="stylesheet" href="./app/assets/taskpane.css" />
-  <!-- hdrWarn block removed -->
-  <style>
-    :root{
-      --bg:            #0b1e2e;
-      --card:          #0f2740;
-      --muted:         #8fa7bd;
-      --text:          #e8f0fa;
-      --outline:       #93a9c4;
-      --shadow:        rgba(5, 20, 35, 0.45);
-      --btn:           #8fb1ff;
-      --btn-contrast:  #0a1a2a;
-      --btn2:          #5aa0ff;
-      --pill:          #1a3550;
-      --border:        #2a4666;
-      --input-bg:      #0a1c2c;
-    }
-    html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Segoe UI,Arial,sans-serif}
-    .wrap{padding:12px}
-    .row{margin:10px 0}
-    .card{
-      background:var(--card);
-      border-radius:8px;
-      padding:10px;
-      border:1px solid var(--border);
-      box-shadow:0 6px 18px var(--shadow);
-    }
-    .flex{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-    input,textarea,select{
-      width:100%;
-      box-sizing:border-box;
-      border:1px solid var(--border);
-      border-radius:6px;
-      background:var(--input-bg);
-      color:var(--text);
-      padding:8px;
-      box-shadow:0 6px 18px var(--shadow);
-      outline-color:var(--outline);
-    }
-    textarea{min-height:110px;resize:vertical}
-    button{
-      border:0;border-radius:6px;padding:8px 12px;cursor:pointer;
-      transition:box-shadow .2s ease;
-      box-shadow:0 4px 12px var(--shadow);
-    }
-    .btn{background:var(--btn);color:var(--btn-contrast)}
-    .btn2{background:var(--btn2);color:#fff}
-    .btn-grey{background:#304a67;color:var(--text);border:1px solid var(--border)}
-    .btn:hover,.btn:focus,.btn2:hover,.btn2:focus,.btn-grey:hover,.btn-grey:focus{
-      box-shadow:0 10px 24px var(--shadow);
-    }
-    .badge,.pill{
-      display:inline-block;padding:3px 8px;border-radius:999px;
-      background:var(--pill);color:var(--text);font-size:12px;margin-right:6px;
-      border:1px solid var(--border);
-    }
-    .muted{color:var(--muted);font-size:12px}
-    #console{
-      background:var(--input-bg);
-      border-radius:8px;padding:8px;white-space:pre-wrap;max-height:170px;overflow:auto;
-      border:1px solid var(--border);
-      box-shadow:0 6px 18px var(--shadow);
-    }
-    .topline{display:flex;justify-content:space-between;align-items:center}
-    .list{margin:0;padding-left:18px}
-    .list li{margin:4px 0}
-    .grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
-    .kv{display:flex;gap:6px;align-items:center}
-    .kv span{font-size:12px}
-    pre{
-      background:var(--input-bg);
-      border:1px solid var(--border);
-      border-radius:8px;padding:8px;overflow:auto;max-height:220px;
-      box-shadow:0 6px 18px var(--shadow);
-    }
-    .pre{
-      background:var(--input-bg);
-      border:1px solid var(--border);
-      border-radius:8px;padding:8px;overflow:auto;max-height:220px;
-      box-shadow:0 6px 18px var(--shadow);
-      white-space:pre-wrap;
-    }
-    .toggle{cursor:pointer;text-decoration:underline}
-    .right{margin-left:auto}
-    .inline{display:inline-flex;gap:6px;align-items:center;flex-wrap:wrap}
-    .sep{height:1px;background:var(--border);margin:8px 0}
-    .sug-card{
-      border:1px solid var(--border);
-      border-radius:8px;padding:8px;margin:6px 0;background:var(--card);
-      box-shadow:0 6px 18px var(--shadow);
-      color:var(--text);
-    }
-    .sug-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px}
-    .sug-title{font-weight:600}
-    .sug-meta{font-size:12px;color:var(--muted)}
-    .hidden{display:none}
-    #doc-snapshot table{width:100%;border-collapse:collapse;margin-top:6px}
-    #doc-snapshot th,#doc-snapshot td{border-bottom:1px solid var(--border);padding:4px 6px;text-align:left;font-size:12px}
-    #doc-snapshot th{color:var(--muted);font-weight:600}
-    code{color:var(--outline)}
-  </style>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Contract AI - Draft Assistant</title>
+    <link rel="stylesheet" href="./app/assets/notifier.css" />
+    <link rel="stylesheet" href="./app/assets/taskpane.css" />
+    <!-- hdrWarn block removed -->
+    <style>
+      :root {
+        --bg: #0b1e2e;
+        --card: #0f2740;
+        --muted: #8fa7bd;
+        --text: #e8f0fa;
+        --outline: #93a9c4;
+        --shadow: rgba(5, 20, 35, 0.45);
+        --btn: #8fb1ff;
+        --btn-contrast: #0a1a2a;
+        --btn2: #5aa0ff;
+        --pill: #1a3550;
+        --border: #2a4666;
+        --input-bg: #0a1c2c;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family:
+          Segoe UI,
+          Arial,
+          sans-serif;
+      }
+      .wrap {
+        padding: 12px;
+      }
+      .row {
+        margin: 10px 0;
+      }
+      .card {
+        background: var(--card);
+        border-radius: 8px;
+        padding: 10px;
+        border: 1px solid var(--border);
+        box-shadow: 0 6px 18px var(--shadow);
+      }
+      .flex {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      input,
+      textarea,
+      select {
+        width: 100%;
+        box-sizing: border-box;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: var(--input-bg);
+        color: var(--text);
+        padding: 8px;
+        box-shadow: 0 6px 18px var(--shadow);
+        outline-color: var(--outline);
+      }
+      textarea {
+        min-height: 110px;
+        resize: vertical;
+      }
+      button {
+        border: 0;
+        border-radius: 6px;
+        padding: 8px 12px;
+        cursor: pointer;
+        transition: box-shadow 0.2s ease;
+        box-shadow: 0 4px 12px var(--shadow);
+      }
+      .btn {
+        background: var(--btn);
+        color: var(--btn-contrast);
+      }
+      .btn2 {
+        background: var(--btn2);
+        color: #fff;
+      }
+      .btn-grey {
+        background: #304a67;
+        color: var(--text);
+        border: 1px solid var(--border);
+      }
+      .btn:hover,
+      .btn:focus,
+      .btn2:hover,
+      .btn2:focus,
+      .btn-grey:hover,
+      .btn-grey:focus {
+        box-shadow: 0 10px 24px var(--shadow);
+      }
+      .badge,
+      .pill {
+        display: inline-block;
+        padding: 3px 8px;
+        border-radius: 999px;
+        background: var(--pill);
+        color: var(--text);
+        font-size: 12px;
+        margin-right: 6px;
+        border: 1px solid var(--border);
+      }
+      .muted {
+        color: var(--muted);
+        font-size: 12px;
+      }
+      #console {
+        background: var(--input-bg);
+        border-radius: 8px;
+        padding: 8px;
+        white-space: pre-wrap;
+        max-height: 170px;
+        overflow: auto;
+        border: 1px solid var(--border);
+        box-shadow: 0 6px 18px var(--shadow);
+      }
+      .topline {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .list {
+        margin: 0;
+        padding-left: 18px;
+      }
+      .list li {
+        margin: 4px 0;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+      .kv {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+      }
+      .kv span {
+        font-size: 12px;
+      }
+      pre {
+        background: var(--input-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 8px;
+        overflow: auto;
+        max-height: 220px;
+        box-shadow: 0 6px 18px var(--shadow);
+      }
+      .pre {
+        background: var(--input-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 8px;
+        overflow: auto;
+        max-height: 220px;
+        box-shadow: 0 6px 18px var(--shadow);
+        white-space: pre-wrap;
+      }
+      .toggle {
+        cursor: pointer;
+        text-decoration: underline;
+      }
+      .right {
+        margin-left: auto;
+      }
+      .inline {
+        display: inline-flex;
+        gap: 6px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .sep {
+        height: 1px;
+        background: var(--border);
+        margin: 8px 0;
+      }
+      .sug-card {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 8px;
+        margin: 6px 0;
+        background: var(--card);
+        box-shadow: 0 6px 18px var(--shadow);
+        color: var(--text);
+      }
+      .sug-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 6px;
+      }
+      .sug-title {
+        font-weight: 600;
+      }
+      .sug-meta {
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .hidden {
+        display: none;
+      }
+      #doc-snapshot table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 6px;
+      }
+      #doc-snapshot th,
+      #doc-snapshot td {
+        border-bottom: 1px solid var(--border);
+        padding: 4px 6px;
+        text-align: left;
+        font-size: 12px;
+      }
+      #doc-snapshot th {
+        color: var(--muted);
+        font-weight: 600;
+      }
+      code {
+        color: var(--outline);
+      }
+    </style>
 
-  <style>
-    [data-busy="1"] .js-busy-indicator { display:inline-block; }
-    .js-busy-indicator { display:none; margin-left:6px; }
-    .is-busy { opacity:.6; pointer-events:none; }
-  </style>
+    <style>
+      [data-busy='1'] .js-busy-indicator {
+        display: inline-block;
+      }
+      .js-busy-indicator {
+        display: none;
+        margin-left: 6px;
+      }
+      .is-busy {
+        opacity: 0.6;
+        pointer-events: none;
+      }
+    </style>
 
-  <!-- Office.js -->
-  <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+    <!-- Office.js -->
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 
-  <!-- Guard to avoid double wiring; bundle will set 'ready' -->
-  <script>
-    window.__CAI_WIRED__ = false;
-    window.__DEV_DEFAULT_API_KEY__ = "{{DEFAULT_API_KEY}}";
-  </script>
+    <!-- Guard to avoid double wiring; bundle will set 'ready' -->
+    <script>
+      window.__CAI_WIRED__ = false;
+      window.__DEV_DEFAULT_API_KEY__ = '{{DEFAULT_API_KEY}}';
+    </script>
 
-  <script src="./taskpane.bundle.js?b=build-20250921-085759"></script>
+    <script src="./taskpane.bundle.js?b=build-20250921-085759"></script>
 
-  <script nomodule>
-    document.body.innerHTML =
-      '<div style=\"padding:12px;color:#f66\">This Office runtime does not support ES modules. '+
-      'Please update Office to a recent build.</div>';
-  </script>
-</head>
-<body data-build="build-20250921-085759">
-<div class="wrap">
-  <div id="hdrWarn" style="display:none;color:#f66;margin-bottom:8px;">Missing headers</div>
-  <div class="topline">
-    <h3 style="margin:6px 0;">Contract AI - Draft Assistant</h3>
-    <span class="pill">Build: <span id="buildInfo">build-20250921-085759</span></span>
-    <span class="pill">Provider: <span id="providerMeta">—</span></span>
-    <span class="pill" id="status-chip">schema: — | cid: —</span>
-  </div>
-
-  <div class="row muted">Endpoints: <code>/health</code> · <code>/api/analyze</code> · <code>/api/gpt-draft</code> · <code>/api/qa-recheck</code></div>
-  <div class="row muted">Rules without matching document type are marked as <code>doc_type_mismatch</code>.</div>
-  <div class="row card">
-    <div class="row"><input id="backendUrl" placeholder="https://127.0.0.1:9443" /></div>
-    <div class="row flex">
-      <button id="btnSave" class="btn-grey">Save</button>
-      <button id="btnTest" class="btn-grey">Test</button>
-      <span class="pill" id="connBadge">Conn: —</span>
-      <span class="pill" id="officeBadge">Office: —</span>
-      <span class="pill" id="anchorsBadge" style="display:none">⚠️ Anchors: partial</span>
-      <span class="pill right" id="doctorToggle">Doctor ▸</span>
-    </div>
-    <div id="statusLine" class="muted">
-      <span class="inline">
-        <span>status:</span><span class="badge" id="status">—</span>
-        <span>cid:</span><span class="badge" id="cid">—</span>
-        <span>X-Cache:</span><span class="badge" id="xcache">—</span>
-        <span>latency:</span><span class="badge" id="latency">—</span>
-        <span>schema:</span><span class="badge" id="schema">—</span>
-        <span>provider:</span><span class="badge" id="provider">—</span>
-        <span>model:</span><span class="badge" id="model">—</span>
-        <span>mode:</span><span class="badge" id="mode">—</span><span id="mockModeBadge" class="badge" style="display:none;background:#facc15;color:#000;">MOCK</span>
-        <span>usage:</span><span class="badge" id="usage">—</span>
-      </span>
-    </div>
-    <div class="row" style="margin-top:6px">
-      <button id="btn-clear-storage" class="btn btn-sm">Clear storage & reload</button>
-    </div>
-  </div>
-  <script>
-  document.getElementById("btn-clear-storage").addEventListener("click", function(){
-    try { localStorage.clear(); } catch {}
-    try { if (window.caches) caches.keys().then(keys => keys.forEach(k => caches.delete(k))); } catch {}
-    try { CAI.Store.setBase(CAI.Store.DEFAULT_BASE); } catch {}
-    location.reload();
-  });
-  </script>
-
-  <div id="doc-snapshot" class="row card hidden">
-    <div class="grid">
-      <div class="kv"><strong>Type:</strong><span data-snap-type>—</span></div>
-      <div class="kv"><strong>Confidence:</strong><span data-snap-type-confidence>—</span></div>
-    </div>
-  </div>
-
-  <div id="doctorPanel" class="row card" style="display:none">
-    <div class="muted" style="margin-bottom:6px">Doctor</div>
-    <div class="grid">
-      <div class="kv"><strong>cid:</strong><span id="doctorCid">—</span></div>
-      <div class="kv"><strong>last latency(ms):</strong><span id="doctorLatency">—</span></div>
-    </div>
-    <div class="row">
-      <strong>Recent requests</strong>
-      <ul class="list" id="doctorReqList"></ul>
-    </div>
-    <div class="row">
-      <strong>Payload size</strong>
-      <div class="muted" id="doctorPayload">—</div>
-    </div>
-  </div>
-
-  <div id="officeTools" class="row card" style="display:block">
-    <div class="muted" style="margin-bottom:6px">Office tools</div>
-    <div class="flex">
-      <button id="btnUseWholeDoc">Use whole doc →</button>
-      <button id="btnAnalyze" disabled>Analyze</button>
-      <button id="btnFixNumbering" class="btn-grey">Fix numbering</button>
-    </div>
-  </div>
-
-  <div id="annotateQA" class="row card">
-    <div class="flex">
-      <div class="kv"><strong>Annotate & QA</strong></div>
-      <div class="kv">
-        <span class="muted">Risk threshold:</span>
-        <select id="selectRiskThreshold">
-          <option value="medium" selected>medium</option>
-          <option value="high">high</option>
-          <option value="critical">critical</option>
-        </select>
-      </div>
-    </div>
-    <div class="row flex" style="margin-top:6px">
-      <label class="inline" style="gap:4px;display:none"><input type="checkbox" id="chkUseSelection"/>Use selection</label>
-      <small class="js-busy-indicator" style="display:none">⏳</small>
-      <button id="btnAnnotate" class="btn2 js-disable-while-busy" disabled>Annotate</button>
-      <button id="btnPrevIssue" class="btn-grey js-disable-while-busy">Prev issue</button>
-      <button id="btnNextIssue" class="btn-grey js-disable-while-busy">Next issue</button>
-      <span id="findingIndex" class="pill">0/0</span>
-      <button id="btnQARecheck" class="btn-grey js-disable-while-busy">QA Recheck</button>
-      <button id="btnClearAnnots" class="btn-grey js-disable-while-busy" title="Select text in Word before applying edits.">Clear Annotations</button>
-      <span class="pill right" id="qaDeltaBadge" title="QA deltas">Δ: —</span>
-    </div>
-    <div class="row">
-      <label class="toggle">
-        <input id="cai-comment-on-analyze" type="checkbox" checked>
-        <span>Add comments on Analyze</span>
-      </label>
-      <input id="chkAddCommentsOnAnalyze" type="checkbox" style="display:none" checked>
-    </div>
-    <div class="row">
-      <label class="toggle">
-        <input id="cai-dry-run-annotate" type="checkbox">
-        <span>Dry-run annotate (no comments)</span>
-      </label>
-    </div>
-    <div id="qaResiduals" class="row" style="display:none">
-      <strong>Residual risks</strong>
-      <ul class="list" id="qaResidualList"></ul>
-    </div>
-  </div>
-
-  <!-- hidden field with original text -->
-  <textarea id="originalText" style="display:none"></textarea>
-
-  <!-- loading indicator -->
-  <div id="busyBar" style="display:none"></div>
-  <div id="loading-book" role="status" aria-live="polite" aria-atomic="true" class="cai-book hidden" data-test-id="loading-book">
-    <div class="cai-book__icon" aria-hidden="true"></div>
-    <span class="sr-only">Processing…</span>
-  </div>
-
-  <div class="row card">
-    <div class="muted" style="margin-bottom:6px">Original clause:</div>
-    <textarea id="originalClause" placeholder="Paste text or load from selection/document…"></textarea>
-    <div class="row flex" style="margin-top:8px">
-      <button id="btnSuggestEdit" class="btn btn-primary btn-sm" disabled>Get draft</button>
-    </div>
-    <div class="row">
-      <span class="badge" id="scoreBadge">score: —</span>
-      <span class="badge" id="riskBadge">risk: —</span>
-      <span class="badge" id="statusBadge">status: —</span>
-      <span class="badge" id="severityBadge">severity: —</span>
-    </div>
-  </div>
-
-  <div id="traceModal" class="card" style="display:none">
-    <div class="row flex" style="margin-bottom:6px">
-      <button id="traceTabJson" class="btn-grey">JSON</button>
-      <button id="traceTabReadable" class="btn-grey">Readable</button>
-      <button id="traceClose" class="btn-grey right">Close</button>
-    </div>
-    <pre id="traceJson" class="pre" style="max-height:260px"></pre>
-    <div id="traceReadable" class="pre" style="display:none;max-height:260px"></div>
-  </div>
-
-  <section id="doc-risk-summary" hidden>
-    <header>
-      <h3>Document Risk Summary</h3>
-      <div class="badges">
-        <span class="badge risk-high">High: <b id="rs-high">0</b></span>
-        <span class="badge risk-med">Medium: <b id="rs-med">0</b></span>
-        <span class="badge risk-low">Low: <b id="rs-low">0</b></span>
-        <span class="badge risk-total">Total: <b id="rs-total">0</b></span>
-      </div>
-    </header>
-    <div class="table-wrap">
-      <table id="rs-table">
-        <thead><tr><th>Rule</th><th>Severity</th><th>Category</th><th>Clause</th><th>Count</th></tr></thead>
-        <tbody></tbody>
-      </table>
-    </div>
-    <div class="actions" style="display:none">
-      <button id="rs-copy">Copy summary</button>
-      <button id="rs-export-md">Export .md</button>
-      <button id="rs-export-json">Export .json</button>
-    </div>
-  </section>
-
-  <section class="row card" id="resultsBlock">
-    <div class="muted" style="margin-bottom:6px">Results</div>
-    <div class="grid">
-      <div class="kv"><strong>Clause type:</strong><span id="clauseTypeOut" data-role="clause-type">—</span></div>
-      <div class="kv"><strong>Findings:</strong><span id="resFindingsCount" data-role="findings-count">—</span></div>
-      <div class="kv"><strong>Visible / Hidden by filters:</strong><span id="visibleHiddenOut" data-role="findings-visible-hidden">—</span></div>
-    </div>
-
-    <!-- сам контейнер результатов для событий -->
-    <section id="results" class="card"></section>
-
-    <div class="row" id="findingsBlock">
-      <strong>Findings</strong>
-      <ol class="list" id="findingsList" data-role="findings"></ol>
-    </div>
-
-      <div class="row" id="recommendationsBlock">
-        <strong>Recommendations</strong>
-        <ol class="list" id="recommendationsList" data-role="recommendations"></ol>
+    <script nomodule>
+      document.body.innerHTML =
+        '<div style=\"padding:12px;color:#f66\">This Office runtime does not support ES modules. ' +
+        'Please update Office to a recent build.</div>';
+    </script>
+  </head>
+  <body data-build="build-20250921-085759">
+    <div class="wrap">
+      <div id="hdrWarn" style="display: none; color: #f66; margin-bottom: 8px">Missing headers</div>
+      <div class="topline">
+        <h3 style="margin: 6px 0">Contract AI - Draft Assistant</h3>
+        <span class="pill">Build: <span id="buildInfo">build-20250921-085759</span></span>
+        <span class="pill">Provider: <span id="providerMeta">—</span></span>
+        <span class="pill" id="status-chip">schema: — | cid: —</span>
       </div>
 
-    <div class="row">
-      <span class="toggle" id="toggleRaw" data-role="toggle-raw-json">Show raw JSON</span>
-      <pre id="rawJson" data-role="raw-json" style="display:none"></pre>
-    </div>
-  </section>
-
-  <div id="cai-suggest" class="card mt-2">
-    <div class="card-header">Suggested edits</div>
-    <div class="card-body">
-      <div class="row" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
-        <div style="flex:1">
-          <label class="form-label">Clause</label>
-          <select id="cai-clause-select" class="form-select js-disable-while-busy"></select>
+      <div class="row muted">
+        Endpoints: <code>/health</code> · <code>/api/analyze</code> · <code>/api/gpt-draft</code> ·
+        <code>/api/qa-recheck</code>
+      </div>
+      <div class="row muted">
+        Rules without matching document type are marked as <code>doc_type_mismatch</code>.
+      </div>
+      <div class="row card">
+        <div class="row"><input id="backendUrl" placeholder="https://127.0.0.1:9443" /></div>
+        <div class="row flex">
+          <button id="btnSave" class="btn-grey">Save</button>
+          <button id="btnTest" class="btn-grey">Test</button>
+          <span class="pill" id="connBadge">Conn: —</span>
+          <span class="pill" id="officeBadge">Office: —</span>
+          <span class="pill" id="anchorsBadge" style="display: none">⚠️ Anchors: partial</span>
+          <span class="pill right" id="doctorToggle">Doctor ▸</span>
         </div>
-        <div style="flex:1">
-          <label class="form-label">Mode</label>
-          <select id="cai-mode" class="form-select js-disable-while-busy">
-            <option value="friendly">friendly</option>
-            <option value="medium">medium</option>
-            <option value="strict">strict</option>
-          </select>
+        <div id="statusLine" class="muted">
+          <span class="inline">
+            <span>status:</span><span class="badge" id="status">—</span> <span>cid:</span
+            ><span class="badge" id="cid">—</span> <span>X-Cache:</span
+            ><span class="badge" id="xcache">—</span> <span>latency:</span
+            ><span class="badge" id="latency">—</span> <span>schema:</span
+            ><span class="badge" id="schema">—</span> <span>provider:</span
+            ><span class="badge" id="provider">—</span> <span>model:</span
+            ><span class="badge" id="model">—</span> <span>mode:</span
+            ><span class="badge" id="mode">—</span
+            ><span
+              id="mockModeBadge"
+              class="badge"
+              style="display: none; background: #facc15; color: #000"
+              >MOCK</span
+            >
+            <span>usage:</span><span class="badge" id="usage">—</span>
+          </span>
         </div>
-        <div class="col-auto d-flex align-items-end">
-          <button id="btnSuggest" class="btn btn-primary js-disable-while-busy">Suggest</button>
+        <div class="row" style="margin-top: 6px">
+          <button id="btn-clear-storage" class="btn btn-sm">Clear storage & reload</button>
         </div>
       </div>
-      <div id="cai-suggest-list">
-        <div id="suggestions"></div>
-        <template id="sugg-item">
-          <div class="sugg-item" data-id="">
-            <div class="sugg-head">
-              <span class="rule"></span>
-              <span class="sev"></span>
-              <span class="badge status"></span>
+      <script>
+        document.getElementById('btn-clear-storage').addEventListener('click', function () {
+          try {
+            localStorage.clear();
+          } catch {}
+          try {
+            if (window.caches) caches.keys().then(keys => keys.forEach(k => caches.delete(k)));
+          } catch {}
+          try {
+            CAI.Store.setBase(CAI.Store.DEFAULT_BASE);
+          } catch {}
+          location.reload();
+        });
+      </script>
+
+      <div id="doc-snapshot" class="row card hidden">
+        <div class="grid">
+          <div class="kv"><strong>Type:</strong><span data-snap-type>—</span></div>
+          <div class="kv"><strong>Confidence:</strong><span data-snap-type-confidence>—</span></div>
+        </div>
+      </div>
+
+      <div id="doctorPanel" class="row card" style="display: none">
+        <div class="muted" style="margin-bottom: 6px">Doctor</div>
+        <div class="grid">
+          <div class="kv"><strong>cid:</strong><span id="doctorCid">—</span></div>
+          <div class="kv"><strong>last latency(ms):</strong><span id="doctorLatency">—</span></div>
+        </div>
+        <div class="row">
+          <strong>Recent requests</strong>
+          <ul class="list" id="doctorReqList"></ul>
+        </div>
+        <div class="row">
+          <strong>Payload size</strong>
+          <div class="muted" id="doctorPayload">—</div>
+        </div>
+      </div>
+
+      <div id="officeTools" class="row card" style="display: block">
+        <div class="muted" style="margin-bottom: 6px">Office tools</div>
+        <div class="flex">
+          <button id="btnUseWholeDoc">Use whole doc →</button>
+          <button id="btnAnalyze" disabled>Analyze</button>
+          <button id="btnFixNumbering" class="btn-grey">Fix numbering</button>
+        </div>
+      </div>
+
+      <div id="annotateQA" class="row card">
+        <div class="flex">
+          <div class="kv"><strong>Annotate & QA</strong></div>
+          <div class="kv">
+            <span class="muted">Risk threshold:</span>
+            <select id="selectRiskThreshold">
+              <option value="medium" selected>medium</option>
+              <option value="high">high</option>
+              <option value="critical">critical</option>
+            </select>
+          </div>
+        </div>
+        <div class="row flex" style="margin-top: 6px">
+          <label class="inline" style="gap: 4px; display: none"
+            ><input type="checkbox" id="chkUseSelection" />Use selection</label
+          >
+          <small class="js-busy-indicator" style="display: none">⏳</small>
+          <button id="btnAnnotate" class="btn2 js-disable-while-busy" disabled>Annotate</button>
+          <button id="btnPrevIssue" class="btn-grey js-disable-while-busy">Prev issue</button>
+          <button id="btnNextIssue" class="btn-grey js-disable-while-busy">Next issue</button>
+          <span id="findingIndex" class="pill">0/0</span>
+          <button id="btnQARecheck" class="btn-grey js-disable-while-busy">QA Recheck</button>
+          <button
+            id="btnClearAnnots"
+            class="btn-grey js-disable-while-busy"
+            title="Select text in Word before applying edits."
+          >
+            Clear Annotations
+          </button>
+          <span class="pill right" id="qaDeltaBadge" title="QA deltas">Δ: —</span>
+        </div>
+        <div class="row">
+          <label class="toggle">
+            <input id="cai-comment-on-analyze" type="checkbox" checked />
+            <span>Add comments on Analyze</span>
+          </label>
+          <input id="chkAddCommentsOnAnalyze" type="checkbox" style="display: none" checked />
+        </div>
+        <div class="row">
+          <label class="toggle">
+            <input id="cai-dry-run-annotate" type="checkbox" />
+            <span>Dry-run annotate (no comments)</span>
+          </label>
+        </div>
+        <div id="qaResiduals" class="row" style="display: none">
+          <strong>Residual risks</strong>
+          <ul class="list" id="qaResidualList"></ul>
+        </div>
+      </div>
+
+      <!-- hidden field with original text -->
+      <textarea id="originalText" style="display: none"></textarea>
+
+      <!-- loading indicator -->
+      <div id="busyBar" style="display: none"></div>
+      <div
+        id="loading-book"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        class="cai-book hidden"
+        data-test-id="loading-book"
+      >
+        <div class="cai-book__icon" aria-hidden="true"></div>
+        <span class="sr-only">Processing…</span>
+      </div>
+
+      <div class="row card">
+        <div class="muted" style="margin-bottom: 6px">Original clause:</div>
+        <textarea
+          id="originalClause"
+          placeholder="Paste text or load from selection/document…"
+        ></textarea>
+        <div class="row flex" style="margin-top: 8px">
+          <button id="btnSuggestEdit" class="btn btn-primary btn-sm" disabled>Get draft</button>
+        </div>
+        <div class="row">
+          <span class="badge" id="scoreBadge">score: —</span>
+          <span class="badge" id="riskBadge">risk: —</span>
+          <span class="badge" id="statusBadge">status: —</span>
+          <span class="badge" id="severityBadge">severity: —</span>
+        </div>
+      </div>
+
+      <div id="traceModal" class="card" style="display: none">
+        <div class="row flex" style="margin-bottom: 6px">
+          <button id="traceTabJson" class="btn-grey">JSON</button>
+          <button id="traceTabReadable" class="btn-grey">Readable</button>
+          <button id="traceClose" class="btn-grey right">Close</button>
+        </div>
+        <pre id="traceJson" class="pre" style="max-height: 260px"></pre>
+        <div id="traceReadable" class="pre" style="display: none; max-height: 260px"></div>
+      </div>
+
+      <section id="doc-risk-summary" hidden>
+        <header>
+          <h3>Document Risk Summary</h3>
+          <div class="badges">
+            <span class="badge risk-high">High: <b id="rs-high">0</b></span>
+            <span class="badge risk-med">Medium: <b id="rs-med">0</b></span>
+            <span class="badge risk-low">Low: <b id="rs-low">0</b></span>
+            <span class="badge risk-total">Total: <b id="rs-total">0</b></span>
+          </div>
+        </header>
+        <div class="table-wrap">
+          <table id="rs-table">
+            <thead>
+              <tr>
+                <th>Rule</th>
+                <th>Severity</th>
+                <th>Category</th>
+                <th>Clause</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div class="actions" style="display: none">
+          <button id="rs-copy">Copy summary</button>
+          <button id="rs-export-md">Export .md</button>
+          <button id="rs-export-json">Export .json</button>
+        </div>
+      </section>
+
+      <section class="row card" id="resultsBlock">
+        <div class="muted" style="margin-bottom: 6px">Results</div>
+        <div class="grid">
+          <div class="kv">
+            <strong>Clause type:</strong><span id="clauseTypeOut" data-role="clause-type">—</span>
+          </div>
+          <div class="kv">
+            <strong>Findings:</strong
+            ><span id="resFindingsCount" data-role="findings-count">—</span>
+          </div>
+          <div class="kv">
+            <strong>Visible / Hidden by filters:</strong
+            ><span id="visibleHiddenOut" data-role="findings-visible-hidden">—</span>
+          </div>
+        </div>
+
+        <!-- сам контейнер результатов для событий -->
+        <section id="results" class="card"></section>
+
+        <div class="row" id="findingsBlock">
+          <strong>Findings</strong>
+          <ol class="list" id="findingsList" data-role="findings"></ol>
+        </div>
+
+        <div class="row" id="recommendationsBlock">
+          <strong>Recommendations</strong>
+          <ol class="list" id="recommendationsList" data-role="recommendations"></ol>
+        </div>
+
+        <div class="row">
+          <span class="toggle" id="toggleRaw" data-role="toggle-raw-json">Show raw JSON</span>
+          <pre id="rawJson" data-role="raw-json" style="display: none"></pre>
+        </div>
+      </section>
+
+      <div id="cai-suggest" class="card mt-2">
+        <div class="card-header">Suggested edits</div>
+        <div class="card-body">
+          <div class="row" style="display: flex; gap: 8px; align-items: flex-end; flex-wrap: wrap">
+            <div style="flex: 1">
+              <label class="form-label">Clause</label>
+              <select id="cai-clause-select" class="form-select js-disable-while-busy"></select>
             </div>
-            <div class="sugg-body">
-              <div class="before"></div>
-              <div class="after"></div>
+            <div style="flex: 1">
+              <label class="form-label">Mode</label>
+              <select id="cai-mode" class="form-select js-disable-while-busy">
+                <option value="friendly">friendly</option>
+                <option value="medium">medium</option>
+                <option value="strict">strict</option>
+              </select>
             </div>
-            <div class="sugg-actions">
-              <button class="btn-apply js-disable-while-busy">Apply (tracked)</button>
-              <button class="btn-accept js-disable-while-busy">Accept</button>
-              <button class="btn-reject js-disable-while-busy">Reject</button>
+            <div class="col-auto d-flex align-items-end">
+              <button id="btnSuggest" class="btn btn-primary js-disable-while-busy">Suggest</button>
             </div>
           </div>
-        </template>
+          <div id="cai-suggest-list">
+            <div id="suggestions"></div>
+            <template id="sugg-item">
+              <div class="sugg-item" data-id="">
+                <div class="sugg-head">
+                  <span class="rule"></span>
+                  <span class="sev"></span>
+                  <span class="badge status"></span>
+                </div>
+                <div class="sugg-body">
+                  <div class="before"></div>
+                  <div class="after"></div>
+                </div>
+                <div class="sugg-actions">
+                  <button class="btn-apply js-disable-while-busy">Apply (tracked)</button>
+                  <button class="btn-accept js-disable-while-busy">Accept</button>
+                  <button class="btn-reject js-disable-while-busy">Reject</button>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <section class="row card" id="draftPane">
+        <div class="muted" style="margin-bottom: 6px">
+          Proposed draft (from analysis or edited manually):
+        </div>
+        <textarea
+          id="draftText"
+          name="proposed"
+          data-role="proposed-text"
+          placeholder="Proposed draft…"
+          rows="8"
+          spellcheck="false"
+        ></textarea>
+        <div class="row flex" style="margin-top: 8px">
+          <button id="btnPreviewDiff" class="btn-grey" disabled>Preview diff</button>
+          <button
+            id="btnApplyTracked"
+            class="btn js-disable-while-busy"
+            disabled
+            title="Select text in Word before applying edits."
+          >
+            Apply (tracked + comment)
+          </button>
+          <button id="btnAcceptAll" class="btn-grey js-disable-while-busy" disabled>
+            Accept all
+          </button>
+          <button id="btnRejectAll" class="btn-grey js-disable-while-busy" disabled>
+            Reject all
+          </button>
+        </div>
+        <div id="diffContainer" class="row" style="display: none; margin-top: 8px">
+          <div class="muted" style="margin-bottom: 4px">Diff Preview</div>
+          <div
+            id="diffOutput"
+            style="
+              background: var(--input-bg);
+              border: 1px solid var(--border);
+              border-radius: 8px;
+              padding: 8px;
+              white-space: pre-wrap;
+            "
+          ></div>
+        </div>
+        <div id="diffView" class="pre"></div>
+      </section>
+
+      <div class="row">
+        <div class="muted" style="margin-bottom: 4px">Console</div>
+        <div id="console" class="console"></div>
       </div>
     </div>
-  </div>
-
-  <section class="row card" id="draftPane">
-    <div class="muted" style="margin-bottom:6px">Proposed draft (from analysis or edited manually):</div>
-    <textarea
-  id="draftText"
-  name="proposed"
-  data-role="proposed-text"
-  placeholder="Proposed draft…"
-  rows="8"
-  spellcheck="false"
-></textarea>
-    <div class="row flex" style="margin-top:8px">
-      <button id="btnPreviewDiff" class="btn-grey" disabled>Preview diff</button>
-      <button id="btnApplyTracked" class="btn js-disable-while-busy" disabled title="Select text in Word before applying edits.">Apply (tracked + comment)</button>
-      <button id="btnAcceptAll" class="btn-grey js-disable-while-busy" disabled>Accept all</button>
-      <button id="btnRejectAll" class="btn-grey js-disable-while-busy" disabled>Reject all</button>
-    </div>
-    <div id="diffContainer" class="row" style="display:none;margin-top:8px">
-      <div class="muted" style="margin-bottom:4px">Diff Preview</div>
-      <div id="diffOutput" style="background:var(--input-bg);border:1px solid var(--border);border-radius:8px;padding:8px;white-space:pre-wrap"></div>
-    </div>
-    <div id="diffView" class="pre"></div>
-  </section>
-
-  <div class="row">
-    <div class="muted" style="margin-bottom:4px">Console</div>
-    <div id="console" class="console"></div>
-  </div>
-</div>
-</body>
+  </body>
 </html>

--- a/word_addin_dev/vitest.config.ci.ts
+++ b/word_addin_dev/vitest.config.ci.ts
@@ -43,7 +43,7 @@ export default defineConfig({
       '**/render*.spec.*',
       '**/*taskpane*.spec.*',
       '**/*ui-gating*.spec.*',
-      '**/*annotate.flow*.spec.*'
+      '**/*annotate.flow*.spec.*',
     ],
     // Разрешённый «белый список» — логика, утилиты, поиск, аннотации, таймауты, нормализация:
     include: [
@@ -53,7 +53,7 @@ export default defineConfig({
       'app/assets/__tests__/**/*annotate*.spec.ts',
       'app/assets/__tests__/**/*timeout*.spec.ts',
       'app/assets/__tests__/**/*normalized*.spec.ts',
-      'app/assets/__tests__/**/*supports*.spec.ts'
+      'app/assets/__tests__/**/*supports*.spec.ts',
     ],
     // ускоряем/стабилизируем CI
     reporters: ['default'],

--- a/word_addin_dev/vitest.setup.ts
+++ b/word_addin_dev/vitest.setup.ts
@@ -1,5 +1,14 @@
 import '@testing-library/jest-dom/vitest';
 
-(globalThis as any).Office = {
-  context: { requirements: { isSetSupported: () => true }, document: { mode: 'edit' } }
+type OfficeStub = {
+  context: {
+    requirements: { isSetSupported: () => boolean };
+    document: { mode: string };
+  };
 };
+
+const officeMock: OfficeStub = {
+  context: { requirements: { isSetSupported: () => true }, document: { mode: 'edit' } },
+};
+
+(globalThis as typeof globalThis & { Office?: OfficeStub }).Office = officeMock;


### PR DESCRIPTION
## Summary
- add Prettier configuration and extend ESLint with plugin:prettier plus stricter ignore rules for generated assets
- wire lint-staged into the pre-commit workflow and add npm scripts for formatting and staged linting
- document lint health and reformat the add-in sources/tests to the unified style while fixing the Vitest Office stub typing

## Testing
- npm --prefix word_addin_dev run lint
- npm --prefix word_addin_dev run lint:staged

------
https://chatgpt.com/codex/tasks/task_e_68d2f6be936c8325ba18deb17c4e6c3b