### PR TITLE
Ensure QA/Word dedupe policy and add coverage

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -957,7 +957,7 @@ export function renderResults(res: any) {
   const findingsList = slot("findingsList", "findings") as HTMLElement | null;
   if (findingsList) {
     findingsList.innerHTML = "";
-    // DO NOT SORT: backend order (agenda).
+    // DO NOT DEDUPE/SORT: backend agenda order
     findingsArr.forEach((f: any) => {
       const li = document.createElement("li");
       li.textContent = typeof f === "string" ? f : JSON.stringify(f);
@@ -996,6 +996,8 @@ function mergeQaResults(json: any) {
   const merged = dedupeFindings([...existing, ...incoming]);
   return { ...(json || {}), findings: merged };
 }
+
+export const mergeQaResultsForTests = mergeQaResults;
 
 function wireResultsToggle() {
   const toggle = slot("toggleRaw", "toggle-raw-json");

--- a/word_addin_dev/app/__tests__/test_main_no_dedupe.spec.ts
+++ b/word_addin_dev/app/__tests__/test_main_no_dedupe.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+describe('main findings list preserves backend ordering', () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalHTMLElement = (globalThis as any).HTMLElement;
+  const originalNode = (globalThis as any).Node;
+  const originalLocalStorage = (globalThis as any).localStorage;
+  const originalLocation = (globalThis as any).location;
+  const originalTestingFlag = (globalThis as any).__CAI_TESTING__;
+  let dom: JSDOM | null = null;
+
+  beforeEach(() => {
+    vi.resetModules();
+    const html = `
+      <section id="resultsBlock">
+        <div class="muted">Results</div>
+      </section>
+      <div id="findingsBlock" style="display: none"></div>
+      <ol id="findingsList" data-role="findings"></ol>
+      <div id="recommendationsBlock" style="display: none"></div>
+      <ol id="recommendationsList" data-role="recommendations"></ol>
+      <span id="resClauseType" data-role="clause-type"></span>
+      <span id="resFindingsCount" data-role="findings-count"></span>
+      <pre id="rawJson" data-role="raw-json"></pre>
+    `;
+    dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { url: 'https://panel.test' });
+    globalThis.window = dom.window as any;
+    globalThis.document = dom.window.document as any;
+    (globalThis as any).HTMLElement = dom.window.HTMLElement;
+    (globalThis as any).Node = dom.window.Node;
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+    };
+    (globalThis as any).location = dom.window.location;
+  });
+
+  afterEach(() => {
+    if (dom) {
+      dom.window.close();
+    }
+    dom = null;
+    if (originalWindow === undefined) {
+      delete (globalThis as any).window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+    if (originalDocument === undefined) {
+      delete (globalThis as any).document;
+    } else {
+      globalThis.document = originalDocument;
+    }
+    if (originalHTMLElement === undefined) {
+      delete (globalThis as any).HTMLElement;
+    } else {
+      (globalThis as any).HTMLElement = originalHTMLElement;
+    }
+    if (originalNode === undefined) {
+      delete (globalThis as any).Node;
+    } else {
+      (globalThis as any).Node = originalNode;
+    }
+    if (originalLocalStorage === undefined) {
+      delete (globalThis as any).localStorage;
+    } else {
+      (globalThis as any).localStorage = originalLocalStorage;
+    }
+    if (originalLocation === undefined) {
+      delete (globalThis as any).location;
+    } else {
+      (globalThis as any).location = originalLocation;
+    }
+    if (originalTestingFlag === undefined) {
+      delete (globalThis as any).__CAI_TESTING__;
+    } else {
+      (globalThis as any).__CAI_TESTING__ = originalTestingFlag;
+    }
+    delete (globalThis as any).__findings;
+  });
+
+  it('renders duplicates without reordering', async () => {
+    const mod = await import('../assets/taskpane');
+    const findings = [
+      { rule_id: 'R3', snippet: 'Clause three', start: 30, end: 40, severity: 'critical' },
+      { rule_id: 'R1', snippet: 'Clause one', start: 0, end: 10, severity: 'high' },
+      { rule_id: 'R1', snippet: 'Clause one', start: 0, end: 10, severity: 'medium' },
+      { rule_id: 'R2', snippet: 'Clause two', start: 20, end: 28, severity: 'medium' },
+    ];
+
+    mod.renderResults({
+      analysis: { findings },
+      clause_type: 'Test',
+    });
+
+    const items = Array.from(document.querySelectorAll('#findingsList li'));
+    expect(items).toHaveLength(4);
+    const order = items.map(li => {
+      const txt = li.textContent || '{}';
+      try {
+        const parsed = JSON.parse(txt);
+        return parsed.rule_id;
+      } catch {
+        return txt;
+      }
+    });
+    expect(order).toEqual(['R3', 'R1', 'R1', 'R2']);
+  });
+});

--- a/word_addin_dev/app/__tests__/test_plan_annotations_dedup.spec.ts
+++ b/word_addin_dev/app/__tests__/test_plan_annotations_dedup.spec.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { planAnnotations } from '../assets/annotate';
+
+describe('planAnnotations dedupe and overlap handling', () => {
+  beforeEach(() => {
+    (globalThis as any).__lastAnalyzed = 'alpha beta gamma delta epsilon zeta';
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).__lastAnalyzed;
+  });
+
+  it('deduplicates identical findings and skips overlapping ranges', () => {
+    const findings = [
+      { rule_id: 'A', snippet: 'alpha', start: 0, end: 5, severity: 'high', advice: 'alpha-high' },
+      { rule_id: 'A', snippet: 'alpha', start: 0, end: 5, severity: 'medium', advice: 'alpha-medium' },
+      { rule_id: 'B', snippet: 'beta', start: 6, end: 10, severity: 'medium', advice: 'beta-advice' },
+      { rule_id: 'C', snippet: 'beta gamma', start: 8, end: 18, severity: 'critical', advice: 'overlap-advice' },
+      { rule_id: 'D', snippet: 'delta', start: 20, end: 25, severity: 'low', advice: 'delta-low' },
+      { rule_id: 'D', snippet: 'delta', start: 20, end: 25, severity: 'critical', advice: 'delta-critical' },
+    ];
+
+    const plan = planAnnotations(findings as any);
+    expect(plan).toHaveLength(3);
+    const order = plan.map(op => op.rule_id);
+    expect(order).toEqual(['A', 'B', 'D']);
+
+    const alpha = plan.find(op => op.rule_id === 'A');
+    expect(alpha?.msg).toContain('alpha-high');
+    const delta = plan.find(op => op.rule_id === 'D');
+    expect(delta?.msg).toContain('delta-critical');
+    const hasOverlap = plan.some(op => op.rule_id === 'C');
+    expect(hasOverlap).toBe(false);
+  });
+});

--- a/word_addin_dev/app/__tests__/test_qa_merge_dedup.spec.ts
+++ b/word_addin_dev/app/__tests__/test_qa_merge_dedup.spec.ts
@@ -1,0 +1,92 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+describe('QA merge deduplication', () => {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalHTMLElement = (globalThis as any).HTMLElement;
+  const originalNode = (globalThis as any).Node;
+  const originalLocalStorage = (globalThis as any).localStorage;
+  const originalLocation = (globalThis as any).location;
+  const originalTestingFlag = (globalThis as any).__CAI_TESTING__;
+  let dom: JSDOM | null = null;
+
+  beforeEach(() => {
+    vi.resetModules();
+    const html = `
+      <section id="resultsBlock">
+        <div class="muted">Results</div>
+      </section>
+    `;
+    dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { url: 'https://panel.test' });
+    (globalThis as any).window = dom.window as any;
+    (globalThis as any).document = dom.window.document as any;
+    (globalThis as any).HTMLElement = dom.window.HTMLElement;
+    (globalThis as any).Node = dom.window.Node;
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+    };
+    (globalThis as any).location = dom.window.location;
+  });
+
+  afterEach(() => {
+    if (dom) {
+      dom.window.close();
+    }
+    dom = null;
+    if (originalWindow === undefined) delete (globalThis as any).window;
+    else globalThis.window = originalWindow;
+    if (originalDocument === undefined) delete (globalThis as any).document;
+    else globalThis.document = originalDocument;
+    if (originalHTMLElement === undefined) delete (globalThis as any).HTMLElement;
+    else (globalThis as any).HTMLElement = originalHTMLElement;
+    if (originalNode === undefined) delete (globalThis as any).Node;
+    else (globalThis as any).Node = originalNode;
+    if (originalLocalStorage === undefined) delete (globalThis as any).localStorage;
+    else (globalThis as any).localStorage = originalLocalStorage;
+    if (originalLocation === undefined) delete (globalThis as any).location;
+    else (globalThis as any).location = originalLocation;
+    if (originalTestingFlag === undefined) delete (globalThis as any).__CAI_TESTING__;
+    else (globalThis as any).__CAI_TESTING__ = originalTestingFlag;
+    delete (globalThis as any).__findings;
+  });
+
+  it('removes duplicates and keeps highest severity entries', async () => {
+    const mod = await import('../assets/taskpane');
+    const base = [
+      { rule_id: 'R1', snippet: 'First clause', start: 0, end: 12, severity: 'high' },
+      { rule_id: 'R2', snippet: 'Second clause', start: 20, end: 35, severity: 'medium' },
+      { rule_id: 'R3', snippet: 'Third clause', start: 40, end: 55, severity: 'medium' },
+      { rule_id: 'R4', snippet: 'Fourth clause', start: 60, end: 75, severity: 'low' },
+      { rule_id: 'R5', snippet: 'Fifth clause', start: 80, end: 96, severity: 'high' },
+    ];
+    (globalThis as any).__findings = base;
+    if (dom) {
+      (dom.window as any).__findings = base;
+    }
+
+    const qa = [
+      { rule_id: 'R2', snippet: 'Second clause', start: 20, end: 35, severity: 'critical' },
+      { rule_id: 'R6', snippet: 'Sixth clause', start: 100, end: 118, severity: 'medium' },
+      { rule_id: 'R3', snippet: 'Third clause', start: 40, end: 55, severity: 'high' },
+      { rule_id: 'R2', snippet: 'Second clause', start: 20, end: 35, severity: 'low' },
+    ];
+
+    const merged = mod.mergeQaResultsForTests({ findings: qa });
+    expect(Array.isArray(merged.findings)).toBe(true);
+    expect(merged.findings).toHaveLength(6);
+
+    const r2Entries = merged.findings.filter((f: any) => f.rule_id === 'R2');
+    expect(r2Entries).toHaveLength(1);
+    expect(r2Entries[0].severity).toBe('critical');
+
+    const r3Entries = merged.findings.filter((f: any) => f.rule_id === 'R3');
+    expect(r3Entries).toHaveLength(1);
+    expect(r3Entries[0].severity).toBe('high');
+
+    const codes = merged.findings.map((f: any) => f.rule_id);
+    expect(codes).toContain('R6');
+  });
+});

--- a/word_addin_dev/app/__tests__/test_static_no_dedupe_in_renderResults.spec.ts
+++ b/word_addin_dev/app/__tests__/test_static_no_dedupe_in_renderResults.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+describe('renderResults static guard', () => {
+  it('does not dedupe or sort findings', () => {
+    const filePath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '../assets/taskpane.ts'
+    );
+    const text = readFileSync(filePath, 'utf-8');
+    const start = text.indexOf('export function renderResults');
+    expect(start).toBeGreaterThan(-1);
+    const end = text.indexOf('function mergeQaResults', start);
+    expect(end).toBeGreaterThan(start);
+    const body = text.slice(start, end);
+    expect(body.includes('dedupeFindings(')).toBe(false);
+    expect(body.includes('.sort(')).toBe(false);
+  });
+});

--- a/word_addin_dev/app/__tests__/test_word_anchor_priority_and_overlap.spec.ts
+++ b/word_addin_dev/app/__tests__/test_word_anchor_priority_and_overlap.spec.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const anchorByOffsetsMock = vi.fn();
+const findAnchorsMock = vi.fn();
+
+vi.mock('../assets/anchors', async () => {
+  const actual = await vi.importActual<typeof import('../assets/anchors')>('../assets/anchors');
+  return {
+    ...actual,
+    anchorByOffsets: anchorByOffsetsMock,
+    findAnchors: findAnchorsMock,
+  };
+});
+
+describe('annotateFindingsIntoWord anchor priority', () => {
+  const originalWord = (globalThis as any).Word;
+  const originalDocument = (globalThis as any).document;
+  const originalWindow = (globalThis as any).window;
+  const originalHTMLElement = (globalThis as any).HTMLElement;
+  const originalNode = (globalThis as any).Node;
+  const originalTestingFlag = (globalThis as any).__CAI_TESTING__;
+  const originalLastAnalyzed = (globalThis as any).__lastAnalyzed;
+  let dom: JSDOM | null = null;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    anchorByOffsetsMock.mockReset();
+    findAnchorsMock.mockReset();
+    dom = new JSDOM(`<!doctype html><html><body><input id="cai-dry-run-annotate" type="checkbox" /></body></html>`);
+    (globalThis as any).window = dom.window as any;
+    (globalThis as any).document = dom.window.document as any;
+    (globalThis as any).HTMLElement = dom.window.HTMLElement;
+    (globalThis as any).Node = dom.window.Node;
+    (globalThis as any).__CAI_TESTING__ = true;
+    (globalThis as any).__lastAnalyzed = 'alpha beta beta overlap gamma';
+  });
+
+  afterEach(() => {
+    if (dom) {
+      dom.window.close();
+    }
+    dom = null;
+    if (originalWord === undefined) delete (globalThis as any).Word;
+    else (globalThis as any).Word = originalWord;
+    if (originalDocument === undefined) delete (globalThis as any).document;
+    else (globalThis as any).document = originalDocument;
+    if (originalWindow === undefined) delete (globalThis as any).window;
+    else (globalThis as any).window = originalWindow;
+    if (originalHTMLElement === undefined) delete (globalThis as any).HTMLElement;
+    else (globalThis as any).HTMLElement = originalHTMLElement;
+    if (originalNode === undefined) delete (globalThis as any).Node;
+    else (globalThis as any).Node = originalNode;
+    if (originalTestingFlag === undefined) delete (globalThis as any).__CAI_TESTING__;
+    else (globalThis as any).__CAI_TESTING__ = originalTestingFlag;
+    if (originalLastAnalyzed === undefined) delete (globalThis as any).__lastAnalyzed;
+    else (globalThis as any).__lastAnalyzed = originalLastAnalyzed;
+  });
+
+  it('prefers offset anchors, falls back to search, and skips overlaps', async () => {
+    const annotateMod = await import('../assets/annotate');
+
+    const added: Array<{ start: number; end: number; text: string }> = [];
+    const makeRange = (start: number, end: number) => {
+      const add = vi.fn((_range: any, text: string) => {
+        added.push({ start, end, text });
+      });
+      return {
+        start,
+        end,
+        load: vi.fn(),
+        context: {
+          document: { comments: { add } },
+          sync: vi.fn(async () => {}),
+        },
+        insertContentControl: vi.fn(() => {
+          added.push({ start, end, text: '[cc]' });
+          return {
+            tag: '',
+            title: '',
+            color: '',
+            insertText: vi.fn(),
+          };
+        }),
+      };
+    };
+
+    const rangeA = makeRange(0, 5);
+    const rangeB = makeRange(10, 16);
+    const rangeC = makeRange(12, 20);
+
+    anchorByOffsetsMock
+      .mockResolvedValueOnce(rangeA)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(rangeC);
+    findAnchorsMock.mockResolvedValueOnce([rangeB]);
+
+    const body = { context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } } };
+    const ctx = {
+      document: { body },
+      sync: vi.fn(async () => {}),
+    };
+
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => await cb(ctx),
+    };
+
+    const findings = [
+      { rule_id: 'F1', snippet: 'alpha', start: 0, end: 5, severity: 'high' },
+      { rule_id: 'F2', snippet: 'beta', start: 10, end: 16, severity: 'medium' },
+      { rule_id: 'F3', snippet: 'beta overlap', start: 12, end: 20, severity: 'medium' },
+    ];
+
+    const inserted = await annotateMod.annotateFindingsIntoWord(findings as any);
+
+    expect(inserted).toBe(2);
+    expect(anchorByOffsetsMock).toHaveBeenCalledTimes(2);
+    expect(findAnchorsMock).toHaveBeenCalledTimes(1);
+    expect(added).toHaveLength(2);
+    expect(added[0].start).toBe(0);
+    expect(added[1].start).toBe(10);
+    expect(added.find(entry => entry.start === 12)).toBeUndefined();
+  });
+});

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -957,7 +957,7 @@ export function renderResults(res: any) {
   const findingsList = slot("findingsList", "findings") as HTMLElement | null;
   if (findingsList) {
     findingsList.innerHTML = "";
-    // DO NOT SORT: backend order (agenda).
+    // DO NOT DEDUPE/SORT: backend agenda order
     findingsArr.forEach((f: any) => {
       const li = document.createElement("li");
       li.textContent = typeof f === "string" ? f : JSON.stringify(f);
@@ -996,6 +996,8 @@ function mergeQaResults(json: any) {
   const merged = dedupeFindings([...existing, ...incoming]);
   return { ...(json || {}), findings: merged };
 }
+
+export const mergeQaResultsForTests = mergeQaResults;
 
 function wireResultsToggle() {
   const toggle = slot("toggleRaw", "toggle-raw-json");


### PR DESCRIPTION
## Summary
- update the taskpane render path to keep findings in backend order and expose the QA merge helper for verification in both dev and bundled copies
- add focused Vitest suites for main list ordering, QA merge dedupe, Word planning/anchoring behaviour, and a static guard on renderResults

## Testing
- `vitest run word_addin_dev/app/__tests__/test_main_no_dedupe.spec.ts word_addin_dev/app/__tests__/test_qa_merge_dedup.spec.ts word_addin_dev/app/__tests__/test_plan_annotations_dedup.spec.ts word_addin_dev/app/__tests__/test_word_anchor_priority_and_overlap.spec.ts word_addin_dev/app/__tests__/test_static_no_dedupe_in_renderResults.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68d39959e7208325b92a056d89d1c2cd