### PR TITLE
Treat zero-length spans as overlapping for dedupe

### DIFF
--- a/contract_review_app/legal_rules/aggregate.py
+++ b/contract_review_app/legal_rules/aggregate.py
@@ -98,6 +98,10 @@ def _spans_overlap(lhs: Tuple[int, int], rhs: Tuple[int, int]) -> bool:
     start_b, end_b = rhs
     if end_a is None or end_b is None:
         return False
+    if start_a is None or start_b is None:
+        return False
+    if end_a == start_a and end_b == start_b:
+        return start_a == start_b
     if end_a <= start_a or end_b <= start_b:
         return False
 


### PR DESCRIPTION
## Summary
- consider zero-length spans equivalent when comparing overlap
- guard against spans missing start offsets before running IoU logic

## Testing
- `ruff check contract_review_app/legal_rules/aggregate.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2ff7716bc83258e8a5a9f6a8348f1