### PR TITLE
fix: limit reports whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,8 @@ _shared_catalog/manifest.xml
 # ==== Артефакты тестов/отчётов ====
 junit.xml
 test-results/
-reports/
-!/reports/
+reports/*
+!reports/
 !/reports/garbage_report.md
 !/reports/garbage_report.json
 


### PR DESCRIPTION
## Summary
- keep the reports directory ignored while still allowing the garbage sweep artifacts

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68d3036f7600832596241504f3de6240