### PR TITLE
Implement agenda-based merge ordering with dedupe

### DIFF
--- a/contract_review_app/analysis/agenda.py
+++ b/contract_review_app/analysis/agenda.py
@@ -1,0 +1,299 @@
+"""Agenda helpers for deterministic merge ordering."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Sequence, Tuple
+
+__all__ = [
+    "AGENDA_ORDER",
+    "DEFAULT_SALIENCE",
+    "MAX_POSITION",
+    "agenda_sort_key",
+    "coerce_int",
+    "extract_span",
+    "infer_channel",
+    "map_to_agenda_group",
+    "resolve_salience",
+]
+
+AGENDA_ORDER: Dict[str, int] = {
+    "presence": 10,
+    "substantive": 20,
+    "policy": 30,
+    "law": 30,
+    "drafting": 40,
+    "grammar": 50,
+    "fixup": 60,
+}
+
+DEFAULT_SALIENCE: Dict[str, int] = {
+    "presence": 95,
+    "substantive": 80,
+    "policy": 70,
+    "law": 70,
+    "drafting": 40,
+    "grammar": 20,
+    "fixup": 10,
+}
+
+MAX_POSITION = 10 ** 12
+
+_CHANNEL_NORMALIZATION: Dict[str, str] = {
+    "presence": "presence",
+    "substantive": "substantive",
+    "substance": "substantive",
+    "policy": "policy",
+    "law": "law",
+    "legal": "law",
+    "drafting": "drafting",
+    "style": "drafting",
+    "grammar": "grammar",
+    "language": "grammar",
+    "fixup": "fixup",
+    "fix": "fixup",
+    "cleanup": "fixup",
+}
+
+_META_CHANNEL_KEYS: Sequence[str] = (
+    "channel",
+    "agenda_channel",
+)
+
+_META_SALIENCE_KEYS: Sequence[str] = (
+    "salience",
+    "rule_salience",
+)
+
+_SPEC_KEYS: Sequence[str] = (
+    "spec",
+    "rule_spec",
+    "rule",
+)
+
+
+def coerce_int(value: Any) -> int | None:
+    """Best-effort coercion used for offsets and salience."""
+
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if value is None:
+        return None
+    try:
+        return int(str(value))
+    except Exception:
+        return None
+
+
+def infer_channel(finding: Mapping[str, Any]) -> str:
+    """Infer a channel when the finding does not provide one explicitly."""
+
+    channel = finding.get("channel")
+    if isinstance(channel, str) and channel.strip():
+        return channel.strip()
+
+    source = finding.get("source")
+    if isinstance(source, str) and source.strip():
+        if source.strip().lower() == "constraints":
+            return "Law"
+
+    rule_id = finding.get("rule_id")
+    if isinstance(rule_id, str) and rule_id.upper().startswith("L2"):
+        return "Law"
+
+    return ""
+
+
+def _normalize_group(value: str | None) -> str:
+    if not isinstance(value, str):
+        return ""
+    lowered = value.strip().lower()
+    return _CHANNEL_NORMALIZATION.get(lowered, lowered)
+
+
+def _candidate_channels(finding: Mapping[str, Any]) -> Iterable[str]:
+    explicit = finding.get("agenda_group")
+    if isinstance(explicit, str) and explicit.strip():
+        yield explicit
+
+    channel = finding.get("channel")
+    if isinstance(channel, str) and channel.strip():
+        yield channel
+
+    meta = finding.get("meta")
+    if isinstance(meta, Mapping):
+        for key in _META_CHANNEL_KEYS:
+            candidate = meta.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                yield candidate
+
+    for spec_key in _SPEC_KEYS:
+        spec = finding.get(spec_key)
+        if isinstance(spec, Mapping):
+            candidate = spec.get("channel")
+            if isinstance(candidate, str) and candidate.strip():
+                yield candidate
+
+    inferred = infer_channel(finding)
+    if inferred:
+        yield inferred
+
+
+def map_to_agenda_group(finding: Mapping[str, Any]) -> str:
+    """Map a finding to an agenda group used for prioritisation."""
+
+    for candidate in _candidate_channels(finding):
+        group = _normalize_group(candidate)
+        if group:
+            return group
+
+    meta = finding.get("meta")
+    if isinstance(meta, Mapping):
+        presence_flag = meta.get("presence")
+        if isinstance(presence_flag, bool) and presence_flag:
+            return "presence"
+        if isinstance(presence_flag, (int, float)) and presence_flag:
+            return "presence"
+
+    rule_id = finding.get("rule_id")
+    if isinstance(rule_id, str) and rule_id.lower().startswith("presence_"):
+        return "presence"
+
+    return "substantive"
+
+
+def _candidate_salience_values(finding: Mapping[str, Any]) -> Iterable[Any]:
+    yield finding.get("salience")
+
+    meta = finding.get("meta")
+    if isinstance(meta, Mapping):
+        for key in _META_SALIENCE_KEYS:
+            value = meta.get(key)
+            if value is not None:
+                yield value
+
+    for spec_key in _SPEC_KEYS:
+        spec = finding.get(spec_key)
+        if isinstance(spec, Mapping):
+            value = spec.get("salience")
+            if value is not None:
+                yield value
+
+
+def resolve_salience(
+    finding: MutableMapping[str, Any],
+    *,
+    group: str | None = None,
+) -> int:
+    """Resolve the salience for ``finding`` clamped to [0, 100]."""
+
+    for value in _candidate_salience_values(finding):
+        coerced = coerce_int(value)
+        if coerced is None:
+            continue
+        if coerced < 0:
+            return 0
+        if coerced > 100:
+            return 100
+        return coerced
+
+    if group is None:
+        group = map_to_agenda_group(finding)
+
+    default = DEFAULT_SALIENCE.get(group, 50)
+    return int(default)
+
+
+def extract_span(finding: Mapping[str, Any]) -> Tuple[int, int] | None:
+    """Extract a representative span from a finding if present."""
+
+    start = coerce_int(finding.get("start"))
+    end = coerce_int(finding.get("end"))
+    if start is not None and end is not None:
+        return start, end
+
+    anchor = finding.get("anchor")
+    if isinstance(anchor, Mapping):
+        span = anchor.get("span")
+        if isinstance(span, Sequence) and len(span) == 2:
+            a_start = coerce_int(span[0])
+            a_end = coerce_int(span[1])
+            if a_start is not None and a_end is not None:
+                return a_start, a_end
+        a_start = coerce_int(anchor.get("start"))
+        a_end = coerce_int(anchor.get("end"))
+        if a_start is not None and a_end is not None:
+            return a_start, a_end
+        range_payload = anchor.get("range")
+        if isinstance(range_payload, Mapping):
+            a_start = coerce_int(range_payload.get("start"))
+            a_end = coerce_int(range_payload.get("end"))
+            if a_start is not None and a_end is not None:
+                return a_start, a_end
+
+    anchors = finding.get("anchors")
+    if isinstance(anchors, Sequence):
+        for candidate in anchors:
+            if not isinstance(candidate, Mapping):
+                continue
+            span = candidate.get("span")
+            if isinstance(span, Sequence) and len(span) == 2:
+                a_start = coerce_int(span[0])
+                a_end = coerce_int(span[1])
+                if a_start is not None and a_end is not None:
+                    return a_start, a_end
+            a_start = coerce_int(candidate.get("start"))
+            a_end = coerce_int(candidate.get("end"))
+            if a_start is not None and a_end is not None:
+                return a_start, a_end
+            range_payload = candidate.get("range")
+            if isinstance(range_payload, Mapping):
+                a_start = coerce_int(range_payload.get("start"))
+                a_end = coerce_int(range_payload.get("end"))
+                if a_start is not None and a_end is not None:
+                    return a_start, a_end
+
+    span = finding.get("span")
+    if isinstance(span, Mapping):
+        a_start = coerce_int(span.get("start"))
+        a_end = coerce_int(span.get("end"))
+        if a_start is not None and a_end is not None:
+            return a_start, a_end
+        range_payload = span.get("range")
+        if isinstance(range_payload, Mapping):
+            a_start = coerce_int(range_payload.get("start"))
+            a_end = coerce_int(range_payload.get("end"))
+            if a_start is not None and a_end is not None:
+                return a_start, a_end
+
+    return None
+
+
+def agenda_sort_key(
+    finding: MutableMapping[str, Any],
+    *,
+    group: str | None = None,
+    salience: int | None = None,
+    start: int | None = None,
+) -> Tuple[int, int, int, str]:
+    """Compute the agenda-based sort key for a finding."""
+
+    if group is None:
+        group = map_to_agenda_group(finding)
+    if salience is None:
+        salience = resolve_salience(finding, group=group)
+    if start is None:
+        span = extract_span(finding)
+        if span is not None:
+            start = span[0]
+    if start is None:
+        start = MAX_POSITION
+
+    agenda_rank = AGENDA_ORDER.get(group, max(AGENDA_ORDER.values()) + 1)
+    rule_id = finding.get("rule_id") or ""
+    return (
+        agenda_rank,
+        -int(salience),
+        int(start),
+        str(rule_id),
+    )

--- a/tests/integration/test_analyze_api_contract_stable.py
+++ b/tests/integration/test_analyze_api_contract_stable.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
+
+
+ALLOWED_FINDING_KEYS = {
+    "rule_id",
+    "channel",
+    "salience",
+    "message",
+    "anchor",
+    "meta",
+}
+
+
+def test_analyze_api_contract_stable():
+    findings = [
+        {
+            "rule_id": "presence-rule",
+            "channel": "presence",
+            "salience": 95,
+            "message": "Presence rule fired",
+            "anchor": {"start": 0, "end": 10},
+        },
+        {
+            "rule_id": "policy-rule",
+            "channel": "policy",
+            "salience": 65,
+            "message": "Policy guidance",
+            "anchor": {"start": 40, "end": 55},
+            "meta": {"entity_id": "policy"},
+        },
+    ]
+
+    merged = apply_merge_policy(findings)
+    assert len(merged) == 2
+    for finding in merged:
+        assert set(finding.keys()) <= ALLOWED_FINDING_KEYS
+        assert "agenda_group" not in finding

--- a/tests/integration/test_panel_order_visible.py
+++ b/tests/integration/test_panel_order_visible.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
+
+
+def test_panel_order_visible():
+    findings = [
+        {
+            "rule_id": "payment-timing",
+            "channel": "substantive",
+            "salience": 75,
+            "anchor": {"start": 120, "end": 180},
+            "meta": {"entity_id": "payment"},
+        },
+        {
+            "rule_id": "payment-timing",
+            "channel": "substantive",
+            "salience": 40,
+            "anchor": {"start": 125, "end": 185},
+            "meta": {"entity_id": "payment"},
+        },
+        {
+            "rule_id": "presence-terms",
+            "channel": "presence",
+            "anchor": {"start": 10, "end": 20},
+        },
+        {
+            "rule_id": "policy-sla",
+            "channel": "policy",
+            "salience": 60,
+            "anchor": {"start": 400, "end": 450},
+        },
+    ]
+
+    merged = apply_merge_policy(findings)
+    assert [f["rule_id"] for f in merged] == [
+        "presence-terms",
+        "payment-timing",
+        "policy-sla",
+    ]
+    assert all("agenda_group" not in f for f in merged)

--- a/tests/lx/test_merge_policy.py
+++ b/tests/lx/test_merge_policy.py
@@ -1,6 +1,6 @@
 import itertools
 
-from contract_review_app.legal_rules.aggregate import apply_merge_policy
+from contract_review_app.legal_rules.aggregate import apply_legacy_merge_policy
 
 
 def _finding(
@@ -25,7 +25,7 @@ def test_channel_priority_beats_other_attributes():
     law_finding = _finding("Law", severity="medium", rule_id="LAW")
     policy_finding = _finding("Policy", severity="critical", rule_id="POL")
 
-    merged = apply_merge_policy([policy_finding, law_finding])
+    merged = apply_legacy_merge_policy([policy_finding, law_finding])
 
     assert len(merged) == 1
     assert merged[0]["rule_id"] == "LAW"
@@ -35,7 +35,7 @@ def test_severity_breaks_ties_within_channel():
     low = _finding("Policy", severity="medium", rule_id="POL-LOW")
     high = _finding("Policy", severity="critical", rule_id="POL-HIGH")
 
-    merged = apply_merge_policy([low, high])
+    merged = apply_legacy_merge_policy([low, high])
 
     assert len(merged) == 1
     assert merged[0]["rule_id"] == "POL-HIGH"
@@ -45,7 +45,7 @@ def test_snippet_length_breaks_severity_ties():
     shorter = _finding("Policy", severity="medium", snippet="short", rule_id="S1")
     longer = _finding("Policy", severity="medium", snippet="longer text", rule_id="L1")
 
-    merged = apply_merge_policy([shorter, longer])
+    merged = apply_legacy_merge_policy([shorter, longer])
 
     assert len(merged) == 1
     assert merged[0]["rule_id"] == "L1"
@@ -55,7 +55,7 @@ def test_rule_id_breaks_all_other_ties():
     first = _finding("Policy", severity="medium", rule_id="A")
     second = _finding("Policy", severity="medium", rule_id="B")
 
-    merged = apply_merge_policy([second, first])
+    merged = apply_legacy_merge_policy([second, first])
 
     assert len(merged) == 1
     assert merged[0]["rule_id"] == "A"
@@ -66,7 +66,7 @@ def test_overlapping_spans_preserve_best_per_span():
     weaker = _finding("Policy", severity="medium", start=0, end=10, rule_id="POL")
     other = _finding("Substantive", severity="medium", start=5, end=15, rule_id="SUB")
 
-    merged = apply_merge_policy([weaker, other, dominant])
+    merged = apply_legacy_merge_policy([weaker, other, dominant])
 
     assert [f["rule_id"] for f in merged] == ["LAW", "SUB"]
 
@@ -78,6 +78,6 @@ def test_merge_policy_is_deterministic():
         _finding("Grammar", severity="low", start=20, end=30, rule_id="G1"),
     ]
 
-    expected = apply_merge_policy(base)
+    expected = apply_legacy_merge_policy(base)
     for perm in itertools.permutations(base):
-        assert apply_merge_policy(list(perm)) == expected
+        assert apply_legacy_merge_policy(list(perm)) == expected

--- a/tests/merge/test_agenda_sort_key.py
+++ b/tests/merge/test_agenda_sort_key.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import copy
+
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
+
+
+def _finding(**kwargs):
+    base = {
+        "rule_id": kwargs.get("rule_id", "rule"),
+        "anchor": {"start": kwargs.get("start", 0), "end": kwargs.get("end", 1)},
+    }
+    base.update(kwargs)
+    base.setdefault("anchor", {"start": kwargs.get("start", 0), "end": kwargs.get("end", 1)})
+    return base
+
+
+def test_order_by_group_then_salience_then_start_then_rule():
+    findings = [
+        _finding(
+            rule_id="policy-1",
+            channel="policy",
+            salience=70,
+            start=300,
+            end=320,
+        ),
+        _finding(
+            rule_id="presence-02",
+            channel="presence",
+            salience=95,
+            start=200,
+            end=210,
+        ),
+        _finding(
+            rule_id="presence-01",
+            channel="presence",
+            salience=95,
+            start=100,
+            end=110,
+        ),
+        _finding(
+            rule_id="presence-00",
+            channel="presence",
+            salience=95,
+            start=100,
+            end=110,
+        ),
+        _finding(
+            rule_id="presence-low",
+            channel="presence",
+            salience=90,
+            start=400,
+            end=420,
+        ),
+        _finding(
+            rule_id="substantive-1",
+            channel="substantive",
+            salience=80,
+            start=10,
+            end=30,
+        ),
+    ]
+
+    ordered = apply_merge_policy(copy.deepcopy(findings))
+    assert [f["rule_id"] for f in ordered] == [
+        "presence-00",
+        "presence-01",
+        "presence-02",
+        "presence-low",
+        "substantive-1",
+        "policy-1",
+    ]
+
+
+def test_salience_defaults_by_group():
+    cases = {
+        "presence-default": ("presence", None, 95),
+        "substantive-default": ("substantive", None, 80),
+        "policy-default": ("policy", None, 70),
+        "law-default": ("law", None, 70),
+        "drafting-default": ("drafting", None, 40),
+        "grammar-default": ("grammar", None, 20),
+        "fixup-default": ("fixup", None, 10),
+        "policy-high-clamp": ("policy", 150, 100),
+        "grammar-low-clamp": ("grammar", -5, 0),
+    }
+
+    findings = [
+        {
+            "rule_id": rule_id,
+            "channel": channel,
+            "salience": salience,
+            "anchor": {"start": idx * 50, "end": idx * 50 + 10},
+        }
+        for idx, (rule_id, (channel, salience, _)) in enumerate(cases.items())
+    ]
+
+    merged = apply_merge_policy(copy.deepcopy(findings))
+    by_rule = {f["rule_id"]: f["salience"] for f in merged}
+
+    for rule_id, (_, __, expected) in cases.items():
+        assert by_rule[rule_id] == expected

--- a/tests/merge/test_overlap_merge.py
+++ b/tests/merge/test_overlap_merge.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
+
+
+def _finding(rule_id: str, channel: str, salience: int, start: int, end: int, *, meta=None):
+    payload = {
+        "rule_id": rule_id,
+        "channel": channel,
+        "salience": salience,
+        "anchor": {"start": start, "end": end},
+    }
+    if meta:
+        payload["meta"] = meta
+    return payload
+
+
+def test_overlap_keeps_strongest_same_group():
+    dominant = _finding("duplicate-rule", "substantive", 90, 0, 100, meta={"entity_id": "payment"})
+    weaker = _finding("duplicate-rule", "substantive", 50, 10, 110, meta={"entity_id": "payment"})
+
+    merged = apply_merge_policy([weaker, dominant])
+    assert [f["rule_id"] for f in merged] == ["duplicate-rule"]
+    assert merged[0]["salience"] == 90
+
+
+def test_overlap_different_groups_not_removed_in_strict_off():
+    presence = _finding("presence-check", "presence", 95, 0, 50)
+    substantive = _finding("sub-check", "substantive", 80, 10, 60)
+
+    merged = apply_merge_policy([substantive, presence])
+    assert {f["rule_id"] for f in merged} == {"presence-check", "sub-check"}
+
+
+def test_overlap_removed_when_strict_merge_on():
+    presence = _finding("presence-check", "presence", 95, 0, 50)
+    substantive = _finding("sub-check", "substantive", 80, 10, 60)
+
+    merged = apply_merge_policy([substantive, presence], strict_merge=True)
+    assert [f["rule_id"] for f in merged] == ["presence-check"]

--- a/tests/merge/test_stability_property.py
+++ b/tests/merge/test_stability_property.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import copy
+import itertools
+
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
+
+
+BASE_FINDINGS = [
+    {
+        "rule_id": "presence-1",
+        "channel": "presence",
+        "salience": 95,
+        "anchor": {"start": 10, "end": 20},
+    },
+    {
+        "rule_id": "substantive-1",
+        "channel": "substantive",
+        "salience": 80,
+        "anchor": {"start": 200, "end": 220},
+    },
+    {
+        "rule_id": "policy-1",
+        "channel": "policy",
+        "salience": 70,
+        "anchor": {"start": 400, "end": 410},
+    },
+    {
+        "rule_id": "presence-2",
+        "channel": "presence",
+        "salience": 90,
+        "anchor": {"start": 50, "end": 60},
+    },
+]
+
+
+def test_permutation_stability():
+    expected = apply_merge_policy(copy.deepcopy(BASE_FINDINGS))
+    expected_order = [f["rule_id"] for f in expected]
+
+    for perm in itertools.permutations(BASE_FINDINGS):
+        result = apply_merge_policy(copy.deepcopy(list(perm)))
+        assert [f["rule_id"] for f in result] == expected_order

--- a/tests/perf/test_merge_perf.py
+++ b/tests/perf/test_merge_perf.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import time
+
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
+
+
+def test_merge_perf_5k_findings():
+    findings = [
+        {
+            "rule_id": f"rule-{idx}",
+            "channel": "substantive" if idx % 3 else "policy",
+            "salience": (idx % 100),
+            "anchor": {"start": idx * 5, "end": idx * 5 + 3},
+        }
+        for idx in range(5000)
+    ]
+
+    start = time.perf_counter()
+    merged = apply_merge_policy(findings)
+    duration = time.perf_counter() - start
+
+    assert len(merged) == len(findings)
+    assert duration < 8.0


### PR DESCRIPTION
## Summary
- add agenda helpers to normalize agenda groups and salience defaults for findings
- replace the merge policy with agenda-aware sorting, overlap collapse, and a legacy fallback
- add feature flags for agenda sorting and tests covering ordering, overlap behaviour, and perf expectations

## Testing
- pytest tests/merge tests/integration/test_panel_order_visible.py tests/integration/test_analyze_api_contract_stable.py tests/lx/test_merge_policy.py tests/perf/test_merge_perf.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f63e5d4883259a15be4351f53d61