### PR TITLE
Add CI gate workflow for lint and test jobs

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,146 @@
+name: ci-gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  paths:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      fe: ${{ steps.filter.outputs.fe }}
+      be: ${{ steps.filter.outputs.be }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            fe:
+              - 'contract_review_app/contract_review_app/static/panel/**'
+              - 'contract_review_app/frontend/**'
+              - 'word_addin_dev/**'
+              - 'frontend/**'
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/package.json'
+              - '**/package-lock.json'
+              - '**/vite.config.*'
+            be:
+              - 'contract_review_app/**'
+              - 'api/**'
+              - 'src/**'
+              - 'schemas/**'
+              - 'tests/**'
+              - '**/*.py'
+              - '!contract_review_app/contract_review_app/static/panel/**'
+              - '!contract_review_app/frontend/**'
+              - '!frontend/**'
+              - '!word_addin_dev/**'
+
+  lint:
+    name: Lint / Pre-commit
+    runs-on: ubuntu-latest
+    needs: [paths]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: pre-commit/action@v3.0.1
+
+  backend:
+    name: BE tests (pytest)
+    runs-on: ubuntu-latest
+    needs: [paths]
+    if: ${{ needs.paths.outputs.be == 'true' || github.event_name == 'push' }}
+    env:
+      PYTHONDONTWRITEBYTECODE: '1'
+      PYTHONUNBUFFERED: '1'
+      FEATURE_TRACE_ARTIFACTS: '1'
+      FEATURE_REASON_OFFSETS: '1'
+      FEATURE_COVERAGE_MAP: '1'
+      FEATURE_AGENDA_SORT: '1'
+      FEATURE_AGENDA_STRICT_MERGE: '0'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install deps
+        run: |
+          python -m pip install -U pip wheel
+          pip install -r requirements.txt
+      - name: PyTest
+        id: pytest
+        continue-on-error: true
+        run: |
+          mkdir -p junit
+          pytest -q \
+            --junitxml=junit/pytest.xml
+      - name: PyTest summary
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: PyTest results
+          path: junit/pytest.xml
+          reporter: pytest
+          fail-on-error: false
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: junit-pytest
+          path: junit/pytest.xml
+      - name: Fail if PyTest failed
+        if: steps.pytest.outcome == 'failure'
+        run: exit 1
+
+  frontend:
+    name: FE tests (Vitest)
+    runs-on: ubuntu-latest
+    needs: [paths]
+    if: ${{ needs.paths.outputs.fe == 'true' || github.event_name == 'push' }}
+    defaults:
+      run:
+        working-directory: word_addin_dev
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'word_addin_dev/package-lock.json'
+      - name: Install
+        run: npm ci
+      - name: FE tests
+        id: vitest
+        continue-on-error: true
+        run: |
+          mkdir -p junit
+          npm run test:ci
+      - name: Vitest summary
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Vitest results
+          path: word_addin_dev/junit/vitest.xml
+          reporter: vitest
+          fail-on-error: false
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: junit-vitest
+          path: word_addin_dev/junit/vitest.xml
+      - name: Fail if Vitest failed
+        if: steps.vitest.outcome == 'failure'
+        run: exit 1

--- a/word_addin_dev/package.json
+++ b/word_addin_dev/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint app --ext .ts --max-warnings=0",
     "format": "prettier --write .",
     "lint:staged": "lint-staged",
-    "test:ci": "vitest run -c vitest.config.ci.ts"
+    "test:ci": "vitest run -c vitest.config.ci.ts --reporter=default --reporter=junit --outputFile=junit/vitest.xml"
   },
   "devDependencies": {
     "vitest": "^0.34.6",


### PR DESCRIPTION
## Summary
- add a ci-gate GitHub Actions workflow that runs linting, backend pytest, and frontend vitest jobs with caching, JUnit artifacts, and summaries while cancelling superseded runs
- ensure the Vitest CI npm script emits JUnit output used by the workflow

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3c42c9bf08325b7c84102568bc0a4