### PR TITLE
Add bridge smoke tests and dev script

### DIFF
--- a/contract_review_app/contract_review_app/static/panel/app/__tests__/smoke_trace_badges_integration.spec.ts
+++ b/contract_review_app/contract_review_app/static/panel/app/__tests__/smoke_trace_badges_integration.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ORIGINAL_CACHE = (globalThis as any).__traceCache;
+
+function setupDom(): void {
+  document.body.innerHTML = `
+    <div id="resultsBlock">
+      <div class="muted">
+        <span data-role="trace-link"></span>
+        <span id="traceBadges"></span>
+      </div>
+    </div>
+  `;
+}
+
+describe('TRACE smoke integration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setupDom();
+    (globalThis as any).__traceCache = new Map<string, any>();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    (globalThis as any).__traceCache = ORIGINAL_CACHE;
+  });
+
+  it('updates trace link and renders badges from cache', async () => {
+    const { updateResultsTraceLink } = await import('../assets/updateResultsTraceLink.ts');
+    const { renderTraceBadges } = await import('../assets/traceBadges.ts');
+
+    const cid = 'cid-smoke-1';
+    const backend = 'http://localhost:9443';
+
+    updateResultsTraceLink(cid, backend);
+
+    const cache = new Map<string, any>();
+    cache.set(cid, {
+      coverage: { zones_total: 45, zones_present: 20, zones_fired: 11 },
+      meta: { timings_ms: { merge_ms: 42 } },
+    });
+    (globalThis as any).__traceCache = cache;
+
+    renderTraceBadges(cid);
+
+    const link = document.querySelector('[data-role="open-trace"]') as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+    expect(link?.href).toBe(`${backend}/api/trace/${cid}.html`);
+
+    const badges = document.getElementById('traceBadges') as HTMLSpanElement | null;
+    expect(badges).not.toBeNull();
+    expect(badges?.style.display).toBe('');
+    expect(badges?.children).toHaveLength(2);
+    expect(badges?.children[0].textContent).toBe('Coverage: 11/20/45');
+    expect(badges?.children[1].textContent).toBe('Merge: 42 ms');
+
+    (globalThis as any).__traceCache = new Map<string, any>();
+    renderTraceBadges(cid);
+
+    const rerenderedBadges = document.getElementById('traceBadges') as HTMLSpanElement | null;
+    expect(rerenderedBadges).not.toBeNull();
+    expect(rerenderedBadges?.children).toHaveLength(0);
+    expect(rerenderedBadges?.style.display).toBe('none');
+
+    const linkAfter = document.querySelector('[data-role="open-trace"]') as HTMLAnchorElement | null;
+    expect(linkAfter).not.toBeNull();
+    expect(linkAfter?.href).toBe(`${backend}/api/trace/${cid}.html`);
+  });
+});

--- a/tests/e2e/test_smoke_full_bridge.py
+++ b/tests/e2e/test_smoke_full_bridge.py
@@ -1,0 +1,107 @@
+import os
+from http import HTTPStatus
+from typing import Any, Mapping
+
+import pytest
+from fastapi.testclient import TestClient
+
+import contract_review_app.api.app as app_module
+from contract_review_app.api.models import SCHEMA_VERSION
+
+
+@pytest.fixture(autouse=True)
+def _feature_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FEATURE_TRACE_ARTIFACTS", "1")
+    monkeypatch.setenv("FEATURE_COVERAGE_MAP", "1")
+    monkeypatch.setenv("FEATURE_REASON_OFFSETS", "1")
+    monkeypatch.setenv("FEATURE_AGENDA_SORT", "1")
+    monkeypatch.setenv("FEATURE_AGENDA_STRICT_MERGE", "0")
+    monkeypatch.setattr(app_module, "FEATURE_TRACE_ARTIFACTS", True, raising=False)
+    monkeypatch.setattr(app_module, "FEATURE_COVERAGE_MAP", True, raising=False)
+    monkeypatch.setattr(app_module, "FEATURE_REASON_OFFSETS", True, raising=False)
+    monkeypatch.setattr(app_module, "FEATURE_AGENDA_SORT", True, raising=False)
+    monkeypatch.setattr(app_module, "FEATURE_AGENDA_STRICT_MERGE", False, raising=False)
+
+
+def _minimal_request_body() -> Mapping[str, Any]:
+    return {
+        "text": (
+            "Payment terms: invoices due within 30 days. "
+            "Governing Law: England and Wales. "
+            "Confidentiality shall survive termination for 3 years. "
+        )
+    }
+
+
+def _headers() -> Mapping[str, str]:
+    return {"x-api-key": "dummy", "x-schema-version": SCHEMA_VERSION}
+
+
+def _no_raw_text(obj: Any, path: str = "") -> None:
+    if isinstance(obj, str):
+        assert len(obj) < 2000, f"raw text too large at {path}"
+    elif isinstance(obj, list):
+        for idx, value in enumerate(obj):
+            _no_raw_text(value, f"{path}[{idx}]")
+    elif isinstance(obj, dict):
+        for key, value in obj.items():
+            _no_raw_text(value, f"{path}.{key}" if path else key)
+
+
+def test_full_bridge_smoke() -> None:
+    client = TestClient(app_module.app)
+
+    analyze_response = client.post(
+        "/api/analyze", headers=_headers(), json=_minimal_request_body()
+    )
+    assert analyze_response.status_code == HTTPStatus.OK
+    analyze_payload = analyze_response.json()
+    cid = analyze_payload.get("cid") or analyze_response.headers.get("x-cid")
+    assert isinstance(cid, str) and len(cid) >= 8
+
+    trace_response = client.get(f"/api/trace/{cid}")
+    assert trace_response.status_code == HTTPStatus.OK
+    trace = trace_response.json()
+
+    for key in ("features", "dispatch", "coverage", "constraints", "proposals"):
+        assert key in trace, f"missing {key} in TRACE"
+
+    coverage = trace["coverage"]
+    assert coverage.get("version") == 1
+    assert int(coverage.get("zones_total", 0)) >= 30
+
+    dispatch = trace["dispatch"]
+    rules_loaded = dispatch.get("rules_loaded")
+    evaluated = dispatch.get("evaluated")
+    if rules_loaded is None or evaluated is None:
+        ruleset = dispatch.get("ruleset") or {}
+        rules_loaded = rules_loaded if rules_loaded is not None else ruleset.get("loaded")
+        evaluated = evaluated if evaluated is not None else ruleset.get("evaluated")
+    assert int(rules_loaded or 0) >= 0
+    assert int(evaluated or 0) >= 0
+
+    timings = (trace.get("meta") or {}).get("timings_ms") or {}
+    merge_ms = timings.get("merge_ms", 0)
+    assert isinstance(merge_ms, (int, float))
+    assert merge_ms >= 0
+
+    reasons_cap = int(os.getenv("TRACE_REASON_MAX_OFFSETS_PER_TYPE", "4"))
+    segments = dispatch.get("segments") or []
+    if not segments:
+        segments = dispatch.get("candidates") or []
+    for segment in segments:
+        candidates = segment.get("candidates") if isinstance(segment, dict) else None
+        if candidates is None:
+            candidates = [segment] if isinstance(segment, dict) else []
+        for candidate in candidates:
+            reasons = candidate.get("reasons", []) if isinstance(candidate, dict) else []
+            for reason in reasons:
+                offsets = reason.get("offsets", {}) if isinstance(reason, dict) else {}
+                if isinstance(offsets, dict):
+                    for _, arr in offsets.items():
+                        if isinstance(arr, list):
+                            assert len(arr) <= reasons_cap
+
+    _no_raw_text(trace)
+
+    client.close()

--- a/tools/smoke_full_bridge.py
+++ b/tools/smoke_full_bridge.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Manual smoke test covering Analyze + TRACE bridge."""
+
+from __future__ import annotations
+
+import json
+import os
+from http import HTTPStatus
+from typing import Any
+
+import requests
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        "text": (
+            "Payment terms: invoices due within 30 days. "
+            "Governing Law: England and Wales. "
+            "Confidentiality shall survive termination for 3 years. "
+        )
+    }
+
+
+def _headers() -> dict[str, str]:
+    schema = os.getenv("TRACE_SMOKE_SCHEMA", "1.4")
+    api_key = os.getenv("TRACE_SMOKE_API_KEY", "local-test-key-123")
+    return {"x-api-key": api_key, "x-schema-version": schema}
+
+
+def main() -> int:
+    backend = os.getenv("BACKEND_URL", "http://127.0.0.1:9443").rstrip("/")
+    analyze_url = f"{backend}/api/analyze"
+
+    try:
+        analyze_resp = requests.post(analyze_url, json=_payload(), headers=_headers(), timeout=30)
+    except Exception as exc:  # pragma: no cover - manual tool
+        print(f"[smoke] POST {analyze_url} failed: {exc}")
+        return 1
+
+    if analyze_resp.status_code != HTTPStatus.OK:
+        print(f"[smoke] analyze failed: {analyze_resp.status_code} {analyze_resp.text}")
+        return 1
+
+    cid = analyze_resp.headers.get("x-cid")
+    if not cid:
+        try:
+            cid = analyze_resp.json().get("cid")
+        except Exception:
+            cid = None
+    if not cid:
+        print("[smoke] analyze succeeded but cid missing")
+        return 1
+
+    trace_url = f"{backend}/api/trace/{cid}"
+    print(f"[smoke] analyze ok, cid={cid}")
+    print(f"[smoke] trace html: {trace_url}.html")
+
+    try:
+        trace_resp = requests.get(trace_url, timeout=30)
+    except Exception as exc:  # pragma: no cover - manual tool
+        print(f"[smoke] GET {trace_url} failed: {exc}")
+        return 1
+
+    if trace_resp.status_code != HTTPStatus.OK:
+        print(f"[smoke] trace fetch failed: {trace_resp.status_code} {trace_resp.text}")
+        return 1
+
+    try:
+        trace = trace_resp.json()
+    except json.JSONDecodeError as exc:
+        print(f"[smoke] trace returned non-JSON payload: {exc}")
+        return 1
+
+    coverage = trace.get("coverage") or {}
+    meta = (trace.get("meta") or {}).get("timings_ms") or {}
+    zones_total = coverage.get("zones_total")
+    zones_fired = coverage.get("zones_fired")
+    merge_ms = meta.get("merge_ms")
+
+    print("[smoke] coverage:", zones_fired, "/", coverage.get("zones_present"), "/", zones_total)
+    print("[smoke] merge_ms:", merge_ms)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an end-to-end smoke test that exercises /api/analyze and /api/trace and validates trace invariants
- add a panel integration test that checks the TRACE link and badge rendering against the cached data
- add a developer smoke script for manually invoking the analyze/trace bridge

## Testing
- pytest tests/e2e/test_smoke_full_bridge.py
- NODE_PATH=../../../../word_addin_dev/node_modules ../../../../word_addin_dev/node_modules/.bin/vitest run -c vitest.config.ci.ts --root . app/__tests__/smoke_trace_badges_integration.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68d3c59930c48325bc362d7ff1e55c93