### PR TITLE
Add dev scripts for panel rebuild and trace smoke tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ secret*.json
 
 # ==== Наши точечные пути с дев-сертификатами и т.п. ====
 dev/
+!scripts/dev/
 word_addin_dev/certs/
 tools/**/certs/
 **/.cert/

--- a/docs/dev_panel_rebuild.md
+++ b/docs/dev_panel_rebuild.md
@@ -1,0 +1,20 @@
+# Dev panel rebuild & flags
+
+## 1) Запуск backend с фич-флагами
+Windows:
+  powershell -ExecutionPolicy Bypass -File scripts/dev/run_api_with_flags.ps1
+Linux/macOS:
+  bash scripts/dev/run_api_with_flags.sh
+
+## 2) Пересборка панели и выкладка в static/panel
+Windows:
+  powershell -ExecutionPolicy Bypass -File scripts/dev/rebuild_panel.ps1
+Linux/macOS:
+  bash scripts/dev/rebuild_panel.sh
+
+## 3) Проверка (опционально)
+BACKEND_URL=https://127.0.0.1:9443 python tools/quick_smoke.py
+
+## 4) В панели (Word → Taskpane)
+Use whole doc → Analyze → в шапке появится «Open TRACE» + бейджи Coverage/Merge.
+Anchors в Word берут offsets из TRACE (точнее попадание).

--- a/scripts/dev/rebuild_panel.ps1
+++ b/scripts/dev/rebuild_panel.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = "Stop"
+
+Write-Host "[rebuild_panel] Node/Vite build (word_addin_dev)..."
+pushd word_addin_dev
+npm ci
+npm run build
+popd
+
+Write-Host "[rebuild_panel] Sync to static/panel + bump build token..."
+python tools/panel_dev_sync.py
+
+Write-Host "[rebuild_panel] Done. Static panel contents:"
+Get-ChildItem contract_review_app/contract_review_app/static/panel | Format-Table Name, Length, LastWriteTime -Auto

--- a/scripts/dev/rebuild_panel.sh
+++ b/scripts/dev/rebuild_panel.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[rebuild_panel] Node/Vite build (word_addin_dev)..."
+pushd word_addin_dev >/dev/null
+npm ci
+npm run build
+popd >/dev/null
+
+echo "[rebuild_panel] Sync to static/panel + bump build token..."
+python tools/panel_dev_sync.py
+
+echo "[rebuild_panel] Done. Static panel contents:"
+ls -lah contract_review_app/contract_review_app/static/panel

--- a/scripts/dev/run_api_with_flags.ps1
+++ b/scripts/dev/run_api_with_flags.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+
+# === Feature flags ===
+$env:FEATURE_TRACE_ARTIFACTS = "1"
+$env:FEATURE_REASON_OFFSETS  = "1"
+$env:FEATURE_COVERAGE_MAP    = "1"
+$env:FEATURE_AGENDA_SORT     = "1"
+$env:FEATURE_AGENDA_STRICT_MERGE = "0"
+
+Write-Host "[run_api_with_flags] Flags:"
+Write-Host " FEATURE_TRACE_ARTIFACTS=$($env:FEATURE_TRACE_ARTIFACTS)"
+Write-Host " FEATURE_REASON_OFFSETS=$($env:FEATURE_REASON_OFFSETS)"
+Write-Host " FEATURE_COVERAGE_MAP=$($env:FEATURE_COVERAGE_MAP)"
+Write-Host " FEATURE_AGENDA_SORT=$($env:FEATURE_AGENDA_SORT)"
+Write-Host " FEATURE_AGENDA_STRICT_MERGE=$($env:FEATURE_AGENDA_STRICT_MERGE)"
+
+# === Backend launch ===
+# Используем стандартный вход в приложение (он уже обслуживает /panel/ и /api/*).
+python -m contract_review_app.api.app

--- a/scripts/dev/run_api_with_flags.sh
+++ b/scripts/dev/run_api_with_flags.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export FEATURE_TRACE_ARTIFACTS=1
+export FEATURE_REASON_OFFSETS=1
+export FEATURE_COVERAGE_MAP=1
+export FEATURE_AGENDA_SORT=1
+export FEATURE_AGENDA_STRICT_MERGE=0
+
+echo "[run_api_with_flags] Flags:"
+env | grep -E '^FEATURE_' || true
+
+python -m contract_review_app.api.app

--- a/tools/quick_smoke.py
+++ b/tools/quick_smoke.py
@@ -1,0 +1,33 @@
+import os
+import time
+import requests
+
+BACKEND = os.environ.get("BACKEND_URL", "https://127.0.0.1:9443")
+VERIFY  = os.environ.get("BACKEND_TLS_VERIFY", "0") == "1"
+
+def analyze_sample():
+    url = f"{BACKEND}/api/analyze"
+    payload = {"text": "CONFIDENTIALITY AGREEMENT\n\nGoverning law: England and Wales.\nPayment terms: 30 days.\n"}
+    r = requests.post(url, json=payload, verify=VERIFY)
+    r.raise_for_status()
+    data = r.json()
+    cid = data.get("cid") or data.get("meta", {}).get("cid")
+    print(f"[quick_smoke] analyze OK, cid={cid}")
+    return cid
+
+def get_trace(cid: str):
+    url = f"{BACKEND}/api/trace/{cid}"
+    r = requests.get(url, verify=VERIFY)
+    r.raise_for_status()
+    data = r.json()
+    keys = list(data.keys())
+    print(f"[quick_smoke] trace OK, sections={keys}")
+    cov = data.get("coverage", {})
+    print(f"[quick_smoke] coverage: total={cov.get('zones_total')} present={cov.get('zones_present')} fired={cov.get('zones_fired')}")
+    return data
+
+if __name__ == "__main__":
+    cid = analyze_sample()
+    time.sleep(0.3)
+    get_trace(cid)
+    print("[quick_smoke] done.")

--- a/word_addin_dev/app/assets/__tests__/smoke_trace_badges_integration.spec.ts
+++ b/word_addin_dev/app/assets/__tests__/smoke_trace_badges_integration.spec.ts
@@ -1,0 +1,49 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { renderTraceBadges } from '../traceBadges';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __traceCache: Map<string, any> | undefined;
+}
+
+describe('trace badges integration', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<span id="traceBadges"></span>';
+    globalThis.__traceCache = new Map();
+  });
+
+  it('smoke_trace_badges_integration renders coverage and merge badges', () => {
+    const cid = 'cid-123';
+    const trace = {
+      coverage: { zones_total: 12, zones_present: 10, zones_fired: 6 },
+      meta: { timings_ms: { merge_ms: 42.2 } },
+    };
+    globalThis.__traceCache?.set(cid, trace);
+
+    renderTraceBadges(cid);
+
+    const badges = Array.from(document.querySelectorAll('#traceBadges .trace-badge'));
+    expect(badges).toHaveLength(2);
+    expect(badges[0]?.textContent).toBe('Coverage: 6/10/12');
+    expect(badges[1]?.textContent).toBe('Merge: 42 ms');
+    expect((document.getElementById('traceBadges') as HTMLElement | null)?.style.display).toBe('');
+  });
+
+  it('hides badges if cache missing entry', () => {
+    renderTraceBadges('missing');
+
+    const container = document.getElementById('traceBadges') as HTMLElement | null;
+    expect(container?.textContent).toBe('');
+    expect(container?.style.display).toBe('none');
+  });
+
+  it('does nothing without container', () => {
+    document.body.innerHTML = '';
+    globalThis.__traceCache = new Map([[
+      'cid',
+      { coverage: { zones_total: 1, zones_present: 1, zones_fired: 1 } },
+    ]]);
+
+    expect(() => renderTraceBadges('cid')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add cross-platform dev scripts to start the API with TRACE-related feature flags and rebuild the add-in panel bundle
- document the workflow for rebuilding the panel and introduce a quick smoke script to verify analyze + trace endpoints
- cover TRACE badge rendering with a dedicated Vitest integration to back the new smoke run command

## Testing
- pytest -q tests/e2e/test_smoke_full_bridge.py
- npm --prefix word_addin_dev run test:ci -- --run smoke_trace_badges_integration

------
https://chatgpt.com/codex/tasks/task_e_68d3d09ff1b083259ce6d714e76e444e