### PR TITLE
Add TRACE offsets fallback and GPT draft validation

### DIFF
--- a/word_addin_dev/app/__tests__/annotation_works_without_trace.spec.ts
+++ b/word_addin_dev/app/__tests__/annotation_works_without_trace.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const anchorByOffsetsMock = vi.fn();
+const findAnchorsMock = vi.fn();
+
+vi.mock('../assets/anchors', async () => {
+  const actual = await vi.importActual<typeof import('../assets/anchors')>('../assets/anchors');
+  return {
+    ...actual,
+    anchorByOffsets: anchorByOffsetsMock,
+    findAnchors: findAnchorsMock,
+  };
+});
+
+describe('annotation without trace fallback', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    anchorByOffsetsMock.mockReset();
+    findAnchorsMock.mockReset();
+    (globalThis as any).__lastAnalyzed = 'alpha beta gamma';
+    delete (globalThis as any).__traceCache;
+    delete (globalThis as any).__lastCid;
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } };
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => {
+        const body = {
+          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
+        } as any;
+        const ctx = {
+          document: { body },
+          sync: vi.fn(async () => {}),
+        };
+        return await cb(ctx);
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as any).__lastAnalyzed;
+    delete (globalThis as any).Word;
+    delete (globalThis as any).Office;
+    vi.resetModules();
+  });
+
+  it('still annotates findings when no trace data is available', async () => {
+    const range = {
+      start: 0,
+      end: 11,
+      load: vi.fn(),
+      context: { sync: vi.fn(async () => {}), document: { comments: { add: vi.fn() } } },
+      insertComment: vi.fn(),
+      parentContentControl: null,
+      insertContentControl: () => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn(),
+      }),
+    } as any;
+    anchorByOffsetsMock.mockResolvedValue(range);
+    findAnchorsMock.mockResolvedValue([]);
+
+    const annotateMod = await import('../assets/annotate');
+    const originalSafeInsert = annotateMod.safeInsertComment;
+    vi
+      .spyOn(annotateMod, 'safeInsertComment')
+      .mockImplementation(async (...args: Parameters<typeof annotateMod.safeInsertComment>) => {
+        return await originalSafeInsert(...args);
+      });
+    vi.spyOn(annotateMod, 'fallbackAnnotateWithContentControl').mockResolvedValue({ ok: false });
+
+    const findings = [
+      {
+        rule_id: 'rule-a',
+        snippet: 'alpha beta',
+        start: 0,
+        end: 10,
+      },
+    ];
+
+    const inserted = await annotateMod.annotateFindingsIntoWord(findings as any);
+
+    expect(inserted).toBe(1);
+    expect(anchorByOffsetsMock).toHaveBeenCalled();
+    expect(range.context.document.comments.add).toHaveBeenCalled();
+  });
+});

--- a/word_addin_dev/app/__tests__/trace_fetch_optional.spec.ts
+++ b/word_addin_dev/app/__tests__/trace_fetch_optional.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('trace fetch optional', () => {
+  const localStorageStub = {
+    getItem: vi.fn().mockReturnValue(null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  } as any;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    const winStub: any = {
+      __cai_pending_fetches: new Set(),
+      __cai_pending_timers: new Set(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      location: { search: '' },
+      document: { addEventListener: vi.fn(), removeEventListener: vi.fn() },
+    };
+    vi.stubGlobal('window', winStub);
+    vi.stubGlobal('document', winStub.document);
+    vi.stubGlobal('localStorage', localStorageStub);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+    delete (globalThis as any).localStorage;
+    delete (globalThis as any).fetch;
+    vi.resetModules();
+  });
+
+  it('returns parsed trace when backend responds with 200', async () => {
+    const payload = { trace: true };
+    const jsonMock = vi.fn().mockResolvedValue(payload);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: jsonMock });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    const { getTrace } = await import('../assets/api-client.ts');
+
+    const result = await getTrace('cid-123');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/trace/cid-123');
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ credentials: 'include' });
+    expect(result).toEqual(payload);
+  });
+
+  it('returns undefined when backend responds with non-OK status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, json: vi.fn() });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    const { getTrace } = await import('../assets/api-client.ts');
+    const result = await getTrace('cid-404');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when request fails', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network'));
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    const { getTrace } = await import('../assets/api-client.ts');
+    const result = await getTrace('cid-error');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeUndefined();
+  });
+});

--- a/word_addin_dev/app/__tests__/trace_offsets_used_when_no_anchor.spec.ts
+++ b/word_addin_dev/app/__tests__/trace_offsets_used_when_no_anchor.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const anchorByOffsetsMock = vi.fn();
+const findAnchorsMock = vi.fn();
+
+vi.mock('../assets/anchors', async () => {
+  const actual = await vi.importActual<typeof import('../assets/anchors')>('../assets/anchors');
+  return {
+    ...actual,
+    anchorByOffsets: anchorByOffsetsMock,
+    findAnchors: findAnchorsMock,
+  };
+});
+
+describe('trace offsets fallback', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    anchorByOffsetsMock.mockReset();
+    findAnchorsMock.mockReset();
+    (globalThis as any).__lastAnalyzed = 'Lorem ipsum dolor sit amet lorem ipsum';
+    (globalThis as any).__traceCache = new Map();
+    (globalThis as any).__lastCid = 'cid-1';
+    (globalThis as any).Office = { context: { requirements: { isSetSupported: () => true } } };
+    (globalThis as any).Word = {
+      InsertLocation: { end: 'end' },
+      run: async (cb: any) => {
+        const body = {
+          context: { sync: vi.fn(async () => {}), trackedObjects: { add: vi.fn() } },
+        } as any;
+        const ctx = {
+          document: { body },
+          sync: vi.fn(async () => {}),
+        };
+        return await cb(ctx);
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as any).__traceCache;
+    delete (globalThis as any).__lastCid;
+    delete (globalThis as any).__lastAnalyzed;
+    delete (globalThis as any).Word;
+    delete (globalThis as any).Office;
+    vi.resetModules();
+  });
+
+  it('adds trace offsets before text variants when anchor is missing', async () => {
+    const span = { start: 12, end: 22 };
+    const range = {
+      ...span,
+      load: vi.fn(),
+      context: { sync: vi.fn(async () => {}), document: { comments: { add: vi.fn() } } },
+      insertComment: vi.fn(),
+      parentContentControl: null,
+      insertContentControl: () => ({
+        tag: '',
+        title: '',
+        color: '',
+        insertText: vi.fn(),
+      }),
+    } as any;
+
+    anchorByOffsetsMock.mockImplementation(async opts => {
+      expect(opts.normalizedCandidates?.[0]).toEqual(span);
+      return range;
+    });
+    findAnchorsMock.mockResolvedValue([]);
+
+    const traceBody = {
+      dispatch: {
+        segments: [
+          {
+            segment_id: 7,
+            candidates: [
+              {
+                rule_id: 'rule-1',
+                reasons: [
+                  { offsets: [{ start: 12, end: 22 }, { start: 12, end: 22 }, { start: 30, end: 40 }] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    (globalThis as any).__traceCache.set('cid-1', traceBody);
+
+    const annotateMod = await import('../assets/annotate');
+    vi.spyOn(annotateMod, 'safeInsertComment').mockResolvedValue({ ok: true } as any);
+    vi.spyOn(annotateMod, 'fallbackAnnotateWithContentControl').mockResolvedValue({ ok: false });
+
+    const findings = [
+      {
+        rule_id: 'rule-1',
+        snippet: 'ipsum dolor',
+        start: 0,
+        end: 11,
+        segment_id: 7,
+        anchor: {},
+      },
+    ];
+
+    const inserted = await annotateMod.annotateFindingsIntoWord(findings as any);
+
+    expect(inserted).toBe(1);
+    expect(anchorByOffsetsMock).toHaveBeenCalledTimes(1);
+    expect(findAnchorsMock).not.toHaveBeenCalled();
+  });
+});

--- a/word_addin_dev/app/assets/api-client.ts
+++ b/word_addin_dev/app/assets/api-client.ts
@@ -103,6 +103,19 @@ function base(): string {
   catch { return DEFAULT_BASE; }
 }
 
+export async function getTrace(cid: string): Promise<any | undefined> {
+  if (!cid) return undefined;
+  const url = `${base()}/api/trace/${cid}`;
+  try {
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) return undefined;
+    return await res.json();
+  } catch (err) {
+    logError('[trace] fetch failed', err);
+    return undefined;
+  }
+}
+
 export function computeAnalyzeTimeout(textBytes: number): number {
   const BASE = 28_000;   // 28с базово
   const PER_KB = 50;     // +50мс за каждый КБ текста

--- a/word_addin_dev/app/assets/traceOffsetsForFinding.ts
+++ b/word_addin_dev/app/assets/traceOffsetsForFinding.ts
@@ -1,0 +1,114 @@
+import type { AnalyzeFindingEx } from "./types.ts";
+
+export interface OffsetSpan {
+  start: number;
+  end: number;
+}
+
+type TraceCandidate = {
+  rule_id?: string | null;
+  reasons?: Array<{ offsets?: Array<OffsetLike> | null } | null> | null;
+};
+
+type TraceSegment = {
+  segment_id?: number | string | null;
+  candidates?: Array<TraceCandidate | null> | null;
+};
+
+type OffsetLike = OffsetSpan | [number, number] | { start?: number | null; end?: number | null } | null | undefined;
+
+type TraceBody = {
+  dispatch?: {
+    segments?: Array<TraceSegment | null> | null;
+    candidates?: Array<TraceCandidate | null> | null;
+  } | null;
+};
+
+function toInt(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.floor(value);
+  }
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function extractOffsets(entries: OffsetLike[]): OffsetSpan[] {
+  const spans: OffsetSpan[] = [];
+  for (const entry of entries) {
+    if (!entry) continue;
+    let start: number | undefined;
+    let end: number | undefined;
+    if (Array.isArray(entry) && entry.length >= 2) {
+      start = toInt(entry[0]);
+      end = toInt(entry[1]);
+    } else if (typeof entry === "object") {
+      start = toInt((entry as OffsetSpan).start);
+      end = toInt((entry as OffsetSpan).end);
+    }
+    if (typeof start === "number" && typeof end === "number" && end > start) {
+      spans.push({ start, end });
+    }
+  }
+  return spans;
+}
+
+function matchSegmentId(segment: TraceSegment | null | undefined, expected: number | string | undefined): boolean {
+  if (expected == null) return true;
+  const segId = segment?.segment_id ?? (segment as any)?.id ?? (segment as any)?.segmentId;
+  const seg = toInt(segId);
+  const exp = toInt(expected);
+  if (seg == null || exp == null) return true;
+  return seg === exp;
+}
+
+function iterateCandidates(trace: TraceBody | null | undefined, segmentId?: number | string) {
+  const dispatch = trace?.dispatch ?? {};
+  const segments = Array.isArray(dispatch.segments) ? dispatch.segments : [];
+  const buckets: TraceCandidate[] = [];
+  for (const segment of segments) {
+    if (!matchSegmentId(segment, segmentId)) continue;
+    const candidates = Array.isArray(segment?.candidates) ? segment?.candidates : [];
+    for (const cand of candidates) {
+      if (cand) buckets.push(cand);
+    }
+  }
+  if (!buckets.length) {
+    const fallback = Array.isArray(dispatch.candidates) ? dispatch.candidates : [];
+    for (const cand of fallback) {
+      if (cand) buckets.push(cand);
+    }
+  }
+  return buckets;
+}
+
+function collectOffsetsFromCandidate(candidate: TraceCandidate | null | undefined): OffsetSpan[] {
+  if (!candidate) return [];
+  const reasons = Array.isArray(candidate.reasons) ? candidate.reasons : [];
+  const spans: OffsetSpan[] = [];
+  for (const reason of reasons) {
+    const offsets = Array.isArray(reason?.offsets) ? reason?.offsets : [];
+    spans.push(...extractOffsets(offsets as OffsetLike[]));
+  }
+  return spans;
+}
+
+export function traceOffsetsForFinding(trace: TraceBody | null | undefined, finding: AnalyzeFindingEx): OffsetSpan[] {
+  if (!trace || !finding?.rule_id) return [];
+  const segmentId = (finding as any)?.segment_id ?? (finding as any)?.segmentId ?? (finding as any)?.segment?.id;
+  const ruleId = String(finding.rule_id);
+  const seen = new Set<string>();
+  const collected: OffsetSpan[] = [];
+  for (const candidate of iterateCandidates(trace, segmentId)) {
+    if (!candidate || String(candidate.rule_id ?? "") !== ruleId) continue;
+    for (const span of collectOffsetsFromCandidate(candidate)) {
+      const key = `${span.start}:${span.end}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      collected.push(span);
+      if (collected.length >= 4) return collected;
+    }
+  }
+  return collected.slice(0, 4);
+}
+
+export type { TraceBody };


### PR DESCRIPTION
## Summary
- add an API client helper to fetch TRACE artifacts and cache them after Analyze
- derive Word anchoring candidates from TRACE offsets when findings lack anchors and update anchoring utilities accordingly
- harden /api/gpt-draft by rejecting empty text payloads
- add targeted Vitest coverage for optional TRACE fetch, TRACE offset usage, and trace-less annotation

## Testing
- `npx vitest run app/__tests__/trace_fetch_optional.spec.ts app/__tests__/trace_offsets_used_when_no_anchor.spec.ts app/__tests__/annotation_works_without_trace.spec.ts`
- `pytest contract_review_app/tests/api/test_gpt_draft_body.py::test_gpt_draft_validation_errors`


------
https://chatgpt.com/codex/tasks/task_e_68d3ac074f448325ac2acd9225baa4c7