### PR TITLE
Add TRACE badge summary in panel header

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_degrade.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_degrade.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderTraceBadges } from '../traceBadges.ts';
+
+function createBadgesEnvironment() {
+  const elementsById = new Map<string, any>();
+
+  const registerId = (el: any) => {
+    Object.defineProperty(el, 'id', {
+      get() {
+        return el._id || '';
+      },
+      set(value: string) {
+        if (el._id) {
+          elementsById.delete(el._id);
+        }
+        el._id = value;
+        if (value) {
+          elementsById.set(value, el);
+        }
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  };
+
+  const makeElement = (tag: string): any => {
+    const element: any = {
+      tagName: tag.toUpperCase(),
+      children: [] as any[],
+      dataset: {} as Record<string, string>,
+      style: {} as Record<string, string>,
+      appendChild(child: any) {
+        this.children.push(child);
+        child.parentNode = this;
+        return child;
+      },
+    };
+    Object.defineProperty(element, 'textContent', {
+      get() {
+        return element._textContent || '';
+      },
+      set(value: string) {
+        element._textContent = value ?? '';
+        element.children = [];
+      },
+      configurable: true,
+      enumerable: true,
+    });
+    registerId(element);
+    return element;
+  };
+
+  const root = makeElement('div');
+  const badges = makeElement('span');
+  badges.id = 'traceBadges';
+  root.appendChild(badges);
+
+  const documentStub = {
+    createElement: makeElement,
+    getElementById(id: string) {
+      return elementsById.get(id) ?? null;
+    },
+  } as any;
+
+  return { documentStub, badges };
+}
+
+const originalDocument = (globalThis as any).document;
+const originalCache = (globalThis as any).__traceCache;
+
+describe('renderTraceBadges degrade modes', () => {
+  afterEach(() => {
+    (globalThis as any).document = originalDocument;
+    (globalThis as any).__traceCache = originalCache;
+  });
+
+  it('keeps badges hidden when trace is missing', () => {
+    const { documentStub, badges } = createBadgesEnvironment();
+    (globalThis as any).document = documentStub;
+    (globalThis as any).__traceCache = new Map<string, any>();
+
+    renderTraceBadges('cid2');
+
+    expect(badges.style.display).toBe('none');
+    expect(badges.children).toHaveLength(0);
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_no_inner_html.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_no_inner_html.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+describe('traceBadges.ts safety', () => {
+  it('does not use innerHTML for trace data', () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const filePath = path.resolve(here, '../traceBadges.ts');
+    const contents = readFileSync(filePath, 'utf-8');
+    expect(contents.includes('innerHTML')).toBe(false);
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_parsing.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_parsing.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderTraceBadges } from '../traceBadges.ts';
+
+function createBadgesEnvironment() {
+  const elementsById = new Map<string, any>();
+
+  const registerId = (el: any) => {
+    Object.defineProperty(el, 'id', {
+      get() {
+        return el._id || '';
+      },
+      set(value: string) {
+        if (el._id) {
+          elementsById.delete(el._id);
+        }
+        el._id = value;
+        if (value) {
+          elementsById.set(value, el);
+        }
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  };
+
+  const makeElement = (tag: string): any => {
+    const element: any = {
+      tagName: tag.toUpperCase(),
+      children: [] as any[],
+      dataset: {} as Record<string, string>,
+      style: {} as Record<string, string>,
+      appendChild(child: any) {
+        this.children.push(child);
+        child.parentNode = this;
+        return child;
+      },
+    };
+    Object.defineProperty(element, 'textContent', {
+      get() {
+        return element._textContent || '';
+      },
+      set(value: string) {
+        element._textContent = value ?? '';
+        element.children = [];
+      },
+      configurable: true,
+      enumerable: true,
+    });
+    registerId(element);
+    return element;
+  };
+
+  const root = makeElement('div');
+  const badges = makeElement('span');
+  badges.id = 'traceBadges';
+  root.appendChild(badges);
+
+  const documentStub = {
+    createElement: makeElement,
+    getElementById(id: string) {
+      return elementsById.get(id) ?? null;
+    },
+  } as any;
+
+  return { documentStub, badges };
+}
+
+const originalDocument = (globalThis as any).document;
+const originalCache = (globalThis as any).__traceCache;
+
+describe('renderTraceBadges', () => {
+  afterEach(() => {
+    (globalThis as any).document = originalDocument;
+    (globalThis as any).__traceCache = originalCache;
+  });
+
+  it('renders coverage and merge badges', () => {
+    const { documentStub, badges } = createBadgesEnvironment();
+    (globalThis as any).document = documentStub;
+
+    const cache = new Map<string, any>();
+    cache.set('cid1', {
+      coverage: { zones_total: 45, zones_present: 22, zones_fired: 12 },
+      meta: { timings_ms: { merge_ms: 37.4 } },
+    });
+    (globalThis as any).__traceCache = cache;
+
+    renderTraceBadges('cid1');
+
+    expect(badges.style.display).toBe('');
+    expect(badges.children).toHaveLength(2);
+    expect(badges.children[0].className).toBe('trace-badge');
+    expect(badges.children[0].textContent).toBe('Coverage: 12/22/45');
+    expect(badges.children[1].textContent).toBe('Merge: 37 ms');
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_link_presence.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_link_presence.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { updateResultsTraceLink } from '../updateResultsTraceLink.ts';
+
+function createStubEnvironment() {
+  const elementsById = new Map<string, any>();
+
+  const matches = (el: any, selector: string): boolean => {
+    if (!el) return false;
+    switch (selector) {
+      case '.muted':
+        return Boolean(el.classList?.contains('muted'));
+      case '[data-role="trace-link"]':
+        return el.dataset?.role === 'trace-link';
+      case '#traceBadges':
+        return el.id === 'traceBadges';
+      case 'a[data-role="open-trace"]':
+        return el.tagName === 'A' && el.dataset?.role === 'open-trace';
+      default:
+        return false;
+    }
+  };
+
+  const querySelectorIn = (node: any, selector: string): any => {
+    if (!node?.children) return null;
+    for (const child of node.children) {
+      if (matches(child, selector)) return child;
+      const nested = querySelectorIn(child, selector);
+      if (nested) return nested;
+    }
+    return null;
+  };
+
+  const registerId = (el: any) => {
+    Object.defineProperty(el, 'id', {
+      get() {
+        return el._id || '';
+      },
+      set(value: string) {
+        if (el._id) {
+          elementsById.delete(el._id);
+        }
+        el._id = value;
+        if (value) {
+          elementsById.set(value, el);
+        }
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  };
+
+  const makeElement = (tag: string): any => {
+    const element: any = {
+      tagName: tag.toUpperCase(),
+      children: [] as any[],
+      dataset: {} as Record<string, string>,
+      style: {} as Record<string, string>,
+      parentNode: null,
+      className: '',
+      appendChild(child: any) {
+        this.children.push(child);
+        child.parentNode = this;
+        return child;
+      },
+      querySelector(selector: string) {
+        return querySelectorIn(this, selector);
+      },
+    };
+    element.classList = {
+      add(cls: string) {
+        if (!element.className) {
+          element.className = cls;
+        } else if (!this.contains(cls)) {
+          element.className += ` ${cls}`;
+        }
+      },
+      remove(cls: string) {
+        element.className = element.className
+          .split(/\s+/)
+          .filter(token => token && token !== cls)
+          .join(' ');
+      },
+      contains(cls: string) {
+        return element.className.split(/\s+/).includes(cls);
+      },
+    };
+    Object.defineProperty(element, 'textContent', {
+      get() {
+        return element._textContent || '';
+      },
+      set(value: string) {
+        element._textContent = value ?? '';
+        element.children = [];
+      },
+      configurable: true,
+      enumerable: true,
+    });
+    registerId(element);
+    return element;
+  };
+
+  const root = makeElement('div');
+  const resultsBlock = makeElement('div');
+  resultsBlock.id = 'resultsBlock';
+  const header = makeElement('div');
+  header.classList.add('muted');
+  resultsBlock.appendChild(header);
+  root.appendChild(resultsBlock);
+
+  const documentStub = {
+    createElement: makeElement,
+    getElementById(id: string) {
+      return elementsById.get(id) ?? null;
+    },
+    querySelector(selector: string) {
+      return querySelectorIn(root, selector);
+    },
+  } as any;
+
+  return { documentStub, header };
+}
+
+const originalDocument = (globalThis as any).document;
+
+describe('updateResultsTraceLink', () => {
+  afterEach(() => {
+    (globalThis as any).document = originalDocument;
+  });
+
+  it('shows trace link with cid', () => {
+    const { documentStub, header } = createStubEnvironment();
+    (globalThis as any).document = documentStub;
+
+    updateResultsTraceLink('abc', 'https://backend.test');
+
+    const container = header.querySelector('[data-role="trace-link"]');
+    expect(container).toBeTruthy();
+    expect(container?.style.display).toBe('');
+
+    const link = container?.querySelector('a[data-role="open-trace"]');
+    expect(link?.href).toBe('https://backend.test/api/trace/abc.html');
+    expect(link?.textContent).toBe('Open TRACE');
+
+    const badges = header.querySelector('#traceBadges');
+    expect(badges).toBeTruthy();
+    expect(badges?.style.display).toBe('none');
+  });
+
+  it('hides trace link when cid missing', () => {
+    const { documentStub, header } = createStubEnvironment();
+    (globalThis as any).document = documentStub;
+
+    updateResultsTraceLink('', 'https://backend.test');
+
+    const container = header.querySelector('[data-role="trace-link"]');
+    expect(container?.style.display).toBe('none');
+
+    const badges = header.querySelector('#traceBadges');
+    expect(badges?.style.display).toBe('none');
+  });
+});

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.css
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.css
@@ -29,3 +29,11 @@
   .cai-book__icon { animation: none; opacity: .75; }
 }
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.trace-badge {
+  display: inline-block;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-size: 12px;
+  opacity: 0.85;
+  margin-left: 6px;
+}

--- a/contract_review_app/contract_review_app/static/panel/app/assets/traceBadges.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/traceBadges.ts
@@ -1,0 +1,46 @@
+export function renderTraceBadges(cid: string): void {
+  try {
+    if (typeof document === 'undefined') return;
+  } catch {
+    return;
+  }
+
+  const container = document.getElementById('traceBadges') as HTMLSpanElement | null;
+  if (!container) return;
+
+  container.textContent = '';
+  container.style.display = 'none';
+
+  const cache = (globalThis as any).__traceCache as Map<string, any> | undefined;
+  if (!cache?.has(cid)) {
+    return;
+  }
+
+  const trace = cache.get(cid) || {};
+  const cov = trace?.coverage;
+  const total = Number(cov?.zones_total) || 0;
+  const present = Number(cov?.zones_present) || 0;
+  const fired = Number(cov?.zones_fired) || 0;
+  const mergeMs = Math.round(Number(trace?.meta?.timings_ms?.merge_ms) || 0);
+
+  const badges: string[] = [];
+  if (total > 0) {
+    badges.push(`Coverage: ${fired}/${present}/${total}`);
+  }
+  if (mergeMs > 0) {
+    badges.push(`Merge: ${mergeMs} ms`);
+  }
+
+  if (!badges.length) {
+    return;
+  }
+
+  badges.forEach(text => {
+    const span = document.createElement('span');
+    span.className = 'trace-badge';
+    span.textContent = text;
+    container.appendChild(span);
+  });
+
+  container.style.display = '';
+}

--- a/contract_review_app/contract_review_app/static/panel/app/assets/updateResultsTraceLink.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/updateResultsTraceLink.ts
@@ -1,0 +1,52 @@
+export function updateResultsTraceLink(cid: string | null | undefined, backend: string): void {
+  try {
+    if (typeof document === 'undefined') return;
+  } catch {
+    return;
+  }
+
+  const parent = document.getElementById('resultsBlock') as HTMLElement | null;
+  if (!parent) return;
+  const header = parent.querySelector('.muted') as HTMLElement | null;
+  if (!header) return;
+
+  let container = header.querySelector('[data-role="trace-link"]') as HTMLElement | null;
+  if (!container) {
+    container = document.createElement('span');
+    container.dataset.role = 'trace-link';
+    container.style.marginLeft = '8px';
+    header.appendChild(container);
+  }
+
+  let badgesContainer = header.querySelector('#traceBadges') as HTMLSpanElement | null;
+  if (!badgesContainer) {
+    badgesContainer = document.createElement('span');
+    badgesContainer.id = 'traceBadges';
+    header.appendChild(badgesContainer);
+  }
+
+  container.textContent = '';
+  badgesContainer.textContent = '';
+  container.style.display = 'none';
+  badgesContainer.style.display = 'none';
+
+  const normalizedCid = (cid ?? '').trim();
+  const backendBase = (backend ?? '').trim().replace(/\/+$/, '');
+  if (!normalizedCid || !backendBase) {
+    return;
+  }
+
+  container.style.display = '';
+
+  const separator = document.createElement('span');
+  separator.textContent = ' · ';
+  container.appendChild(separator);
+
+  const link = document.createElement('a');
+  link.dataset.role = 'open-trace';
+  link.target = '_blank';
+  link.rel = 'noreferrer noopener';
+  link.textContent = 'Open TRACE';
+  link.href = `${backendBase}/api/trace/${normalizedCid}.html`;
+  container.appendChild(link);
+}

--- a/word_addin_dev/app/assets/taskpane.css
+++ b/word_addin_dev/app/assets/taskpane.css
@@ -29,3 +29,11 @@
   .cai-book__icon { animation: none; opacity: .75; }
 }
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.trace-badge {
+  display: inline-block;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-size: 12px;
+  opacity: 0.85;
+  margin-left: 6px;
+}

--- a/word_addin_dev/app/assets/traceBadges.ts
+++ b/word_addin_dev/app/assets/traceBadges.ts
@@ -1,0 +1,46 @@
+export function renderTraceBadges(cid: string): void {
+  try {
+    if (typeof document === 'undefined') return;
+  } catch {
+    return;
+  }
+
+  const container = document.getElementById('traceBadges') as HTMLSpanElement | null;
+  if (!container) return;
+
+  container.textContent = '';
+  container.style.display = 'none';
+
+  const cache = (globalThis as any).__traceCache as Map<string, any> | undefined;
+  if (!cache?.has(cid)) {
+    return;
+  }
+
+  const trace = cache.get(cid) || {};
+  const cov = trace?.coverage;
+  const total = Number(cov?.zones_total) || 0;
+  const present = Number(cov?.zones_present) || 0;
+  const fired = Number(cov?.zones_fired) || 0;
+  const mergeMs = Math.round(Number(trace?.meta?.timings_ms?.merge_ms) || 0);
+
+  const badges: string[] = [];
+  if (total > 0) {
+    badges.push(`Coverage: ${fired}/${present}/${total}`);
+  }
+  if (mergeMs > 0) {
+    badges.push(`Merge: ${mergeMs} ms`);
+  }
+
+  if (!badges.length) {
+    return;
+  }
+
+  badges.forEach(text => {
+    const span = document.createElement('span');
+    span.className = 'trace-badge';
+    span.textContent = text;
+    container.appendChild(span);
+  });
+
+  container.style.display = '';
+}

--- a/word_addin_dev/app/assets/updateResultsTraceLink.ts
+++ b/word_addin_dev/app/assets/updateResultsTraceLink.ts
@@ -1,0 +1,52 @@
+export function updateResultsTraceLink(cid: string | null | undefined, backend: string): void {
+  try {
+    if (typeof document === 'undefined') return;
+  } catch {
+    return;
+  }
+
+  const parent = document.getElementById('resultsBlock') as HTMLElement | null;
+  if (!parent) return;
+  const header = parent.querySelector('.muted') as HTMLElement | null;
+  if (!header) return;
+
+  let container = header.querySelector('[data-role="trace-link"]') as HTMLElement | null;
+  if (!container) {
+    container = document.createElement('span');
+    container.dataset.role = 'trace-link';
+    container.style.marginLeft = '8px';
+    header.appendChild(container);
+  }
+
+  let badgesContainer = header.querySelector('#traceBadges') as HTMLSpanElement | null;
+  if (!badgesContainer) {
+    badgesContainer = document.createElement('span');
+    badgesContainer.id = 'traceBadges';
+    header.appendChild(badgesContainer);
+  }
+
+  container.textContent = '';
+  badgesContainer.textContent = '';
+  container.style.display = 'none';
+  badgesContainer.style.display = 'none';
+
+  const normalizedCid = (cid ?? '').trim();
+  const backendBase = (backend ?? '').trim().replace(/\/+$/, '');
+  if (!normalizedCid || !backendBase) {
+    return;
+  }
+
+  container.style.display = '';
+
+  const separator = document.createElement('span');
+  separator.textContent = ' · ';
+  container.appendChild(separator);
+
+  const link = document.createElement('a');
+  link.dataset.role = 'open-trace';
+  link.target = '_blank';
+  link.rel = 'noreferrer noopener';
+  link.textContent = 'Open TRACE';
+  link.href = `${backendBase}/api/trace/${normalizedCid}.html`;
+  container.appendChild(link);
+}


### PR DESCRIPTION
## Summary
- create reusable helpers to build the TRACE link to `/api/trace/{cid}.html` and manage the badge container
- render cached coverage and merge timing badges alongside the TRACE link and style them for the panel
- mirror the link/badge wiring for the dev add-in bundle and add Vitest coverage for link rendering, badge parsing, degradation, and safety checks

## Testing
- npx vitest run contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_link_presence.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_parsing.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_degrade.spec.ts contract_review_app/contract_review_app/static/panel/app/assets/__tests__/trace_badges_no_inner_html.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d3b5f2ee288325bd7ad855ef41a249