### PR TITLE
Add agenda order safeguards and tests

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -957,6 +957,7 @@ export function renderResults(res: any) {
   const findingsList = slot("findingsList", "findings") as HTMLElement | null;
   if (findingsList) {
     findingsList.innerHTML = "";
+    // DO NOT SORT: backend order (agenda).
     findingsArr.forEach((f: any) => {
       const li = document.createElement("li");
       li.textContent = typeof f === "string" ? f : JSON.stringify(f);

--- a/contract_review_app/frontend/draft_panel/__tests__/test_load_more_keeps_order.spec.tsx
+++ b/contract_review_app/frontend/draft_panel/__tests__/test_load_more_keeps_order.spec.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+vi.mock('../../common/http', () => ({
+  postJSON: vi.fn(async () => ({ draft_text: '' })),
+  getHealth: vi.fn(async () => ({})),
+  ensureHeadersSet: vi.fn(),
+}));
+
+import { DraftAssistantPanel } from '../index';
+
+interface RenderHandle {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+function getFindingsSection(container: HTMLElement): HTMLElement {
+  const heading = Array.from(container.querySelectorAll('h3')).find(
+    (el) => el.textContent?.trim() === 'Findings',
+  );
+  if (!heading || !heading.parentElement) {
+    throw new Error('Findings section not found');
+  }
+  return heading.parentElement;
+}
+
+function getFindingCards(section: HTMLElement): HTMLElement[] {
+  const heading = section.querySelector('h3');
+  return Array.from(section.children).filter((node): node is HTMLElement => {
+    if (!(node instanceof HTMLElement)) return false;
+    if (heading && node === heading) return false;
+    if (node.tagName !== 'DIV') return false;
+    return true;
+  });
+}
+
+async function renderPanel(analysis: any): Promise<RenderHandle> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<DraftAssistantPanel initialAnalysis={analysis} initialAnalysisMeta={{}} />);
+  });
+  return { container, root };
+}
+
+describe('DraftAssistantPanel load more preserves order', () => {
+  let handles: RenderHandle[] = [];
+
+  beforeEach(() => {
+    handles = [];
+    (globalThis as any).localStorage = { getItem: () => '', setItem: () => {} };
+    (globalThis as any).sessionStorage = { getItem: () => null, setItem: () => {} };
+    (globalThis as any).navigator = { clipboard: { writeText: async () => {} } };
+    (globalThis as any).Office = {
+      context: {
+        document: {
+          setSelectedDataAsync: (_text: string, _opts: any, cb: any) => cb({ status: 'succeeded' }),
+        },
+      },
+      CoercionType: { Text: 'text' },
+      AsyncResultStatus: { Succeeded: 'succeeded' },
+    };
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      handles.splice(0).map(async ({ root, container }) => {
+        await act(async () => {
+          root.unmount();
+        });
+        container.remove();
+      }),
+    );
+  });
+
+  it('shows all findings in backend order after loading more', async () => {
+    const findings = Array.from({ length: 150 }, (_v, idx) => ({
+      rule_id: `R${idx + 1}`,
+      code: `R${idx + 1}`,
+      message: `Finding ${idx + 1}`,
+    }));
+    const analysis = { findings };
+
+    const handle = await renderPanel(analysis);
+    handles.push(handle);
+
+    const section = getFindingsSection(handle.container);
+    let cards = getFindingCards(section);
+    expect(cards).toHaveLength(100);
+    let codes = cards.map((card) => card.querySelector('b')?.textContent);
+    expect(codes).toEqual(findings.slice(0, 100).map((f) => f.code));
+
+    const loadMoreButton = Array.from(section.querySelectorAll('button')).find(
+      (btn) => btn.textContent === 'Load more',
+    );
+    expect(loadMoreButton).toBeTruthy();
+
+    await act(async () => {
+      loadMoreButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {});
+
+    cards = getFindingCards(section);
+    expect(cards).toHaveLength(150);
+    codes = cards.map((card) => card.querySelector('b')?.textContent);
+    expect(codes).toEqual(findings.map((f) => f.code));
+  });
+});

--- a/contract_review_app/frontend/draft_panel/__tests__/test_no_client_dedupe_on_main_list.spec.tsx
+++ b/contract_review_app/frontend/draft_panel/__tests__/test_no_client_dedupe_on_main_list.spec.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+vi.mock('../../common/http', () => ({
+  postJSON: vi.fn(async () => ({ draft_text: '' })),
+  getHealth: vi.fn(async () => ({})),
+  ensureHeadersSet: vi.fn(),
+}));
+
+import { DraftAssistantPanel } from '../index';
+
+interface RenderHandle {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+function getFindingsSection(container: HTMLElement): HTMLElement {
+  const heading = Array.from(container.querySelectorAll('h3')).find(
+    (el) => el.textContent?.trim() === 'Findings',
+  );
+  if (!heading || !heading.parentElement) {
+    throw new Error('Findings section not found');
+  }
+  return heading.parentElement;
+}
+
+function getFindingCards(section: HTMLElement): HTMLElement[] {
+  const heading = section.querySelector('h3');
+  return Array.from(section.children).filter((node): node is HTMLElement => {
+    if (!(node instanceof HTMLElement)) return false;
+    if (heading && node === heading) return false;
+    if (node.tagName !== 'DIV') return false;
+    return true;
+  });
+}
+
+async function renderPanel(analysis: any): Promise<RenderHandle> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<DraftAssistantPanel initialAnalysis={analysis} initialAnalysisMeta={{}} />);
+  });
+  return { container, root };
+}
+
+describe('DraftAssistantPanel main list dedupe guard', () => {
+  let handles: RenderHandle[] = [];
+
+  beforeEach(() => {
+    handles = [];
+    (globalThis as any).localStorage = { getItem: () => '', setItem: () => {} };
+    (globalThis as any).sessionStorage = { getItem: () => null, setItem: () => {} };
+    (globalThis as any).navigator = { clipboard: { writeText: async () => {} } };
+    (globalThis as any).Office = {
+      context: {
+        document: {
+          setSelectedDataAsync: (_text: string, _opts: any, cb: any) => cb({ status: 'succeeded' }),
+        },
+      },
+      CoercionType: { Text: 'text' },
+      AsyncResultStatus: { Succeeded: 'succeeded' },
+    };
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      handles.splice(0).map(async ({ root, container }) => {
+        await act(async () => {
+          root.unmount();
+        });
+        container.remove();
+      }),
+    );
+  });
+
+  it('renders duplicate findings when backend sends them', async () => {
+    const analysis = {
+      findings: [
+        {
+          rule_id: 'R1',
+          code: 'R1',
+          message: 'First occurrence',
+          severity: 'medium',
+          anchor: { start: 5, end: 10 },
+        },
+        {
+          rule_id: 'R1',
+          code: 'R1',
+          message: 'Second occurrence',
+          severity: 'high',
+          anchor: { start: 5, end: 10 },
+        },
+      ],
+    };
+
+    const handle = await renderPanel(analysis);
+    handles.push(handle);
+
+    const section = getFindingsSection(handle.container);
+    const cards = getFindingCards(section);
+    expect(cards).toHaveLength(2);
+    const messages = cards.map((card) => card.querySelectorAll('div')[1]?.textContent?.trim());
+    expect(messages).toEqual(['First occurrence', 'Second occurrence']);
+  });
+});

--- a/contract_review_app/frontend/draft_panel/__tests__/test_respects_backend_order.spec.tsx
+++ b/contract_review_app/frontend/draft_panel/__tests__/test_respects_backend_order.spec.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+vi.mock('../../common/http', () => ({
+  postJSON: vi.fn(async () => ({ draft_text: '' })),
+  getHealth: vi.fn(async () => ({})),
+  ensureHeadersSet: vi.fn(),
+}));
+
+import { DraftAssistantPanel } from '../index';
+
+interface RenderHandle {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+function getFindingsSection(container: HTMLElement): HTMLElement {
+  const heading = Array.from(container.querySelectorAll('h3')).find(
+    (el) => el.textContent?.trim() === 'Findings',
+  );
+  if (!heading || !heading.parentElement) {
+    throw new Error('Findings section not found');
+  }
+  return heading.parentElement;
+}
+
+function getFindingCards(section: HTMLElement): HTMLElement[] {
+  const heading = section.querySelector('h3');
+  return Array.from(section.children).filter((node): node is HTMLElement => {
+    if (!(node instanceof HTMLElement)) return false;
+    if (heading && node === heading) return false;
+    if (node.tagName !== 'DIV') return false;
+    return true;
+  });
+}
+
+async function renderPanel(analysis: any): Promise<RenderHandle> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<DraftAssistantPanel initialAnalysis={analysis} initialAnalysisMeta={{}} />);
+  });
+  return { container, root };
+}
+
+describe('DraftAssistantPanel respects backend order', () => {
+  let handles: RenderHandle[] = [];
+
+  beforeEach(() => {
+    handles = [];
+    (globalThis as any).localStorage = { getItem: () => '', setItem: () => {} };
+    (globalThis as any).sessionStorage = { getItem: () => null, setItem: () => {} };
+    (globalThis as any).navigator = { clipboard: { writeText: async () => {} } };
+    (globalThis as any).Office = {
+      context: {
+        document: {
+          setSelectedDataAsync: (_text: string, _opts: any, cb: any) => cb({ status: 'succeeded' }),
+        },
+      },
+      CoercionType: { Text: 'text' },
+      AsyncResultStatus: { Succeeded: 'succeeded' },
+    };
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      handles.splice(0).map(async ({ root, container }) => {
+        await act(async () => {
+          root.unmount();
+        });
+        container.remove();
+      }),
+    );
+  });
+
+  it('renders findings exactly in backend order', async () => {
+    const analysis = {
+      findings: [
+        { rule_id: 'R3', code: 'R3', message: 'Third', severity: 'high' },
+        { rule_id: 'R1', code: 'R1', message: 'First', severity: 'medium' },
+        { rule_id: 'R2', code: 'R2', message: 'Second', severity: 'medium' },
+      ],
+    };
+
+    const handle = await renderPanel(analysis);
+    handles.push(handle);
+
+    const section = getFindingsSection(handle.container);
+    const cards = getFindingCards(section);
+    const codes = cards.map((card) => card.querySelector('b')?.textContent);
+    expect(codes).toEqual(['R3', 'R1', 'R2']);
+  });
+});

--- a/contract_review_app/frontend/draft_panel/index.tsx
+++ b/contract_review_app/frontend/draft_panel/index.tsx
@@ -289,6 +289,7 @@ const DraftAssistantPanel: React.FC<PanelProps> = ({ initialAnalysis = null, ini
               <div>No findings (rules_evaluated: {meta.rules_evaluated}, triggered: {meta.rules_triggered})</div>
             )}
             {Array.isArray(findings) &&
+              // DO NOT SORT: backend order (agenda).
               findings.slice(0, findingsLimit).map((f: any, i: number) => (
                 <div key={f?.rule_id || i} style={{ background: '#f8f9fa', padding: 8, borderRadius: 4, marginBottom: 6 }}>
                   <div><b>{f?.code || 'FINDING'}</b> {f?.severity ? `(${f.severity})` : ''}</div>

--- a/contract_review_app/frontend/vitest.config.ts
+++ b/contract_review_app/frontend/vitest.config.ts
@@ -1,7 +1,7 @@
 export default {
   test: {
     environment: 'jsdom',
-    include: ['draft_panel/__tests__/**/*.test.ts?(x)'],
+    include: ['draft_panel/__tests__/**/*.{test,spec}.ts?(x)'],
     globals: true,
   },
 };

--- a/tests/integration/test_backend_order_is_deterministic.py
+++ b/tests/integration/test_backend_order_is_deterministic.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import copy
+
+from contract_review_app.analysis.agenda import agenda_sort_key
+from contract_review_app.legal_rules.aggregate import apply_merge_policy
+
+
+def _fingerprint(findings: list[dict]) -> list[tuple[str | None, int | None, int | None]]:
+    result: list[tuple[str | None, int | None, int | None]] = []
+    for finding in findings:
+        anchor = finding.get("anchor") or {}
+        start = anchor.get("start") if isinstance(anchor, dict) else None
+        end = anchor.get("end") if isinstance(anchor, dict) else None
+        result.append((finding.get("rule_id"), start if isinstance(start, int) else None, end if isinstance(end, int) else None))
+    return result
+
+
+def test_backend_order_is_deterministic() -> None:
+    findings = [
+        {
+            "rule_id": "presence-primary",
+            "channel": "presence",
+            "salience": 95,
+            "anchor": {"start": 0, "end": 12},
+        },
+        {
+            "rule_id": "substantive-gap",
+            "channel": "substantive",
+            "salience": 80,
+            "anchor": {"start": 40, "end": 60},
+        },
+        {
+            "rule_id": "policy-warning",
+            "channel": "policy",
+            "salience": 75,
+            "anchor": {"start": 80, "end": 100},
+        },
+        {
+            "rule_id": "policy-low",
+            "channel": "policy",
+            "salience": 65,
+            "anchor": {"start": 120, "end": 140},
+        },
+        {
+            "rule_id": "drafting-typo",
+            "channel": "drafting",
+            "salience": 30,
+            "anchor": {"start": 160, "end": 170},
+        },
+    ]
+
+    shuffled = [findings[3], findings[1], findings[4], findings[0], findings[2]]
+
+    ordered = apply_merge_policy(copy.deepcopy(findings), use_agenda=True)
+    reordered = apply_merge_policy(copy.deepcopy(shuffled), use_agenda=True)
+
+    assert _fingerprint(ordered) == _fingerprint(reordered)
+    assert _fingerprint(ordered) == _fingerprint(sorted(copy.deepcopy(ordered), key=agenda_sort_key))

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -957,6 +957,7 @@ export function renderResults(res: any) {
   const findingsList = slot("findingsList", "findings") as HTMLElement | null;
   if (findingsList) {
     findingsList.innerHTML = "";
+    // DO NOT SORT: backend order (agenda).
     findingsArr.forEach((f: any) => {
       const li = document.createElement("li");
       li.textContent = typeof f === "string" ? f : JSON.stringify(f);


### PR DESCRIPTION
## Summary
- add explicit "DO NOT SORT" guard comments where the panel renders backend findings so the agenda order is preserved
- add React panel tests that cover backend ordering, duplicate retention, and load-more pagination, and update Vitest config so the new specs run
- add an integration test that checks `apply_merge_policy(..., use_agenda=True)` produces a deterministic order regardless of input ordering

## Testing
- `NODE_PATH=contract_review_app/frontend/node_modules:word_addin_dev/node_modules word_addin_dev/node_modules/.bin/vitest run --config vitest.config.ts --root contract_review_app/frontend`
- `pytest` *(fails: current /api/gpt-draft implementation normalizes empty text instead of rejecting it, so test_gpt_draft_validation_errors expects a 422 but receives 200)*

------
https://chatgpt.com/codex/tasks/task_e_68d394e44e208325b1ad8a6c1a5d2e71