### PR TITLE
Improve QA merge logic to preserve order and priority

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/assets/qa/mergeQaResults.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/qa/mergeQaResults.ts
@@ -1,0 +1,172 @@
+import { AnalyzeFinding } from "../api-client.ts";
+import { normalizeText, severityRank } from "../dedupe.ts";
+
+const AGENDA_GROUP_ORDER: Record<string, number> = {
+  law: 0,
+  policy: 1,
+  substantive: 2,
+  drafting: 3,
+  grammar: 4,
+};
+
+function coerceNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return Number.NaN;
+}
+
+function getSalience(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return Number.NEGATIVE_INFINITY;
+}
+
+function agendaRank(value: unknown): number {
+  if (typeof value === "string") {
+    const key = value.trim().toLowerCase();
+    if (key in AGENDA_GROUP_ORDER) {
+      return AGENDA_GROUP_ORDER[key as keyof typeof AGENDA_GROUP_ORDER];
+    }
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function cloneFinding(finding: AnalyzeFinding): AnalyzeFinding {
+  return { ...finding };
+}
+
+function hasSourceProp(finding: AnalyzeFinding): boolean {
+  return Object.prototype.hasOwnProperty.call(finding, "source");
+}
+
+function setSourceIfNeeded(
+  finding: AnalyzeFinding,
+  preferred: unknown,
+  shouldMark: boolean,
+): AnalyzeFinding {
+  if (!shouldMark) {
+    return finding;
+  }
+  const clone = cloneFinding(finding);
+  if (typeof preferred !== "undefined") {
+    (clone as any).source = preferred;
+  } else if (typeof (clone as any).source === "undefined") {
+    (clone as any).source = "qa";
+  }
+  return clone;
+}
+
+export function makeKey(finding: AnalyzeFinding): string {
+  const rule = finding?.rule_id ?? "";
+  const start = coerceNumber((finding as any)?.start);
+  const end = coerceNumber((finding as any)?.end);
+  const snippetNorm = normalizeText((finding as any)?.snippet ?? "");
+  return `${rule}|${start}|${end}|${snippetNorm}`;
+}
+
+export function priorityCompare(a: AnalyzeFinding, b: AnalyzeFinding): number {
+  const severityDiff = severityRank((a as any)?.severity) - severityRank((b as any)?.severity);
+  if (severityDiff !== 0) {
+    return severityDiff;
+  }
+
+  const salienceDiff = getSalience((a as any)?.salience) - getSalience((b as any)?.salience);
+  if (salienceDiff !== 0) {
+    return salienceDiff;
+  }
+
+  const agendaDiff = agendaRank((b as any)?.agenda_group) - agendaRank((a as any)?.agenda_group);
+  if (agendaDiff !== 0) {
+    return agendaDiff;
+  }
+
+  const ruleA = `${(a as any)?.rule_id ?? ""}`;
+  const ruleB = `${(b as any)?.rule_id ?? ""}`;
+  const cmp = ruleA.localeCompare(ruleB, undefined, { numeric: true, sensitivity: "base" });
+  if (cmp !== 0) {
+    return -cmp;
+  }
+
+  return 0;
+}
+
+function getCollectionEntry(
+  base: AnalyzeFinding[],
+  appends: AnalyzeFinding[],
+  index: number,
+): AnalyzeFinding {
+  return index < base.length ? base[index] : appends[index - base.length];
+}
+
+function setCollectionEntry(
+  base: AnalyzeFinding[],
+  appends: AnalyzeFinding[],
+  index: number,
+  value: AnalyzeFinding,
+): void {
+  if (index < base.length) {
+    base[index] = value;
+  } else {
+    appends[index - base.length] = value;
+  }
+}
+
+export function mergeQaFindings(
+  baseFindings: AnalyzeFinding[] = [],
+  qaFindings: AnalyzeFinding[] = [],
+): AnalyzeFinding[] {
+  const base = Array.isArray(baseFindings) ? [...baseFindings] : [];
+  const qa = Array.isArray(qaFindings) ? qaFindings : [];
+  const map = new Map<string, number>();
+  for (let i = 0; i < base.length; i += 1) {
+    map.set(makeKey(base[i]), i);
+  }
+
+  const appends: AnalyzeFinding[] = [];
+  const shouldMarkSource = base.some(hasSourceProp) || qa.some(hasSourceProp);
+
+  for (const qaItem of qa) {
+    const candidate = cloneFinding(qaItem);
+    const key = makeKey(candidate);
+    const idx = map.get(key);
+    if (typeof idx === "number") {
+      const existing = getCollectionEntry(base, appends, idx);
+      const cmp = priorityCompare(candidate, existing);
+      if (cmp < 0) {
+        continue;
+      }
+      const preferredSource = shouldMarkSource ? (existing as any)?.source : undefined;
+      const replacement = setSourceIfNeeded(candidate, preferredSource, shouldMarkSource);
+      setCollectionEntry(base, appends, idx, replacement);
+      continue;
+    }
+
+    const preferredIndex = base.length + appends.length;
+    const appended = shouldMarkSource ? setSourceIfNeeded(candidate, undefined, true) : candidate;
+    appends.push(appended);
+    map.set(key, preferredIndex);
+  }
+
+  return base.concat(appends);
+}
+
+export function mergeQaPayload(
+  existing: AnalyzeFinding[] | undefined,
+  qaPayload: AnalyzeFinding[] | undefined,
+): AnalyzeFinding[] {
+  return mergeQaFindings(existing ?? [], qaPayload ?? []);
+}

--- a/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/assets/taskpane.ts
@@ -3,6 +3,7 @@ import type { AnalyzeFindingEx } from "./types.ts";
 import { parseFindings } from "./findings.ts";
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, dedupeFindings, severityRank, type RiskLevel } from "./dedupe.ts";
+import { mergeQaFindings } from "./qa/mergeQaResults.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
 import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment, fallbackAnnotateWithContentControl } from "./annotate.ts";
 import { findAnchors } from "./anchors.ts";
@@ -1014,7 +1015,7 @@ export function renderResults(res: any, options?: { append?: boolean; prevLimit?
 function mergeQaResults(json: any) {
   const existing: AnalyzeFinding[] = (window as any).__findings || [];
   const incoming = parseFindings(json);
-  const merged = dedupeFindings([...existing, ...incoming]);
+  const merged = mergeQaFindings(existing, incoming);
   return { ...(json || {}), findings: merged };
 }
 

--- a/word_addin_dev/app/__tests__/qa_merge_append_only_new.spec.ts
+++ b/word_addin_dev/app/__tests__/qa_merge_append_only_new.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { performance } from 'perf_hooks';
+import { mergeQaFindings } from '../assets/qa/mergeQaResults';
+
+describe('mergeQaFindings append behavior', () => {
+  it('appends only new QA findings and runs in linear time', () => {
+    const base = Array.from({ length: 1000 }, (_, idx) => ({
+      rule_id: `R-${idx}`,
+      start: idx * 5,
+      end: idx * 5 + 4,
+      snippet: `Snippet ${idx}`,
+      severity: idx % 4 === 0 ? 'high' : 'medium',
+      salience: idx % 10,
+      agenda_group: idx % 5 === 0 ? 'law' : 'policy',
+    }));
+
+    const qaDuplicates = Array.from({ length: 50 }, (_, idx) => ({
+      rule_id: `R-${idx}`,
+      start: idx * 5,
+      end: idx * 5 + 4,
+      snippet: `Snippet ${idx}`,
+      severity: 'critical',
+      salience: 10 - idx,
+      agenda_group: 'law',
+    }));
+
+    const qaNew = Array.from({ length: 50 }, (_, idx) => ({
+      rule_id: `QA-${idx}`,
+      start: 5000 + idx * 5,
+      end: 5000 + idx * 5 + 4,
+      snippet: `QA Snippet ${idx}`,
+      severity: 'medium',
+      salience: idx,
+      agenda_group: 'drafting',
+    }));
+
+    const qa = [...qaDuplicates, ...qaNew];
+
+    const start = performance.now();
+    const merged = mergeQaFindings(base, qa);
+    const duration = performance.now() - start;
+
+    expect(merged).toHaveLength(base.length + qaNew.length);
+
+    if (duration >= 50) {
+      console.warn(`[perf] mergeQaFindings took ${duration.toFixed(2)}ms`);
+    } else {
+      expect(duration).toBeLessThan(50);
+    }
+    expect(duration).toBeLessThan(200);
+
+    const appendedIds = merged.slice(-qaNew.length).map(item => item.rule_id);
+    expect(new Set(appendedIds)).toEqual(new Set(qaNew.map(item => item.rule_id)));
+  });
+});

--- a/word_addin_dev/app/__tests__/qa_merge_idempotent.spec.ts
+++ b/word_addin_dev/app/__tests__/qa_merge_idempotent.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { mergeQaFindings } from '../assets/qa/mergeQaResults';
+
+describe('mergeQaFindings idempotency', () => {
+  it('produces stable results when merging the same QA payload twice', () => {
+    const base = [
+      { rule_id: 'A', start: 0, end: 5, snippet: 'Alpha', severity: 'low', salience: 0.1, agenda_group: 'law' },
+      { rule_id: 'B', start: 6, end: 10, snippet: 'Beta', severity: 'medium', salience: 0.2, agenda_group: 'policy' },
+    ];
+    const qa = [
+      { rule_id: 'B', start: 6, end: 10, snippet: 'Beta', severity: 'high', salience: 0.4, agenda_group: 'policy' },
+      { rule_id: 'C', start: 11, end: 15, snippet: 'Gamma', severity: 'medium', salience: 0.3, agenda_group: 'drafting' },
+    ];
+
+    const once = mergeQaFindings(base, qa);
+    const twice = mergeQaFindings(once, qa);
+
+    expect(twice).toEqual(once);
+    expect(once).not.toBe(base);
+  });
+});

--- a/word_addin_dev/app/__tests__/qa_merge_no_sorting_main_list.spec.ts
+++ b/word_addin_dev/app/__tests__/qa_merge_no_sorting_main_list.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mergeQaFindings } from '../assets/qa/mergeQaResults';
+
+describe('mergeQaFindings does not sort results', () => {
+  it('avoids calling Array.sort on the merged output', () => {
+    const sortSpy = vi.spyOn(Array.prototype as any, 'sort');
+
+    try {
+      const base = [
+        { rule_id: 'A', start: 0, end: 5, snippet: 'Alpha', severity: 'low', salience: 0.1, agenda_group: 'law' },
+        { rule_id: 'B', start: 6, end: 10, snippet: 'Beta', severity: 'medium', salience: 0.2, agenda_group: 'policy' },
+      ];
+      const qa = [
+        { rule_id: 'C', start: 11, end: 15, snippet: 'Gamma', severity: 'high', salience: 0.5, agenda_group: 'grammar' },
+      ];
+
+      mergeQaFindings(base, qa);
+      expect(sortSpy).not.toHaveBeenCalled();
+    } finally {
+      sortSpy.mockRestore();
+    }
+  });
+});

--- a/word_addin_dev/app/__tests__/qa_merge_preserves_base_order.spec.ts
+++ b/word_addin_dev/app/__tests__/qa_merge_preserves_base_order.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { mergeQaFindings } from '../assets/qa/mergeQaResults';
+
+describe('mergeQaFindings - base order preservation', () => {
+  it('replaces duplicates in place and appends new QA findings', () => {
+    const base = [
+      { rule_id: 'A', start: 0, end: 10, snippet: 'Alpha', severity: 'low', agenda_group: 'law', salience: 0.5, source: 'analyze', message: 'Base A' },
+      { rule_id: 'B', start: 11, end: 20, snippet: 'Beta', severity: 'medium', agenda_group: 'policy', salience: 0.4, source: 'analyze', message: 'Base B' },
+      { rule_id: 'C', start: 21, end: 30, snippet: 'Gamma', severity: 'low', agenda_group: 'drafting', salience: 0.3, source: 'analyze', message: 'Base C' },
+    ];
+
+    const qa = [
+      { rule_id: 'B', start: 11, end: 20, snippet: 'Beta', severity: 'high', agenda_group: 'policy', salience: 0.6, message: 'QA B prime' },
+      { rule_id: 'D', start: 31, end: 40, snippet: 'Delta', severity: 'medium', agenda_group: 'grammar', salience: 0.2, message: 'QA D' },
+    ];
+
+    const merged = mergeQaFindings(base, qa);
+
+    expect(merged).toHaveLength(4);
+    expect(merged.map(item => item.rule_id)).toEqual(['A', 'B', 'C', 'D']);
+    expect(merged[1].message).toBe('QA B prime');
+    expect(merged[1].severity).toBe('high');
+    expect(merged[1].salience).toBe(0.6);
+    expect(merged[1].agenda_group).toBe('policy');
+    expect(merged[1]).not.toBe(base[1]);
+    expect(base[1].message).toBe('Base B');
+    expect(merged[3].rule_id).toBe('D');
+    expect((merged[3] as any).source).toBe('qa');
+  });
+});

--- a/word_addin_dev/app/__tests__/qa_merge_priority_rules.spec.ts
+++ b/word_addin_dev/app/__tests__/qa_merge_priority_rules.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { priorityCompare } from '../assets/qa/mergeQaResults';
+
+function makeFinding(overrides: Record<string, any> = {}) {
+  return {
+    rule_id: 'R-100',
+    start: 0,
+    end: 5,
+    snippet: 'text',
+    severity: 'medium',
+    salience: 1,
+    agenda_group: 'policy',
+    ...overrides,
+  };
+}
+
+describe('priorityCompare', () => {
+  it('prefers higher severity first', () => {
+    const high = makeFinding({ severity: 'high' });
+    const low = makeFinding({ severity: 'low' });
+    expect(priorityCompare(high, low)).toBeGreaterThan(0);
+    expect(priorityCompare(low, high)).toBeLessThan(0);
+  });
+
+  it('prefers higher salience when severity ties', () => {
+    const a = makeFinding({ salience: 0.8 });
+    const b = makeFinding({ salience: 0.4 });
+    expect(priorityCompare(a, b)).toBeGreaterThan(0);
+    expect(priorityCompare(b, a)).toBeLessThan(0);
+  });
+
+  it('prefers agenda groups by backend ordering', () => {
+    const law = makeFinding({ agenda_group: 'law', salience: 0 });
+    const grammar = makeFinding({ agenda_group: 'grammar', salience: 0 });
+    expect(priorityCompare(law, grammar)).toBeGreaterThan(0);
+    expect(priorityCompare(grammar, law)).toBeLessThan(0);
+  });
+
+  it('falls back to rule_id ascending', () => {
+    const a = makeFinding({ rule_id: 'A-1', salience: 0 });
+    const b = makeFinding({ rule_id: 'B-1', salience: 0 });
+    expect(priorityCompare(a, b)).toBeGreaterThan(0);
+    expect(priorityCompare(b, a)).toBeLessThan(0);
+    expect(priorityCompare(a, a)).toBe(0);
+  });
+});

--- a/word_addin_dev/app/assets/qa/mergeQaResults.ts
+++ b/word_addin_dev/app/assets/qa/mergeQaResults.ts
@@ -1,0 +1,172 @@
+import { AnalyzeFinding } from "../api-client.ts";
+import { normalizeText, severityRank } from "../dedupe.ts";
+
+const AGENDA_GROUP_ORDER: Record<string, number> = {
+  law: 0,
+  policy: 1,
+  substantive: 2,
+  drafting: 3,
+  grammar: 4,
+};
+
+function coerceNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return Number.NaN;
+}
+
+function getSalience(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return Number.NEGATIVE_INFINITY;
+}
+
+function agendaRank(value: unknown): number {
+  if (typeof value === "string") {
+    const key = value.trim().toLowerCase();
+    if (key in AGENDA_GROUP_ORDER) {
+      return AGENDA_GROUP_ORDER[key as keyof typeof AGENDA_GROUP_ORDER];
+    }
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function cloneFinding(finding: AnalyzeFinding): AnalyzeFinding {
+  return { ...finding };
+}
+
+function hasSourceProp(finding: AnalyzeFinding): boolean {
+  return Object.prototype.hasOwnProperty.call(finding, "source");
+}
+
+function setSourceIfNeeded(
+  finding: AnalyzeFinding,
+  preferred: unknown,
+  shouldMark: boolean,
+): AnalyzeFinding {
+  if (!shouldMark) {
+    return finding;
+  }
+  const clone = cloneFinding(finding);
+  if (typeof preferred !== "undefined") {
+    (clone as any).source = preferred;
+  } else if (typeof (clone as any).source === "undefined") {
+    (clone as any).source = "qa";
+  }
+  return clone;
+}
+
+export function makeKey(finding: AnalyzeFinding): string {
+  const rule = finding?.rule_id ?? "";
+  const start = coerceNumber((finding as any)?.start);
+  const end = coerceNumber((finding as any)?.end);
+  const snippetNorm = normalizeText((finding as any)?.snippet ?? "");
+  return `${rule}|${start}|${end}|${snippetNorm}`;
+}
+
+export function priorityCompare(a: AnalyzeFinding, b: AnalyzeFinding): number {
+  const severityDiff = severityRank((a as any)?.severity) - severityRank((b as any)?.severity);
+  if (severityDiff !== 0) {
+    return severityDiff;
+  }
+
+  const salienceDiff = getSalience((a as any)?.salience) - getSalience((b as any)?.salience);
+  if (salienceDiff !== 0) {
+    return salienceDiff;
+  }
+
+  const agendaDiff = agendaRank((b as any)?.agenda_group) - agendaRank((a as any)?.agenda_group);
+  if (agendaDiff !== 0) {
+    return agendaDiff;
+  }
+
+  const ruleA = `${(a as any)?.rule_id ?? ""}`;
+  const ruleB = `${(b as any)?.rule_id ?? ""}`;
+  const cmp = ruleA.localeCompare(ruleB, undefined, { numeric: true, sensitivity: "base" });
+  if (cmp !== 0) {
+    return -cmp;
+  }
+
+  return 0;
+}
+
+function getCollectionEntry(
+  base: AnalyzeFinding[],
+  appends: AnalyzeFinding[],
+  index: number,
+): AnalyzeFinding {
+  return index < base.length ? base[index] : appends[index - base.length];
+}
+
+function setCollectionEntry(
+  base: AnalyzeFinding[],
+  appends: AnalyzeFinding[],
+  index: number,
+  value: AnalyzeFinding,
+): void {
+  if (index < base.length) {
+    base[index] = value;
+  } else {
+    appends[index - base.length] = value;
+  }
+}
+
+export function mergeQaFindings(
+  baseFindings: AnalyzeFinding[] = [],
+  qaFindings: AnalyzeFinding[] = [],
+): AnalyzeFinding[] {
+  const base = Array.isArray(baseFindings) ? [...baseFindings] : [];
+  const qa = Array.isArray(qaFindings) ? qaFindings : [];
+  const map = new Map<string, number>();
+  for (let i = 0; i < base.length; i += 1) {
+    map.set(makeKey(base[i]), i);
+  }
+
+  const appends: AnalyzeFinding[] = [];
+  const shouldMarkSource = base.some(hasSourceProp) || qa.some(hasSourceProp);
+
+  for (const qaItem of qa) {
+    const candidate = cloneFinding(qaItem);
+    const key = makeKey(candidate);
+    const idx = map.get(key);
+    if (typeof idx === "number") {
+      const existing = getCollectionEntry(base, appends, idx);
+      const cmp = priorityCompare(candidate, existing);
+      if (cmp < 0) {
+        continue;
+      }
+      const preferredSource = shouldMarkSource ? (existing as any)?.source : undefined;
+      const replacement = setSourceIfNeeded(candidate, preferredSource, shouldMarkSource);
+      setCollectionEntry(base, appends, idx, replacement);
+      continue;
+    }
+
+    const preferredIndex = base.length + appends.length;
+    const appended = shouldMarkSource ? setSourceIfNeeded(candidate, undefined, true) : candidate;
+    appends.push(appended);
+    map.set(key, preferredIndex);
+  }
+
+  return base.concat(appends);
+}
+
+export function mergeQaPayload(
+  existing: AnalyzeFinding[] | undefined,
+  qaPayload: AnalyzeFinding[] | undefined,
+): AnalyzeFinding[] {
+  return mergeQaFindings(existing ?? [], qaPayload ?? []);
+}

--- a/word_addin_dev/app/assets/taskpane.ts
+++ b/word_addin_dev/app/assets/taskpane.ts
@@ -3,6 +3,7 @@ import type { AnalyzeFindingEx } from "./types.ts";
 import { parseFindings } from "./findings.ts";
 import domSchema from "../panel_dom.schema.json";
 import { normalizeText, dedupeFindings, severityRank, type RiskLevel } from "./dedupe.ts";
+import { mergeQaFindings } from "./qa/mergeQaResults.ts";
 export { normalizeText, dedupeFindings } from "./dedupe.ts";
 import { planAnnotations, annotateFindingsIntoWord, AnnotationPlan, COMMENT_PREFIX, safeInsertComment, fallbackAnnotateWithContentControl } from "./annotate.ts";
 import { findAnchors } from "./anchors.ts";
@@ -948,7 +949,7 @@ export function renderResults(res: any) {
 function mergeQaResults(json: any) {
   const existing: AnalyzeFinding[] = (window as any).__findings || [];
   const incoming = parseFindings(json);
-  const merged = dedupeFindings([...existing, ...incoming]);
+  const merged = mergeQaFindings(existing, incoming);
   return { ...(json || {}), findings: merged };
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated QA merge helper that applies priority comparisons and key-based matching while preserving base ordering
- update the Word add-in and contract review taskpane merge flows to use the helper and keep agenda order intact
- add Vitest coverage for order preservation, priority rules, idempotency, sort guards, and performance expectations

## Testing
- `npx vitest run qa_merge`


------
https://chatgpt.com/codex/tasks/task_e_68d3c1041a98832595c2dc0fae5d74c3